### PR TITLE
docs: add README with usage examples and godoc comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,152 @@
+# tavern
+
+Thread-safe, topic-based pub/sub broker for Server-Sent Events (SSE) in Go.
+
+Tavern provides a minimal, concurrent-safe message broker that fans out string
+messages to subscribers by topic. It is designed to sit behind an HTTP handler
+(Echo, Chi, net/http, etc.) and push real-time events to browser clients over
+SSE.
+
+## Install
+
+```bash
+go get github.com/catgoose/tavern
+```
+
+## Usage
+
+### Create a broker
+
+```go
+broker := tavern.NewSSEBroker()
+defer broker.Close()
+```
+
+### Subscribe and unsubscribe
+
+`Subscribe` returns a read-only channel and an unsubscribe function. Always
+defer the unsubscribe to avoid leaking goroutines and channels.
+
+```go
+ch, unsub := broker.Subscribe("events")
+defer unsub()
+
+for msg := range ch {
+    // handle msg
+}
+```
+
+### Publish
+
+`Publish` fans out a message to every subscriber of a topic. It is
+non-blocking: if a subscriber's channel buffer is full, the message is silently
+dropped for that subscriber.
+
+```go
+broker.Publish("events", "hello, world")
+```
+
+### Format SSE messages
+
+`SSEMessage` builds wire-format SSE text. Chain `WithID` and `WithRetry` for
+optional fields.
+
+```go
+// Minimal message
+msg := tavern.NewSSEMessage("update", `{"id":1}`).String()
+// event: update
+// data: {"id":1}
+
+// With ID and retry
+msg := tavern.NewSSEMessage("update", `{"id":1}`).
+    WithID("42").
+    WithRetry(5000).
+    String()
+// event: update
+// data: {"id":1}
+// id: 42
+// retry: 5000
+```
+
+### Graceful shutdown
+
+`Close` closes all subscriber channels and removes all topics. Pending reads
+on subscriber channels will receive the zero value after `Close` returns.
+
+```go
+broker.Close()
+```
+
+### Check for subscribers
+
+Skip expensive serialization when nobody is listening:
+
+```go
+if broker.HasSubscribers("system-stats") {
+    stats := collectStats()
+    broker.Publish("system-stats", toJSON(stats))
+}
+```
+
+### Echo SSE endpoint
+
+```go
+func sseHandler(broker *tavern.SSEBroker) echo.HandlerFunc {
+    return func(c echo.Context) error {
+        c.Response().Header().Set("Content-Type", "text/event-stream")
+        c.Response().Header().Set("Cache-Control", "no-cache")
+        c.Response().Header().Set("Connection", "keep-alive")
+
+        ch, unsub := broker.Subscribe("events")
+        defer unsub()
+
+        for {
+            select {
+            case msg, ok := <-ch:
+                if !ok {
+                    return nil // broker closed
+                }
+                if _, err := fmt.Fprint(c.Response(), msg); err != nil {
+                    return nil // client disconnected
+                }
+                c.Response().Flush()
+            case <-c.Request().Context().Done():
+                return nil
+            }
+        }
+    }
+}
+```
+
+### Topic metrics
+
+```go
+// Per-topic subscriber counts
+counts := broker.TopicCounts()
+for topic, n := range counts {
+    fmt.Printf("%s: %d subscribers\n", topic, n)
+}
+```
+
+## Topic constants
+
+Tavern ships a set of topic name constants as conventions for common use
+cases (dashboards, activity feeds, etc.). These are optional -- any string
+works as a topic name.
+
+```go
+broker.Publish(tavern.TopicSystemStats, statsJSON)
+broker.Publish(tavern.TopicActivityFeed, eventJSON)
+```
+
+## Thread safety
+
+All `SSEBroker` methods are safe for concurrent use. The broker uses an
+`sync.RWMutex` internally: subscribing and unsubscribing take a write lock,
+while publishing and reading counts take a read lock. `Publish` snapshots the
+subscriber set under the read lock, then sends outside it, so publishers never
+block each other.
+
+## License
+
+[MIT](LICENSE)

--- a/broker.go
+++ b/broker.go
@@ -1,25 +1,40 @@
-// Package tavern provides a topic-based pub/sub broker for Server-Sent Events.
+// Package tavern provides a thread-safe, topic-based pub/sub broker for
+// Server-Sent Events (SSE). It is designed for fan-out messaging where a
+// server publishes events and multiple HTTP clients consume them via SSE
+// streams.
+//
+// All broker methods are safe for concurrent use by multiple goroutines.
 package tavern
 
 import (
 	"sync"
 )
 
-// SSEBroker manages topic-based pub/sub for SSE events.
+// SSEBroker is a thread-safe, topic-based pub/sub message broker. Subscribers
+// receive messages on a buffered channel and publishers fan out messages to all
+// subscribers of a given topic. A zero-value SSEBroker is not usable; create
+// one with [NewSSEBroker].
 type SSEBroker struct {
 	topics map[string]map[chan string]struct{}
 	mu     sync.RWMutex
 }
 
-// NewSSEBroker creates a new SSEBroker instance.
+// NewSSEBroker creates a ready-to-use [SSEBroker] with no active topics or
+// subscribers.
 func NewSSEBroker() *SSEBroker {
 	return &SSEBroker{
 		topics: make(map[string]map[chan string]struct{}),
 	}
 }
 
-// Subscribe returns a read channel for a topic and an unsubscribe function.
-// The caller must invoke the returned function to release resources.
+// Subscribe registers a new subscriber for the given topic and returns a
+// read-only channel that will receive published messages, along with an
+// unsubscribe function. The caller must invoke the returned function when done
+// to release resources and close the channel. Calling the unsubscribe function
+// more than once is safe and has no effect after the first call.
+//
+// The returned channel is buffered (capacity 10). If the subscriber does not
+// drain the channel fast enough, messages will be dropped by [SSEBroker.Publish].
 func (b *SSEBroker) Subscribe(topic string) (<-chan string, func()) {
 	ch := make(chan string, 10)
 	b.mu.Lock()
@@ -38,7 +53,9 @@ func (b *SSEBroker) Subscribe(topic string) (<-chan string, func()) {
 	}
 }
 
-// HasSubscribers reports whether the given topic has at least one subscriber.
+// HasSubscribers reports whether the given topic has at least one active
+// subscriber. This is useful for skipping expensive serialization when no
+// clients are listening.
 func (b *SSEBroker) HasSubscribers(topic string) bool {
 	b.mu.RLock()
 	n := len(b.topics[topic])
@@ -46,7 +63,8 @@ func (b *SSEBroker) HasSubscribers(topic string) bool {
 	return n > 0
 }
 
-// TopicCounts returns the number of active subscribers per topic.
+// TopicCounts returns a snapshot of the number of active subscribers per topic.
+// The returned map is a copy and safe to read without synchronization.
 func (b *SSEBroker) TopicCounts() map[string]int {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
@@ -57,8 +75,10 @@ func (b *SSEBroker) TopicCounts() map[string]int {
 	return counts
 }
 
-// Publish sends a message to all subscribers of a topic.
-// Non-blocking: if a subscriber channel is full, the message is skipped for that subscriber.
+// Publish fans out msg to every subscriber of the given topic. It is
+// non-blocking: if a subscriber's channel buffer is full, the message is
+// silently dropped for that subscriber rather than blocking the publisher.
+// Publishing to a topic with no subscribers is a no-op.
 func (b *SSEBroker) Publish(topic, msg string) {
 	b.mu.RLock()
 	subscribers, exists := b.topics[topic]
@@ -86,7 +106,11 @@ func (b *SSEBroker) Publish(topic, msg string) {
 	}
 }
 
-// Close drains all topic subscriber maps for clean shutdown.
+// Close shuts down the broker by closing all subscriber channels and removing
+// all topics. After Close returns, any pending reads on subscriber channels
+// will receive the zero value. It is safe to call Close while other goroutines
+// are publishing or subscribing; however, no new messages will be delivered
+// after Close returns.
 func (b *SSEBroker) Close() {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/message.go
+++ b/message.go
@@ -5,15 +5,25 @@ import (
 	"strings"
 )
 
-// SSEMessage represents a complete SSE message conforming to the SSE specification.
+// SSEMessage represents a complete Server-Sent Event message conforming to the
+// W3C SSE specification (https://html.spec.whatwg.org/multipage/server-sent-events.html).
+// Use [NewSSEMessage] to create one with the required fields, then chain
+// [SSEMessage.WithID] or [SSEMessage.WithRetry] for optional fields.
 type SSEMessage struct {
+	// Event is the SSE event type (the "event:" field).
 	Event string
-	Data  string
-	ID    string
+	// Data is the event payload (the "data:" field).
+	Data string
+	// ID is the optional event identifier (the "id:" field). When set, the
+	// browser will send it back as Last-Event-ID on reconnection.
+	ID string
+	// Retry is the optional reconnection time in milliseconds (the "retry:"
+	// field). A zero value omits the field.
 	Retry int
 }
 
-// String formats the SSEMessage as a wire-format SSE event.
+// String formats the SSEMessage as wire-format SSE text, terminated by a
+// double newline as required by the specification.
 func (m SSEMessage) String() string {
 	var parts []string
 	parts = append(parts, fmt.Sprintf("event: %s", m.Event))
@@ -27,18 +37,23 @@ func (m SSEMessage) String() string {
 	return strings.Join(parts, "\n") + "\n\n"
 }
 
-// NewSSEMessage creates a new SSEMessage with the required event and data fields.
+// NewSSEMessage creates an [SSEMessage] with the required event type and data
+// payload. Use the builder methods [SSEMessage.WithID] and
+// [SSEMessage.WithRetry] to set optional fields.
 func NewSSEMessage(event, data string) SSEMessage {
 	return SSEMessage{Event: event, Data: data}
 }
 
-// WithID adds an ID to the SSE message.
+// WithID returns a copy of the message with the given event ID set. The
+// browser uses this ID for reconnection via the Last-Event-ID header.
 func (m SSEMessage) WithID(id string) SSEMessage {
 	m.ID = id
 	return m
 }
 
-// WithRetry adds a reconnection time (ms) to the SSE message.
+// WithRetry returns a copy of the message with the reconnection time set to ms
+// milliseconds. The browser will wait this long before attempting to reconnect
+// after a connection loss.
 func (m SSEMessage) WithRetry(ms int) SSEMessage {
 	m.Retry = ms
 	return m

--- a/stats.go
+++ b/stats.go
@@ -7,7 +7,9 @@ import (
 	"time"
 )
 
-// SystemStats holds Go runtime metrics for the SSE system dashboard.
+// SystemStats holds a point-in-time snapshot of Go runtime metrics. It is
+// intended for use in SSE-powered dashboards that stream system health data
+// to connected clients. Use [CollectRuntimeStats] to populate it.
 type SystemStats struct {
 	Timestamp       string
 	GoVersion       string
@@ -33,8 +35,9 @@ type SystemStats struct {
 	GCCycles        uint32
 }
 
-// CollectRuntimeStats samples the current Go runtime metrics.
-// start is the time the process was started (used to compute Uptime).
+// CollectRuntimeStats samples the current Go runtime and memory statistics and
+// returns them as a [SystemStats] value. The start parameter is the time the
+// process was started; it is used to compute the Uptime field.
 func CollectRuntimeStats(start time.Time) SystemStats {
 	var ms runtime.MemStats
 	runtime.ReadMemStats(&ms)

--- a/topics.go
+++ b/topics.go
@@ -1,6 +1,12 @@
 package tavern
 
-// Topic constants for SSE broker channels.
+// Topic name constants provided as conventions. These are common topic names
+// used in dashboard and real-time UI applications. Your application may use any
+// string as a topic name; these constants are provided for convenience and to
+// encourage consistent naming across projects.
+//
+// See https://github.com/catgoose/tavern/issues/6 for discussion about moving
+// app-specific constants to examples.
 const (
 	TopicSystemStats  = "system-stats"
 	TopicDashMetrics  = "dashboard-metrics"


### PR DESCRIPTION
## Summary

- Add comprehensive README with install instructions, usage examples (broker lifecycle, subscribe/publish, SSE message formatting, Echo endpoint, topic metrics), and thread safety documentation
- Add godoc comments to all exported types and functions across `broker.go`, `message.go`, `stats.go`, and `topics.go`
- Document non-obvious behavior: non-blocking publish drops to full channels, safe double-unsubscribe, Close semantics

Closes #2, closes #3