### PR TITLE
feat: add configurable subscriber channel buffer size

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -15,16 +15,32 @@ import (
 // subscribers of a given topic. A zero-value SSEBroker is not usable; create
 // one with [NewSSEBroker].
 type SSEBroker struct {
-	topics map[string]map[chan string]struct{}
-	mu     sync.RWMutex
+	topics     map[string]map[chan string]struct{}
+	mu         sync.RWMutex
+	bufferSize int
+}
+
+// BrokerOption configures the SSE broker.
+type BrokerOption func(*SSEBroker)
+
+// WithBufferSize sets the subscriber channel buffer size. Default is 10.
+func WithBufferSize(size int) BrokerOption {
+	return func(b *SSEBroker) {
+		b.bufferSize = size
+	}
 }
 
 // NewSSEBroker creates a ready-to-use [SSEBroker] with no active topics or
-// subscribers.
-func NewSSEBroker() *SSEBroker {
-	return &SSEBroker{
-		topics: make(map[string]map[chan string]struct{}),
+// subscribers. It accepts optional [BrokerOption] values to override defaults.
+func NewSSEBroker(opts ...BrokerOption) *SSEBroker {
+	b := &SSEBroker{
+		topics:     make(map[string]map[chan string]struct{}),
+		bufferSize: 10,
 	}
+	for _, opt := range opts {
+		opt(b)
+	}
+	return b
 }
 
 // Subscribe registers a new subscriber for the given topic and returns a
@@ -33,10 +49,11 @@ func NewSSEBroker() *SSEBroker {
 // to release resources and close the channel. Calling the unsubscribe function
 // more than once is safe and has no effect after the first call.
 //
-// The returned channel is buffered (capacity 10). If the subscriber does not
-// drain the channel fast enough, messages will be dropped by [SSEBroker.Publish].
+// The returned channel is buffered (default capacity 10, configurable via
+// [WithBufferSize]). If the subscriber does not drain the channel fast enough,
+// messages will be dropped by [SSEBroker.Publish].
 func (b *SSEBroker) Subscribe(topic string) (<-chan string, func()) {
-	ch := make(chan string, 10)
+	ch := make(chan string, b.bufferSize)
 	b.mu.Lock()
 	if b.topics[topic] == nil {
 		b.topics[topic] = make(map[chan string]struct{})

--- a/broker_test.go
+++ b/broker_test.go
@@ -152,3 +152,99 @@ func TestPublishToNonExistentTopic(t *testing.T) {
 	// Should not panic.
 	assert.NotPanics(t, func() { b.Publish("nonexistent", "msg") })
 }
+
+func TestNewSSEBroker_DefaultBuffer(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	assert.Equal(t, 10, b.bufferSize)
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	// Fill the default buffer of 10 without blocking.
+	for i := range 10 {
+		b.Publish("t", string(rune('a'+i)))
+	}
+
+	// 11th message should be dropped (buffer full).
+	b.Publish("t", "overflow")
+
+	received := 0
+	for range 10 {
+		select {
+		case <-ch:
+			received++
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("timed out draining channel")
+		}
+	}
+	assert.Equal(t, 10, received)
+
+	// Channel should be empty now.
+	select {
+	case <-ch:
+		t.Fatal("unexpected extra message")
+	default:
+	}
+}
+
+func TestNewSSEBroker_CustomBuffer(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(3))
+	defer b.Close()
+
+	assert.Equal(t, 3, b.bufferSize)
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	// Fill the custom buffer of 3.
+	for i := range 3 {
+		b.Publish("t", string(rune('a'+i)))
+	}
+
+	// 4th message should be dropped.
+	b.Publish("t", "overflow")
+
+	received := 0
+	for range 3 {
+		select {
+		case <-ch:
+			received++
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("timed out draining channel")
+		}
+	}
+	assert.Equal(t, 3, received)
+
+	select {
+	case <-ch:
+		t.Fatal("unexpected extra message — buffer was larger than configured")
+	default:
+	}
+}
+
+func TestWithBufferSize_LargeBuffer(t *testing.T) {
+	const bufSize = 500
+	b := NewSSEBroker(WithBufferSize(bufSize))
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	// Publish exactly bufSize messages — none should be dropped.
+	for i := range bufSize {
+		b.Publish("t", string(rune('0'+(i%10))))
+	}
+
+	received := 0
+	for range bufSize {
+		select {
+		case <-ch:
+			received++
+		case <-time.After(time.Second):
+			t.Fatalf("timed out after receiving %d/%d messages", received, bufSize)
+		}
+	}
+	assert.Equal(t, bufSize, received)
+}


### PR DESCRIPTION
## Summary

- Adds `BrokerOption` functional options pattern and `WithBufferSize` option to configure the subscriber channel buffer size
- `NewSSEBroker()` with no args still defaults to buffer size 10 (backwards compatible)
- `Subscribe` now uses `b.bufferSize` instead of the hardcoded `10`

## Tests

- `TestNewSSEBroker_DefaultBuffer` — verifies default buffer size of 10 is unchanged
- `TestNewSSEBroker_CustomBuffer` — verifies `WithBufferSize(3)` limits the buffer to 3
- `TestWithBufferSize_LargeBuffer` — verifies 500-message buffer delivers all messages without drops

Closes #4