### PR TITLE
feat: OOB fragment helpers for server-pushed HTML via SSE

### DIFF
--- a/oob.go
+++ b/oob.go
@@ -1,0 +1,52 @@
+package tavern
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Fragment describes a targeted DOM mutation for HTMX OOB swaps via SSE.
+type Fragment struct {
+	ID   string // target element ID
+	Swap string // hx-swap-oob value: outerHTML, innerHTML, delete, beforeend, afterbegin
+	HTML string // inner HTML content (empty for delete)
+}
+
+// Delete creates a fragment that removes an element from the DOM.
+func Delete(id string) Fragment {
+	return Fragment{ID: id, Swap: "delete"}
+}
+
+// Replace creates a fragment that replaces an element's outer HTML.
+func Replace(id string, html string) Fragment {
+	return Fragment{ID: id, Swap: "outerHTML", HTML: html}
+}
+
+// Append creates a fragment that appends content to the end of an element.
+func Append(id string, html string) Fragment {
+	return Fragment{ID: id, Swap: "beforeend", HTML: html}
+}
+
+// Prepend creates a fragment that prepends content to the beginning of an element.
+func Prepend(id string, html string) Fragment {
+	return Fragment{ID: id, Swap: "afterbegin", HTML: html}
+}
+
+// RenderFragments concatenates fragments into a single SSE-ready HTML string.
+// Each fragment is wrapped with hx-swap-oob for HTMX OOB processing.
+func RenderFragments(fragments ...Fragment) string {
+	var b strings.Builder
+	for _, f := range fragments {
+		if f.Swap == "delete" {
+			fmt.Fprintf(&b, `<div id="%s" hx-swap-oob="delete"></div>`, f.ID)
+		} else {
+			fmt.Fprintf(&b, `<div id="%s" hx-swap-oob="%s">%s</div>`, f.ID, f.Swap, f.HTML)
+		}
+	}
+	return b.String()
+}
+
+// PublishOOB renders the given fragments and publishes them as a single SSE event.
+func (b *SSEBroker) PublishOOB(topic string, fragments ...Fragment) {
+	b.Publish(topic, RenderFragments(fragments...))
+}

--- a/oob_test.go
+++ b/oob_test.go
@@ -1,0 +1,41 @@
+package tavern
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDelete(t *testing.T) {
+	f := Delete("task-row-5")
+	assert.Equal(t, "task-row-5", f.ID)
+	assert.Equal(t, "delete", f.Swap)
+	assert.Empty(t, f.HTML)
+}
+
+func TestReplace(t *testing.T) {
+	f := Replace("stats-bar", "<span>3</span>")
+	assert.Equal(t, "stats-bar", f.ID)
+	assert.Equal(t, "outerHTML", f.Swap)
+	assert.Equal(t, "<span>3</span>", f.HTML)
+}
+
+func TestAppend(t *testing.T) {
+	f := Append("list", "<li>new</li>")
+	assert.Equal(t, "beforeend", f.Swap)
+}
+
+func TestPrepend(t *testing.T) {
+	f := Prepend("feed", "<div>latest</div>")
+	assert.Equal(t, "afterbegin", f.Swap)
+}
+
+func TestRenderFragments(t *testing.T) {
+	html := RenderFragments(
+		Delete("task-row-5"),
+		Replace("stats-bar", "<span>2</span>"),
+	)
+	assert.Contains(t, html, `id="task-row-5" hx-swap-oob="delete"`)
+	assert.Contains(t, html, `id="stats-bar" hx-swap-oob="outerHTML"`)
+	assert.Contains(t, html, "<span>2</span>")
+}


### PR DESCRIPTION
Implements #12.

Adds Fragment primitives (Delete, Replace, Append, Prepend) and PublishOOB method for pushing HTMX OOB swaps through SSE events.

Zero new dependencies. Backward compatible — existing Subscribe/Publish unchanged.