### PR TITLE
feat: add templ.Component rendering helpers for OOB fragments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/catgoose/tavern
 
 go 1.26.1
 
-require github.com/stretchr/testify v1.11.1
+require (
+	github.com/a-h/templ v0.3.1001
+	github.com/stretchr/testify v1.11.1
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
+github.com/a-h/templ v0.3.1001 h1:yHDTgexACdJttyiyamcTHXr2QkIeVF1MukLy44EAhMY=
+github.com/a-h/templ v0.3.1001/go.mod h1:oCZcnKRf5jjsGpf2yELzQfodLphd2mwecwG4Crk5HBo=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/templ/templ.go
+++ b/templ/templ.go
@@ -1,0 +1,36 @@
+// Package templ provides templ.Component-aware Fragment helpers for tavern.
+package templ
+
+import (
+	"bytes"
+	"context"
+
+	atempl "github.com/a-h/templ"
+	"github.com/catgoose/tavern"
+)
+
+// ReplaceComponent renders a templ.Component and returns a Replace fragment.
+// If rendering fails, the fragment contains the error message as HTML.
+func ReplaceComponent(id string, cmp atempl.Component) tavern.Fragment {
+	return tavern.Fragment{ID: id, Swap: "outerHTML", HTML: render(cmp)}
+}
+
+// AppendComponent renders a templ.Component and returns an Append fragment.
+// If rendering fails, the fragment contains the error message as HTML.
+func AppendComponent(id string, cmp atempl.Component) tavern.Fragment {
+	return tavern.Fragment{ID: id, Swap: "beforeend", HTML: render(cmp)}
+}
+
+// PrependComponent renders a templ.Component and returns a Prepend fragment.
+// If rendering fails, the fragment contains the error message as HTML.
+func PrependComponent(id string, cmp atempl.Component) tavern.Fragment {
+	return tavern.Fragment{ID: id, Swap: "afterbegin", HTML: render(cmp)}
+}
+
+func render(cmp atempl.Component) string {
+	var buf bytes.Buffer
+	if err := cmp.Render(context.Background(), &buf); err != nil {
+		return "<!-- render error: " + err.Error() + " -->"
+	}
+	return buf.String()
+}

--- a/templ/templ_test.go
+++ b/templ/templ_test.go
@@ -1,0 +1,51 @@
+package templ
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	atempl "github.com/a-h/templ"
+	"github.com/stretchr/testify/require"
+)
+
+func textComponent(s string) atempl.Component {
+	return atempl.ComponentFunc(func(_ context.Context, w io.Writer) error {
+		_, err := io.WriteString(w, s)
+		return err
+	})
+}
+
+func failComponent() atempl.Component {
+	return atempl.ComponentFunc(func(_ context.Context, _ io.Writer) error {
+		return errors.New("render failed")
+	})
+}
+
+func TestReplaceComponent(t *testing.T) {
+	f := ReplaceComponent("stats", textComponent("<span>42</span>"))
+	require.Equal(t, "stats", f.ID)
+	require.Equal(t, "outerHTML", f.Swap)
+	require.Equal(t, "<span>42</span>", f.HTML)
+}
+
+func TestAppendComponent(t *testing.T) {
+	f := AppendComponent("list", textComponent("<li>new</li>"))
+	require.Equal(t, "list", f.ID)
+	require.Equal(t, "beforeend", f.Swap)
+	require.Equal(t, "<li>new</li>", f.HTML)
+}
+
+func TestPrependComponent(t *testing.T) {
+	f := PrependComponent("list", textComponent("<li>first</li>"))
+	require.Equal(t, "list", f.ID)
+	require.Equal(t, "afterbegin", f.Swap)
+	require.Equal(t, "<li>first</li>", f.HTML)
+}
+
+func TestRenderError(t *testing.T) {
+	f := ReplaceComponent("broken", failComponent())
+	require.Contains(t, f.HTML, "render error")
+	require.Contains(t, f.HTML, "render failed")
+}


### PR DESCRIPTION
## Summary

- Adds `templ` subpackage with `ReplaceComponent`, `AppendComponent`, and `PrependComponent` helpers that accept `templ.Component` values and return `tavern.Fragment` structs
- Eliminates manual render-to-string boilerplate when using templ components with OOB swaps
- Rendering errors are captured as HTML comments rather than panicking

## Test plan

- [x] `TestReplaceComponent` - verifies correct ID, swap strategy, and rendered HTML
- [x] `TestAppendComponent` - verifies beforeend swap with rendered content
- [x] `TestPrependComponent` - verifies afterbegin swap with rendered content
- [x] `TestRenderError` - verifies graceful error handling on render failure
- [x] All existing tavern tests continue to pass

Closes #14