### PR TITLE
docs: add screenshot to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/catgoose/tavern.svg)](https://pkg.go.dev/github.com/catgoose/tavern)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+![tavern](https://raw.githubusercontent.com/catgoose/screenshots/main/tavern/tavern.png)
+
 Thread-safe, topic-based pub/sub broker for Server-Sent Events (SSE) in Go.
 
 Tavern provides a minimal, concurrent-safe message broker that fans out string


### PR DESCRIPTION
## Summary
- Add screenshot image after badges in README, hosted from catgoose/screenshots repo