### PR TITLE
fix: remove Dothog Manifesto attribution suffix from README quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Thread-safe, topic-based pub/sub broker for Server-Sent Events (SSE) in Go.
 >
 > Grug say: "server tell it."
 >
-> -- Layman Grug, Dothog Manifesto
+> -- Layman Grug
 
 Tavern provides a minimal, concurrent-safe message broker that fans out string
 messages to subscribers by topic. It is designed to sit behind an HTTP handler
@@ -85,7 +85,7 @@ defer broker.Close()
 
 > The server sends a representation. The representation contains links and forms. The client follows them. THAT IS THE ENTIRE INTERACTION MODEL.
 >
-> -- The Wisdom of the Uniform Interface, Dothog Manifesto
+> -- The Wisdom of the Uniform Interface
 
 The server speaks; the client listens. This is the natural order. `Subscribe` returns a read-only channel and an unsubscribe function. Always
 defer the unsubscribe to avoid leaking goroutines and channels.
@@ -153,7 +153,7 @@ if broker.HasSubscribers("system-stats") {
 
 > Before enlightenment: fetch JSON, parse JSON, validate JSON, transform JSON, store JSON in client state, derive view from client state, diff virtual DOM, reconcile DOM. After enlightenment: the server tells it.
 >
-> -- Layman Grug, Dothog Manifesto (adapted for SSE)
+> -- Layman Grug (adapted for SSE)
 
 ### Echo SSE endpoint
 


### PR DESCRIPTION
## Summary
- Remove ", Dothog Manifesto" suffix from all block quote attributions in README
- Quotes now end with just the speaker/source name