### PR TITLE
Add RunPublisher for managed publisher goroutine lifecycle

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -7,6 +7,9 @@
 package tavern
 
 import (
+	"context"
+	"fmt"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 )
@@ -22,6 +25,8 @@ type SSEBroker struct {
 	bufferSize   int
 	drops        atomic.Int64
 	closed       bool
+	publishers   sync.WaitGroup
+	logger       *slog.Logger
 }
 
 // Topic name constants are conventions for common real-time use cases.
@@ -35,6 +40,10 @@ type scopedSub struct {
 	scope string
 }
 
+// PublisherFunc is a long-running function that publishes messages to the broker.
+// It receives the broker's context and should return when the context is cancelled.
+type PublisherFunc func(ctx context.Context)
+
 // BrokerOption configures the SSE broker.
 type BrokerOption func(*SSEBroker)
 
@@ -42,6 +51,14 @@ type BrokerOption func(*SSEBroker)
 func WithBufferSize(size int) BrokerOption {
 	return func(b *SSEBroker) {
 		b.bufferSize = size
+	}
+}
+
+// WithLogger sets a structured logger for the broker. When set, publisher
+// panics and errors are logged. Default is nil (no logging).
+func WithLogger(l *slog.Logger) BrokerOption {
+	return func(b *SSEBroker) {
+		b.logger = l
 	}
 }
 
@@ -264,12 +281,37 @@ func (b *SSEBroker) PublishTo(topic, scope, msg string) {
 	}
 }
 
-// Close shuts down the broker by closing all subscriber channels and removing
-// all topics. After Close returns, any pending reads on subscriber channels
-// will receive the zero value. It is safe to call Close while other goroutines
-// are publishing or subscribing; however, no new messages will be delivered
-// after Close returns.
+// RunPublisher launches fn in a new goroutine with panic recovery. If fn
+// panics, the panic is recovered and logged (when a logger is configured via
+// [WithLogger]). The goroutine is tracked by the broker's internal wait group
+// so that [SSEBroker.Close] blocks until all publishers have returned.
+//
+// fn receives the provided context and should return when the context is
+// cancelled. Callers typically pass a context derived from the application's
+// shutdown signal.
+func (b *SSEBroker) RunPublisher(ctx context.Context, fn PublisherFunc) {
+	b.publishers.Add(1)
+	go func() {
+		defer b.publishers.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				if b.logger != nil {
+					b.logger.Error("publisher panic recovered", "panic", fmt.Sprint(r))
+				}
+			}
+		}()
+		fn(ctx)
+	}()
+}
+
+// Close shuts down the broker. It first waits for all publisher goroutines
+// started via [SSEBroker.RunPublisher] to return, then closes all subscriber
+// channels and removes all topics. After Close returns, any pending reads on
+// subscriber channels will receive the zero value. It is safe to call Close
+// while other goroutines are publishing or subscribing; however, no new
+// messages will be delivered after Close returns.
 func (b *SSEBroker) Close() {
+	b.publishers.Wait()
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.closed = true

--- a/broker_test.go
+++ b/broker_test.go
@@ -1,7 +1,10 @@
 package tavern
 
 import (
+	"context"
+	"log/slog"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -550,4 +553,96 @@ func TestScopedAndUnscopedCoexist(t *testing.T) {
 	s := b.Stats()
 	assert.Equal(t, 1, s.Topics)
 	assert.Equal(t, 2, s.Subscribers)
+}
+
+func TestRunPublisher_ContextCancellation(t *testing.T) {
+	b := NewSSEBroker()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var ran atomic.Bool
+	b.RunPublisher(ctx, func(ctx context.Context) {
+		ran.Store(true)
+		<-ctx.Done()
+	})
+
+	// Give the goroutine time to start.
+	time.Sleep(10 * time.Millisecond)
+	require.True(t, ran.Load())
+
+	cancel()
+	// Close should return promptly because publisher exits on cancel.
+	done := make(chan struct{})
+	go func() {
+		b.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close blocked — publisher did not exit after context cancel")
+	}
+}
+
+func TestRunPublisher_PanicRecovery(t *testing.T) {
+	b := NewSSEBroker(WithLogger(slog.Default()))
+
+	b.RunPublisher(context.Background(), func(_ context.Context) {
+		panic("test panic")
+	})
+
+	// Close should return without hanging — the panicking publisher is recovered.
+	done := make(chan struct{})
+	go func() {
+		b.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close blocked — panic was not recovered")
+	}
+}
+
+func TestRunPublisher_PublishesMessages(t *testing.T) {
+	b := NewSSEBroker()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, unsub := b.Subscribe("tick")
+	defer unsub()
+
+	b.RunPublisher(ctx, func(ctx context.Context) {
+		b.Publish("tick", "hello from publisher")
+		<-ctx.Done()
+	})
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "hello from publisher", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for publisher message")
+	}
+
+	cancel()
+	b.Close()
+}
+
+func TestRunPublisher_CloseWaitsForAll(t *testing.T) {
+	b := NewSSEBroker()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var count atomic.Int32
+	for range 5 {
+		b.RunPublisher(ctx, func(ctx context.Context) {
+			count.Add(1)
+			<-ctx.Done()
+		})
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	require.Equal(t, int32(5), count.Load())
+
+	cancel()
+	b.Close()
+	// All publishers have exited if Close returned.
 }


### PR DESCRIPTION
## Summary
- Adds `RunPublisher(ctx, fn)` method to `SSEBroker` that launches publisher goroutines with panic recovery and `sync.WaitGroup` tracking
- `Close()` now waits for all publishers started via `RunPublisher` to exit before closing subscriber channels
- Adds `WithLogger(*slog.Logger)` option for logging recovered panics
- Adds `PublisherFunc` type for publisher function signatures

## Test plan
- [x] TestRunPublisher_ContextCancellation — publisher exits on cancel, Close returns promptly
- [x] TestRunPublisher_PanicRecovery — panicking publisher is recovered, Close doesn't hang
- [x] TestRunPublisher_PublishesMessages — publisher can publish to broker normally
- [x] TestRunPublisher_CloseWaitsForAll — Close blocks until all 5 publishers exit

Resolves #28