### PR TITLE
feat: topic lifecycle hooks

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -25,6 +25,8 @@ type SSEBroker struct {
 	scopedTopics      map[string]map[chan string]scopedSub
 	replayCache       map[string]string
 	lastHash          map[string]uint64 // topic → FNV hash of last published message via PublishIfChanged
+	onFirst           map[string][]func(string)
+	onLast            map[string][]func(string)
 	mu                sync.RWMutex
 	bufferSize        int
 	drops             atomic.Int64
@@ -98,6 +100,8 @@ func NewSSEBroker(opts ...BrokerOption) *SSEBroker {
 		replayCache:  make(map[string]string),
 		topicEmpty:   make(map[string]time.Time),
 		lastHash:     make(map[string]uint64),
+		onFirst:      make(map[string][]func(string)),
+		onLast:       make(map[string][]func(string)),
 		bufferSize:   10,
 		done:         make(chan struct{}),
 	}
@@ -135,9 +139,17 @@ func (b *SSEBroker) Subscribe(topic string) (msgs <-chan string, unsubscribe fun
 		b.topics[topic] = make(map[chan string]struct{})
 	}
 	b.topics[topic][ch] = struct{}{}
+	total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+	var firstHooks []func(string)
+	if total == 1 {
+		firstHooks = b.onFirst[topic]
+	}
 	replay, hasReplay := b.replayCache[topic]
 	delete(b.topicEmpty, topic)
 	b.mu.Unlock()
+	for _, fn := range firstHooks {
+		go fn(topic)
+	}
 	if hasReplay {
 		select {
 		case ch <- replay:
@@ -146,14 +158,20 @@ func (b *SSEBroker) Subscribe(topic string) (msgs <-chan string, unsubscribe fun
 	}
 	return ch, func() {
 		b.mu.Lock()
+		var lastHooks []func(string)
 		if _, ok := b.topics[topic][ch]; ok {
 			delete(b.topics[topic], ch)
 			close(ch)
-			if len(b.topics[topic])+len(b.scopedTopics[topic]) == 0 {
+			total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+			if total == 0 {
+				lastHooks = b.onLast[topic]
 				b.topicEmpty[topic] = time.Now()
 			}
 		}
 		b.mu.Unlock()
+		for _, fn := range lastHooks {
+			go fn(topic)
+		}
 	}
 }
 
@@ -174,9 +192,17 @@ func (b *SSEBroker) SubscribeScoped(topic, scope string) (msgs <-chan string, un
 		b.scopedTopics[topic] = make(map[chan string]scopedSub)
 	}
 	b.scopedTopics[topic][ch] = scopedSub{scope: scope}
+	total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+	var firstHooks []func(string)
+	if total == 1 {
+		firstHooks = b.onFirst[topic]
+	}
 	replay, hasReplay := b.replayCache[topic]
 	delete(b.topicEmpty, topic)
 	b.mu.Unlock()
+	for _, fn := range firstHooks {
+		go fn(topic)
+	}
 	if hasReplay {
 		select {
 		case ch <- replay:
@@ -185,15 +211,49 @@ func (b *SSEBroker) SubscribeScoped(topic, scope string) (msgs <-chan string, un
 	}
 	return ch, func() {
 		b.mu.Lock()
+		var lastHooks []func(string)
 		if _, ok := b.scopedTopics[topic][ch]; ok {
 			delete(b.scopedTopics[topic], ch)
 			close(ch)
-			if len(b.topics[topic])+len(b.scopedTopics[topic]) == 0 {
+			total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+			if total == 0 {
+				lastHooks = b.onLast[topic]
 				b.topicEmpty[topic] = time.Now()
 			}
 		}
 		b.mu.Unlock()
+		for _, fn := range lastHooks {
+			go fn(topic)
+		}
 	}
+}
+
+// OnFirstSubscriber registers a callback that fires when the given topic goes
+// from zero to one total subscribers (counting both unscoped and scoped). The
+// callback runs in its own goroutine and does not block Subscribe. Multiple
+// hooks per topic are allowed and all will fire. Hooks persist across
+// subscriber cycles. Calling this on a closed broker is a no-op.
+func (b *SSEBroker) OnFirstSubscriber(topic string, fn func(topic string)) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return
+	}
+	b.onFirst[topic] = append(b.onFirst[topic], fn)
+}
+
+// OnLastUnsubscribe registers a callback that fires when the given topic goes
+// from one to zero total subscribers (counting both unscoped and scoped). The
+// callback runs in its own goroutine and does not block the unsubscribe call.
+// Multiple hooks per topic are allowed and all will fire. Hooks persist across
+// subscriber cycles. Calling this on a closed broker is a no-op.
+func (b *SSEBroker) OnLastUnsubscribe(topic string, fn func(topic string)) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return
+	}
+	b.onLast[topic] = append(b.onLast[topic], fn)
 }
 
 // HasSubscribers reports whether the given topic has at least one active

--- a/broker_test.go
+++ b/broker_test.go
@@ -1112,3 +1112,160 @@ func TestPublishIfChanged_EmptyMessage(t *testing.T) {
 	default:
 	}
 }
+
+func TestOnFirstSubscriber_FiresOnFirstSub(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	fired := make(chan string, 1)
+	b.OnFirstSubscriber("t", func(topic string) { fired <- topic })
+
+	_, unsub := b.Subscribe("t")
+	defer unsub()
+
+	select {
+	case got := <-fired:
+		assert.Equal(t, "t", got)
+	case <-time.After(time.Second):
+		t.Fatal("hook did not fire")
+	}
+}
+
+func TestOnLastUnsubscribe_FiresWhenLastLeaves(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	fired := make(chan string, 1)
+	b.OnLastUnsubscribe("t", func(topic string) { fired <- topic })
+
+	_, unsub := b.Subscribe("t")
+	unsub()
+
+	select {
+	case got := <-fired:
+		assert.Equal(t, "t", got)
+	case <-time.After(time.Second):
+		t.Fatal("hook did not fire")
+	}
+}
+
+func TestLifecycleHooks_MultipleHooksPerTopic(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	fired := make(chan int, 2)
+	b.OnFirstSubscriber("t", func(string) { fired <- 1 })
+	b.OnFirstSubscriber("t", func(string) { fired <- 2 })
+
+	_, unsub := b.Subscribe("t")
+	defer unsub()
+
+	got := make(map[int]bool)
+	for range 2 {
+		select {
+		case v := <-fired:
+			got[v] = true
+		case <-time.After(time.Second):
+			t.Fatal("hook did not fire")
+		}
+	}
+	assert.True(t, got[1])
+	assert.True(t, got[2])
+}
+
+func TestLifecycleHooks_SurvivesSubscriberCycles(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	count := make(chan string, 2)
+	b.OnFirstSubscriber("t", func(topic string) { count <- topic })
+
+	// First cycle.
+	_, unsub1 := b.Subscribe("t")
+	select {
+	case <-count:
+	case <-time.After(time.Second):
+		t.Fatal("first hook did not fire")
+	}
+	unsub1()
+
+	// Second cycle — hook should fire again.
+	_, unsub2 := b.Subscribe("t")
+	defer unsub2()
+	select {
+	case <-count:
+	case <-time.After(time.Second):
+		t.Fatal("hook did not fire on second cycle")
+	}
+}
+
+func TestLifecycleHooks_CountsBothScopedAndUnscoped(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	lastFired := make(chan string, 1)
+	b.OnLastUnsubscribe("t", func(topic string) { lastFired <- topic })
+
+	// Subscribe unscoped then scoped — total 2.
+	_, unsubUnscoped := b.Subscribe("t")
+	_, unsubScoped := b.SubscribeScoped("t", "s1")
+
+	// Remove unscoped — total still 1, onLast should NOT fire.
+	unsubUnscoped()
+	select {
+	case <-lastFired:
+		t.Fatal("onLast fired while scoped subscriber still active")
+	case <-time.After(100 * time.Millisecond):
+		// expected
+	}
+
+	// Remove scoped — total now 0, onLast should fire.
+	unsubScoped()
+	select {
+	case got := <-lastFired:
+		assert.Equal(t, "t", got)
+	case <-time.After(time.Second):
+		t.Fatal("onLast did not fire")
+	}
+}
+
+func TestLifecycleHooks_ClosedBroker(t *testing.T) {
+	b := NewSSEBroker()
+	b.Close()
+
+	fired := make(chan string, 1)
+	b.OnFirstSubscriber("t", func(topic string) { fired <- topic })
+
+	_, unsub := b.Subscribe("t")
+	defer unsub()
+
+	select {
+	case <-fired:
+		t.Fatal("hook should not fire on closed broker")
+	case <-time.After(100 * time.Millisecond):
+		// expected
+	}
+}
+
+func TestOnFirstSubscriber_NonBlocking(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.OnFirstSubscriber("t", func(string) {
+		time.Sleep(500 * time.Millisecond)
+	})
+
+	done := make(chan struct{})
+	go func() {
+		_, unsub := b.Subscribe("t")
+		defer unsub()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Subscribe returned quickly — not blocked by slow hook.
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Subscribe was blocked by slow hook")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `OnFirstSubscriber(topic, fn)` and `OnLastUnsubscribe(topic, fn)` methods to `SSEBroker`
- Hooks fire when a topic transitions between 0 and 1 total subscribers (both scoped and unscoped counted)
- Callbacks run in goroutines (non-blocking), multiple hooks per topic supported, hooks persist across subscriber cycles

Closes #31

## Test plan

- [x] `TestOnFirstSubscriber_FiresOnFirstSub` — hook fires on first subscribe
- [x] `TestOnLastUnsubscribe_FiresWhenLastLeaves` — hook fires when last subscriber leaves
- [x] `TestLifecycleHooks_MultipleHooksPerTopic` — multiple hooks all fire
- [x] `TestLifecycleHooks_SurvivesSubscriberCycles` — hook fires again after sub/unsub/sub
- [x] `TestLifecycleHooks_CountsBothScopedAndUnscoped` — mixed scoped/unscoped counting works correctly
- [x] `TestLifecycleHooks_ClosedBroker` — no-op on closed broker
- [x] `TestOnFirstSubscriber_NonBlocking` — slow hook does not block Subscribe
- [x] All existing tests pass with race detector