### PR TITLE
feat: publish-if-changed content deduplication

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -9,6 +9,7 @@ package tavern
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -23,6 +24,7 @@ type SSEBroker struct {
 	topics            map[string]map[chan string]struct{}
 	scopedTopics      map[string]map[chan string]scopedSub
 	replayCache       map[string]string
+	lastHash          map[string]uint64 // topic → FNV hash of last published message via PublishIfChanged
 	mu                sync.RWMutex
 	bufferSize        int
 	drops             atomic.Int64
@@ -95,6 +97,7 @@ func NewSSEBroker(opts ...BrokerOption) *SSEBroker {
 		scopedTopics: make(map[string]map[chan string]scopedSub),
 		replayCache:  make(map[string]string),
 		topicEmpty:   make(map[string]time.Time),
+		lastHash:     make(map[string]uint64),
 		bufferSize:   10,
 		done:         make(chan struct{}),
 	}
@@ -375,6 +378,65 @@ func (b *SSEBroker) PublishTo(topic, scope, msg string) {
 	}
 }
 
+// hashMsg returns the FNV-64a hash of msg.
+func hashMsg(msg string) uint64 {
+	h := fnv.New64a()
+	h.Write([]byte(msg)) //nolint:errcheck // hash.Write never returns an error
+	return h.Sum64()
+}
+
+// PublishIfChanged publishes msg to the given topic only when it differs from
+// the last message published via PublishIfChanged for that topic. It returns
+// true if the message was published (content changed) or false if it was
+// skipped (identical to the previous message). Comparison is done via an
+// FNV-64a hash of the message content.
+//
+// The deduplication state is per-topic and independent of [SSEBroker.Publish].
+// Use [SSEBroker.ClearDedup] to reset the stored hash for a topic.
+func (b *SSEBroker) PublishIfChanged(topic, msg string) bool {
+	h := hashMsg(msg)
+
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return false
+	}
+	if prev, ok := b.lastHash[topic]; ok && prev == h {
+		b.mu.Unlock()
+		return false
+	}
+	b.lastHash[topic] = h
+
+	// Snapshot subscribers while we hold the lock.
+	subscribers := b.topics[topic]
+	channels := make([]chan string, 0, len(subscribers))
+	for ch := range subscribers {
+		channels = append(channels, ch)
+	}
+	b.mu.Unlock()
+
+	for _, ch := range channels {
+		func() {
+			defer func() { _ = recover() }()
+			select {
+			case ch <- msg:
+			default:
+				b.drops.Add(1)
+			}
+		}()
+	}
+	return true
+}
+
+// ClearDedup resets the deduplication state for the given topic so the next
+// call to [SSEBroker.PublishIfChanged] will always publish regardless of
+// content.
+func (b *SSEBroker) ClearDedup(topic string) {
+	b.mu.Lock()
+	delete(b.lastHash, topic)
+	b.mu.Unlock()
+}
+
 // RunPublisher launches fn in a new goroutine with panic recovery. If fn
 // panics, the panic is recovered and logged (when a logger is configured via
 // [WithLogger]). The goroutine is tracked by the broker's internal wait group
@@ -455,6 +517,7 @@ func (b *SSEBroker) Close() {
 	b.closed = true
 	close(b.done)
 	b.replayCache = nil
+	b.lastHash = nil
 	for topic, subs := range b.topics {
 		for ch := range subs {
 			delete(subs, ch)

--- a/broker_test.go
+++ b/broker_test.go
@@ -943,3 +943,172 @@ func TestWithTopicTTL_ScopedTopics(t *testing.T) {
 		return len(b.TopicCounts()) == 0
 	}, time.Second, 10*time.Millisecond)
 }
+
+func TestPublishIfChanged_PublishesNewMessage(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	ok := b.PublishIfChanged("t", "hello")
+	require.True(t, ok)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "hello", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+}
+
+func TestPublishIfChanged_SkipsDuplicate(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	ok1 := b.PublishIfChanged("t", "same")
+	require.True(t, ok1)
+
+	ok2 := b.PublishIfChanged("t", "same")
+	require.False(t, ok2)
+
+	// Drain the one message that was delivered.
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "same", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+
+	// No second message should be present.
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected second message: %s", msg)
+	default:
+	}
+}
+
+func TestPublishIfChanged_PublishesAfterChange(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	ok1 := b.PublishIfChanged("t", "A")
+	require.True(t, ok1)
+
+	ok2 := b.PublishIfChanged("t", "B")
+	require.True(t, ok2)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "A", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first message")
+	}
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "B", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for second message")
+	}
+}
+
+func TestPublishIfChanged_PerTopic(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch1, unsub1 := b.Subscribe("topic1")
+	defer unsub1()
+	ch2, unsub2 := b.Subscribe("topic2")
+	defer unsub2()
+
+	// Same message to different topics — both should publish.
+	ok1 := b.PublishIfChanged("topic1", "same")
+	ok2 := b.PublishIfChanged("topic2", "same")
+	require.True(t, ok1)
+	require.True(t, ok2)
+
+	select {
+	case msg := <-ch1:
+		assert.Equal(t, "same", msg)
+	case <-time.After(time.Second):
+		t.Fatal("topic1 timed out")
+	}
+
+	select {
+	case msg := <-ch2:
+		assert.Equal(t, "same", msg)
+	case <-time.After(time.Second):
+		t.Fatal("topic2 timed out")
+	}
+}
+
+func TestPublishIfChanged_AfterClose(t *testing.T) {
+	b := NewSSEBroker()
+	b.Close()
+
+	assert.NotPanics(t, func() {
+		ok := b.PublishIfChanged("t", "msg")
+		assert.False(t, ok)
+	})
+}
+
+func TestClearDedup(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	ok1 := b.PublishIfChanged("t", "msg")
+	require.True(t, ok1)
+
+	// Clear dedup state.
+	b.ClearDedup("t")
+
+	// Same message should now publish again.
+	ok2 := b.PublishIfChanged("t", "msg")
+	require.True(t, ok2)
+
+	// Drain both messages.
+	for range 2 {
+		select {
+		case <-ch:
+		case <-time.After(time.Second):
+			t.Fatal("timed out")
+		}
+	}
+}
+
+func TestPublishIfChanged_EmptyMessage(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	ok1 := b.PublishIfChanged("t", "")
+	require.True(t, ok1)
+
+	ok2 := b.PublishIfChanged("t", "")
+	require.False(t, ok2)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected second message: %q", msg)
+	default:
+	}
+}


### PR DESCRIPTION
## Summary

- Add `PublishIfChanged(topic, msg string) bool` method that skips publishing when the message is identical (by FNV-64a hash) to the last one published for that topic
- Add `ClearDedup(topic string)` to reset deduplication state for a topic
- Dedup state is cleaned up on `Close()`

Closes #34

## Test plan

- [x] `TestPublishIfChanged_PublishesNewMessage` — new message arrives and returns true
- [x] `TestPublishIfChanged_SkipsDuplicate` — duplicate is skipped, returns false
- [x] `TestPublishIfChanged_PublishesAfterChange` — different message publishes, returns true
- [x] `TestPublishIfChanged_PerTopic` — dedup is per-topic, not global
- [x] `TestPublishIfChanged_AfterClose` — returns false, no panic
- [x] `TestClearDedup` — clearing allows same message to republish
- [x] `TestPublishIfChanged_EmptyMessage` — empty string deduplicates correctly