### PR TITLE
feat: debounce, throttle, replay-n, drop-oldest

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,55 @@ broker := tavern.NewSSEBroker(tavern.WithBufferSize(64))
 defer broker.Close()
 ```
 
+`WithDropOldest` changes the buffer strategy from drop-newest (default) to
+drop-oldest. When a subscriber's buffer is full, the oldest queued message is
+discarded to make room for the new one. Use this for dashboards where stale
+data is worse than gaps.
+
+```go
+broker := tavern.NewSSEBroker(tavern.WithBufferSize(5), tavern.WithDropOldest())
+```
+
+### Replay
+
+Cache recent messages so new subscribers get them immediately on connect:
+
+```go
+// Default: replays last 1 message
+broker.PublishWithReplay("dashboard", msg)
+
+// Replay last 10 messages (activity feed, chat)
+broker.SetReplayPolicy("activity", 10)
+broker.PublishWithReplay("activity", msg) // last 10 cached
+```
+
+Clear the cache:
+
+```go
+broker.ClearReplay("dashboard")
+```
+
+### Debounce and throttle
+
+Control publish frequency for rapid state changes:
+
+```go
+// Debounce: publish only after 200ms of quiet (typing indicators, search)
+broker.PublishDebounced("search-results", html, 200*time.Millisecond)
+
+// Throttle: publish at most once per second, first call immediate
+broker.PublishThrottled("live-stats", html, time.Second)
+```
+
+**Debounce** waits for a quiet period — if new messages keep arriving, the timer
+resets and only the final message is published. Best for user input where you
+want the settled state.
+
+**Throttle** publishes the first message immediately, then rate-limits to at
+most one message per interval. If messages arrive during the cooldown, the most
+recent one is published when the interval elapses. Best for continuous data
+where you want bounded latency.
+
 ### Topic metrics
 
 ```go

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -512,3 +512,118 @@ es.addEventListener("message", (e) => {
   feed.insertAdjacentHTML("beforeend", e.data);
 });
 ```
+
+---
+
+## 8. Debounced search with SSE results
+
+Publish search results via SSE only after the user stops typing. The server
+debounces rapid keystrokes so only the final query triggers rendering and
+publishing.
+
+### Go handler (search endpoint)
+
+```go
+func searchHandler(broker *tavern.SSEBroker, db *sql.DB) echo.HandlerFunc {
+    return func(c echo.Context) error {
+        query := c.QueryParam("q")
+        results := search(db, query)
+        html := renderSearchResults(results)
+
+        // Only publish after 300ms of quiet — rapid typing resets the timer.
+        broker.PublishDebounced("search-"+userID(c), html, 300*time.Millisecond)
+
+        return c.NoContent(http.StatusOK)
+    }
+}
+```
+
+### HTML
+
+```html
+<input type="search"
+       hx-get="/search"
+       hx-trigger="keyup changed delay:100ms"
+       hx-target="#search-results"
+       hx-swap="none"
+       name="q" />
+
+<div id="search-results"
+     hx-ext="sse"
+     sse-connect="/sse?topic=search-user123"
+     sse-swap="message">
+</div>
+```
+
+---
+
+## 9. Throttled live dashboard
+
+Rate-limit a high-frequency data source to publish at most once per second.
+The first update shows immediately; subsequent updates are coalesced.
+
+### Go publisher
+
+```go
+func startMetricsPublisher(ctx context.Context, broker *tavern.SSEBroker) {
+    broker.RunPublisher(ctx, func(ctx context.Context) {
+        for {
+            select {
+            case <-ctx.Done():
+                return
+            case sample := <-metricsChannel:
+                html := renderMetricsPanel(sample)
+                // At most 1 publish per second, latest data wins.
+                broker.PublishThrottled("metrics", html, time.Second)
+            }
+        }
+    })
+}
+```
+
+### HTML
+
+```html
+<div id="metrics-panel"
+     hx-ext="sse"
+     sse-connect="/sse?topic=metrics"
+     sse-swap="message">
+  <!-- updates at most once per second -->
+</div>
+```
+
+---
+
+## 10. Activity feed with replay history
+
+New visitors to the activity page immediately see the last 20 events, then
+receive live updates as they happen.
+
+### Go setup
+
+```go
+broker.SetReplayPolicy("activity", 20)
+
+func createEvent(broker *tavern.SSEBroker, db *sql.DB) echo.HandlerFunc {
+    return func(c echo.Context) error {
+        event := persistEvent(db, c)
+        html := renderActivityItem(event)
+
+        // Cached for replay + published to live subscribers
+        broker.PublishWithReplay("activity", html)
+
+        return c.NoContent(http.StatusCreated)
+    }
+}
+```
+
+### HTML
+
+```html
+<ul id="activity-feed"
+    hx-ext="sse"
+    sse-connect="/sse?topic=activity"
+    sse-swap="message">
+  <!-- last 20 events replayed on connect, then live updates -->
+</ul>
+```

--- a/broker.go
+++ b/broker.go
@@ -23,7 +23,8 @@ import (
 type SSEBroker struct {
 	topics            map[string]map[chan string]struct{}
 	scopedTopics      map[string]map[chan string]scopedSub
-	replayCache       map[string]string
+	replayCache       map[string][]string // topic → recent messages (ring buffer)
+	replaySize        map[string]int      // topic → max messages to keep
 	lastHash          map[string]uint64 // topic → FNV hash of last published message via PublishIfChanged
 	onFirst           map[string][]func(string)
 	onLast            map[string][]func(string)
@@ -37,6 +38,9 @@ type SSEBroker struct {
 	topicTTL          time.Duration
 	topicEmpty        map[string]time.Time
 	done              chan struct{}
+	dropOldest        bool
+	debounce          debouncer
+	throttle          throttler
 }
 
 // Topic name constants are conventions for common real-time use cases.
@@ -91,13 +95,25 @@ func WithTopicTTL(ttl time.Duration) BrokerOption {
 	}
 }
 
+// WithDropOldest changes the subscriber buffer strategy from drop-newest
+// (default) to drop-oldest. When a subscriber's buffer is full, the oldest
+// buffered message is discarded to make room for the new one. This is useful
+// for dashboards where the latest data is always more relevant than queued
+// historical data.
+func WithDropOldest() BrokerOption {
+	return func(b *SSEBroker) {
+		b.dropOldest = true
+	}
+}
+
 // NewSSEBroker creates a ready-to-use [SSEBroker] with no active topics or
 // subscribers. It accepts optional [BrokerOption] values to override defaults.
 func NewSSEBroker(opts ...BrokerOption) *SSEBroker {
 	b := &SSEBroker{
 		topics:       make(map[string]map[chan string]struct{}),
 		scopedTopics: make(map[string]map[chan string]scopedSub),
-		replayCache:  make(map[string]string),
+		replayCache:  make(map[string][]string),
+		replaySize:   make(map[string]int),
 		topicEmpty:   make(map[string]time.Time),
 		lastHash:     make(map[string]uint64),
 		onFirst:      make(map[string][]func(string)),
@@ -108,6 +124,8 @@ func NewSSEBroker(opts ...BrokerOption) *SSEBroker {
 	for _, opt := range opts {
 		opt(b)
 	}
+	b.debounce.timers = make(map[string]*debounceEntry)
+	b.throttle.state = make(map[string]*throttleEntry)
 	if b.keepaliveInterval > 0 {
 		go b.keepaliveLoop()
 	}
@@ -144,15 +162,15 @@ func (b *SSEBroker) Subscribe(topic string) (msgs <-chan string, unsubscribe fun
 	if total == 1 {
 		firstHooks = b.onFirst[topic]
 	}
-	replay, hasReplay := b.replayCache[topic]
+	replayMsgs := append([]string(nil), b.replayCache[topic]...)
 	delete(b.topicEmpty, topic)
 	b.mu.Unlock()
 	for _, fn := range firstHooks {
 		go fn(topic)
 	}
-	if hasReplay {
+	for _, msg := range replayMsgs {
 		select {
-		case ch <- replay:
+		case ch <- msg:
 		default:
 		}
 	}
@@ -197,15 +215,15 @@ func (b *SSEBroker) SubscribeScoped(topic, scope string) (msgs <-chan string, un
 	if total == 1 {
 		firstHooks = b.onFirst[topic]
 	}
-	replay, hasReplay := b.replayCache[topic]
+	replayMsgs := append([]string(nil), b.replayCache[topic]...)
 	delete(b.topicEmpty, topic)
 	b.mu.Unlock()
 	for _, fn := range firstHooks {
 		go fn(topic)
 	}
-	if hasReplay {
+	for _, msg := range replayMsgs {
 		select {
-		case ch <- replay:
+		case ch <- msg:
 		default:
 		}
 	}
@@ -338,6 +356,41 @@ func (b *SSEBroker) Stats() BrokerStats {
 	}
 }
 
+// send attempts to send msg on ch. If the channel is full and dropOldest is
+// enabled, it drains the oldest message first. Returns true if sent, false if
+// dropped.
+// send attempts to send msg on ch. If the channel is full and dropOldest is
+// enabled, it drains the oldest message first and counts the drop. Returns
+// true if the new message was sent, false if it was dropped entirely.
+func (b *SSEBroker) send(ch chan string, msg string) bool {
+	if b.dropOldest {
+		select {
+		case ch <- msg:
+			return true
+		default:
+			// Channel full — drain oldest and count it as a drop.
+			select {
+			case <-ch:
+				b.drops.Add(1)
+			default:
+			}
+			// Try again.
+			select {
+			case ch <- msg:
+				return true
+			default:
+				return false
+			}
+		}
+	}
+	select {
+	case ch <- msg:
+		return true
+	default:
+		return false
+	}
+}
+
 // Publish fans out msg to every subscriber of the given topic. It is
 // non-blocking: if a subscriber's channel buffer is full, the message is
 // silently dropped for that subscriber rather than blocking the publisher.
@@ -360,9 +413,7 @@ func (b *SSEBroker) Publish(topic, msg string) {
 		// Recover from the resulting panic rather than adding complex synchronization.
 		func() {
 			defer func() { _ = recover() }()
-			select {
-			case ch <- msg:
-			default:
+			if !b.send(ch, msg) {
 				b.drops.Add(1)
 			}
 		}()
@@ -379,7 +430,16 @@ func (b *SSEBroker) PublishWithReplay(topic, msg string) {
 		b.mu.Unlock()
 		return
 	}
-	b.replayCache[topic] = msg
+	maxSize := 1
+	if n, ok := b.replaySize[topic]; ok {
+		maxSize = n
+	}
+	msgs := b.replayCache[topic]
+	msgs = append(msgs, msg)
+	if len(msgs) > maxSize {
+		msgs = msgs[len(msgs)-maxSize:]
+	}
+	b.replayCache[topic] = msgs
 	subscribers := b.topics[topic]
 	channels := make([]chan string, 0, len(subscribers))
 	for ch := range subscribers {
@@ -390,12 +450,27 @@ func (b *SSEBroker) PublishWithReplay(topic, msg string) {
 	for _, ch := range channels {
 		func() {
 			defer func() { _ = recover() }()
-			select {
-			case ch <- msg:
-			default:
+			if !b.send(ch, msg) {
 				b.drops.Add(1)
 			}
 		}()
+	}
+}
+
+// SetReplayPolicy sets how many recent messages to cache for replay on the
+// given topic. New subscribers receive up to n cached messages in order before
+// live messages. Use n=0 to disable replay for the topic.
+func (b *SSEBroker) SetReplayPolicy(topic string, n int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if n <= 0 {
+		delete(b.replaySize, topic)
+		delete(b.replayCache, topic)
+		return
+	}
+	b.replaySize[topic] = n
+	if msgs := b.replayCache[topic]; len(msgs) > n {
+		b.replayCache[topic] = msgs[len(msgs)-n:]
 	}
 }
 
@@ -404,6 +479,7 @@ func (b *SSEBroker) PublishWithReplay(topic, msg string) {
 func (b *SSEBroker) ClearReplay(topic string) {
 	b.mu.Lock()
 	delete(b.replayCache, topic)
+	delete(b.replaySize, topic)
 	b.mu.Unlock()
 }
 
@@ -429,9 +505,7 @@ func (b *SSEBroker) PublishTo(topic, scope, msg string) {
 	for _, ch := range channels {
 		func() {
 			defer func() { _ = recover() }()
-			select {
-			case ch <- msg:
-			default:
+			if !b.send(ch, msg) {
 				b.drops.Add(1)
 			}
 		}()
@@ -478,9 +552,7 @@ func (b *SSEBroker) PublishIfChanged(topic, msg string) bool {
 	for _, ch := range channels {
 		func() {
 			defer func() { _ = recover() }()
-			select {
-			case ch <- msg:
-			default:
+			if !b.send(ch, msg) {
 				b.drops.Add(1)
 			}
 		}()
@@ -570,13 +642,14 @@ func (b *SSEBroker) sendKeepalive() {
 func (b *SSEBroker) Close() {
 	b.publishers.Wait()
 	b.mu.Lock()
-	defer b.mu.Unlock()
 	if b.closed {
+		b.mu.Unlock()
 		return
 	}
 	b.closed = true
 	close(b.done)
 	b.replayCache = nil
+	b.replaySize = nil
 	b.lastHash = nil
 	for topic, subs := range b.topics {
 		for ch := range subs {
@@ -592,6 +665,21 @@ func (b *SSEBroker) Close() {
 		}
 		delete(b.scopedTopics, topic)
 	}
+	b.mu.Unlock()
+	b.debounce.mu.Lock()
+	for topic, entry := range b.debounce.timers {
+		entry.timer.Stop()
+		delete(b.debounce.timers, topic)
+	}
+	b.debounce.mu.Unlock()
+	b.throttle.mu.Lock()
+	for topic, entry := range b.throttle.state {
+		if entry.timer != nil {
+			entry.timer.Stop()
+		}
+		delete(b.throttle.state, topic)
+	}
+	b.throttle.mu.Unlock()
 }
 
 // startTopicSweep periodically removes topics that have had zero subscribers

--- a/broker_test.go
+++ b/broker_test.go
@@ -2,6 +2,7 @@ package tavern
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -1268,4 +1269,236 @@ func TestOnFirstSubscriber_NonBlocking(t *testing.T) {
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("Subscribe was blocked by slow hook")
 	}
+}
+
+// --- ReplayN tests ---
+
+func TestSetReplayPolicy_ReplayN(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("topic", 3)
+
+	for i := 1; i <= 5; i++ {
+		b.PublishWithReplay("topic", fmt.Sprintf("msg-%d", i))
+	}
+
+	ch, unsub := b.Subscribe("topic")
+	defer unsub()
+
+	var got []string
+	for i := 0; i < 3; i++ {
+		select {
+		case msg := <-ch:
+			got = append(got, msg)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for replay message")
+		}
+	}
+
+	assert.Equal(t, []string{"msg-3", "msg-4", "msg-5"}, got)
+
+	// No more replay messages.
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected extra replay message: %s", msg)
+	default:
+	}
+}
+
+func TestSetReplayPolicy_DefaultOne(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	// No SetReplayPolicy — default should replay last 1.
+	b.PublishWithReplay("topic", "first")
+	b.PublishWithReplay("topic", "second")
+	b.PublishWithReplay("topic", "third")
+
+	ch, unsub := b.Subscribe("topic")
+	defer unsub()
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "third", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for replay")
+	}
+
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected extra replay message: %s", msg)
+	default:
+	}
+}
+
+func TestSetReplayPolicy_Zero(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("topic", 3)
+	b.PublishWithReplay("topic", "msg-1")
+	b.PublishWithReplay("topic", "msg-2")
+
+	// Disable replay.
+	b.SetReplayPolicy("topic", 0)
+
+	ch, unsub := b.Subscribe("topic")
+	defer unsub()
+
+	select {
+	case msg := <-ch:
+		t.Fatalf("should not have received replay after policy set to 0: %s", msg)
+	default:
+		// expected
+	}
+}
+
+func TestSetReplayPolicy_TrimExisting(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("topic", 5)
+	for i := 1; i <= 5; i++ {
+		b.PublishWithReplay("topic", fmt.Sprintf("msg-%d", i))
+	}
+
+	// Trim down to 2.
+	b.SetReplayPolicy("topic", 2)
+
+	ch, unsub := b.Subscribe("topic")
+	defer unsub()
+
+	var got []string
+	for i := 0; i < 2; i++ {
+		select {
+		case msg := <-ch:
+			got = append(got, msg)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for replay message")
+		}
+	}
+
+	assert.Equal(t, []string{"msg-4", "msg-5"}, got)
+
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected extra replay message: %s", msg)
+	default:
+	}
+}
+
+func TestSetReplayPolicy_MultipleScopedReplay(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 3)
+	b.PublishWithReplay("events", "e-1")
+	b.PublishWithReplay("events", "e-2")
+	b.PublishWithReplay("events", "e-3")
+
+	ch, unsub := b.SubscribeScoped("events", "scope-1")
+	defer unsub()
+
+	var got []string
+	for i := 0; i < 3; i++ {
+		select {
+		case msg := <-ch:
+			got = append(got, msg)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for scoped replay message")
+		}
+	}
+
+	assert.Equal(t, []string{"e-1", "e-2", "e-3"}, got)
+}
+
+// --- WithDropOldest tests ---
+
+func TestWithDropOldest_DropsOldMessage(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(2), WithDropOldest())
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("topic")
+	defer unsub()
+
+	// Fill buffer and overflow.
+	b.Publish("topic", "msg-1")
+	b.Publish("topic", "msg-2")
+	b.Publish("topic", "msg-3")
+
+	// Should get msg-2 and msg-3 (msg-1 was dropped as oldest).
+	var got []string
+	for i := 0; i < 2; i++ {
+		select {
+		case msg := <-ch:
+			got = append(got, msg)
+		case <-time.After(time.Second):
+			t.Fatal("timed out")
+		}
+	}
+
+	assert.Equal(t, []string{"msg-2", "msg-3"}, got)
+}
+
+func TestWithDropOldest_DefaultDropNewest(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(2))
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("topic")
+	defer unsub()
+
+	// Fill buffer and overflow — default drops newest.
+	b.Publish("topic", "msg-1")
+	b.Publish("topic", "msg-2")
+	b.Publish("topic", "msg-3") // dropped
+
+	var got []string
+	for i := 0; i < 2; i++ {
+		select {
+		case msg := <-ch:
+			got = append(got, msg)
+		case <-time.After(time.Second):
+			t.Fatal("timed out")
+		}
+	}
+
+	assert.Equal(t, []string{"msg-1", "msg-2"}, got)
+}
+
+func TestWithDropOldest_CountsDrops(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(1), WithDropOldest())
+	defer b.Close()
+
+	_, unsub := b.Subscribe("topic")
+	defer unsub()
+
+	b.Publish("topic", "msg-1")
+	b.Publish("topic", "msg-2") // drops msg-1
+
+	assert.Equal(t, int64(1), b.PublishDrops())
+}
+
+func TestWithDropOldest_WorksWithPublishTo(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(2), WithDropOldest())
+	defer b.Close()
+
+	ch, unsub := b.SubscribeScoped("topic", "scope-1")
+	defer unsub()
+
+	b.PublishTo("topic", "scope-1", "msg-1")
+	b.PublishTo("topic", "scope-1", "msg-2")
+	b.PublishTo("topic", "scope-1", "msg-3")
+
+	var got []string
+	for i := 0; i < 2; i++ {
+		select {
+		case msg := <-ch:
+			got = append(got, msg)
+		case <-time.After(time.Second):
+			t.Fatal("timed out")
+		}
+	}
+
+	assert.Equal(t, []string{"msg-2", "msg-3"}, got)
 }

--- a/debounce.go
+++ b/debounce.go
@@ -1,0 +1,44 @@
+package tavern
+
+import (
+	"sync"
+	"time"
+)
+
+// debouncer tracks per-topic debounce timers.
+type debouncer struct {
+	mu     sync.Mutex
+	timers map[string]*debounceEntry
+}
+
+type debounceEntry struct {
+	timer *time.Timer
+	msg   string
+}
+
+// PublishDebounced publishes msg to the topic after the given duration of quiet.
+// If called again for the same topic before the duration elapses, the timer
+// resets and only the latest message is published. This is useful for rapid
+// state changes (typing indicators, slider drags) where intermediate states
+// are noise.
+func (b *SSEBroker) PublishDebounced(topic, msg string, after time.Duration) {
+	b.debounce.mu.Lock()
+	defer b.debounce.mu.Unlock()
+
+	if entry, ok := b.debounce.timers[topic]; ok {
+		entry.timer.Stop()
+		entry.msg = msg
+		entry.timer.Reset(after)
+		return
+	}
+
+	entry := &debounceEntry{msg: msg}
+	entry.timer = time.AfterFunc(after, func() {
+		b.debounce.mu.Lock()
+		m := entry.msg
+		delete(b.debounce.timers, topic)
+		b.debounce.mu.Unlock()
+		b.Publish(topic, m)
+	})
+	b.debounce.timers[topic] = entry
+}

--- a/debounce_test.go
+++ b/debounce_test.go
@@ -1,0 +1,105 @@
+package tavern
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishDebounced_SingleCall(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("topic")
+	defer unsub()
+
+	b.PublishDebounced("topic", "hello", 50*time.Millisecond)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "hello", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for debounced message")
+	}
+}
+
+func TestPublishDebounced_ResetsTimer(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("topic")
+	defer unsub()
+
+	b.PublishDebounced("topic", "first", 50*time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
+	b.PublishDebounced("topic", "second", 50*time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
+	b.PublishDebounced("topic", "third", 50*time.Millisecond)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "third", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for debounced message")
+	}
+
+	// Only one message should arrive.
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected extra message: %s", msg)
+	case <-time.After(100 * time.Millisecond):
+		// expected
+	}
+}
+
+func TestPublishDebounced_IndependentTopics(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch1, unsub1 := b.Subscribe("topic-a")
+	defer unsub1()
+	ch2, unsub2 := b.Subscribe("topic-b")
+	defer unsub2()
+
+	b.PublishDebounced("topic-a", "msg-a", 50*time.Millisecond)
+	b.PublishDebounced("topic-b", "msg-b", 50*time.Millisecond)
+
+	got := make(map[string]string)
+	for i := 0; i < 2; i++ {
+		select {
+		case msg := <-ch1:
+			got["a"] = msg
+		case msg := <-ch2:
+			got["b"] = msg
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for debounced messages")
+		}
+	}
+
+	assert.Equal(t, "msg-a", got["a"])
+	assert.Equal(t, "msg-b", got["b"])
+}
+
+func TestPublishDebounced_CloseStopsTimers(t *testing.T) {
+	b := NewSSEBroker()
+
+	ch, _ := b.Subscribe("topic")
+
+	b.PublishDebounced("topic", "should-not-arrive", 5*time.Second)
+	b.Close()
+
+	// Wait a bit and verify nothing arrives (channel is closed by Close).
+	select {
+	case msg, ok := <-ch:
+		if ok {
+			t.Fatalf("unexpected message after close: %s", msg)
+		}
+		// channel closed — expected
+	case <-time.After(100 * time.Millisecond):
+		// also fine — timer was stopped
+	}
+
+	require.Empty(t, b.debounce.timers)
+}

--- a/scheduled_test.go
+++ b/scheduled_test.go
@@ -287,9 +287,9 @@ loop:
 		}
 	}
 
-	// Cancel publisher before unsubscribing to avoid send-on-closed-channel race.
+	// Cancel publisher and close broker to wait for goroutines before unsubscribing.
 	cancel()
-	time.Sleep(20 * time.Millisecond)
+	b.Close()
 	unsub()
 
 	// With 50ms base tick and 50ms interval, expect roughly 4-5 messages in 250ms.

--- a/throttle.go
+++ b/throttle.go
@@ -1,0 +1,76 @@
+package tavern
+
+import (
+	"sync"
+	"time"
+)
+
+// throttler tracks per-topic throttle state.
+type throttler struct {
+	mu    sync.Mutex
+	state map[string]*throttleEntry
+}
+
+type throttleEntry struct {
+	lastSent time.Time
+	pending  *string
+	timer    *time.Timer
+}
+
+// PublishThrottled publishes msg to the topic at most once per interval.
+// The first call publishes immediately. Subsequent calls within the interval
+// are held; when the interval elapses, the most recent held message is
+// published. This guarantees bounded latency for the first message while
+// rate-limiting subsequent ones.
+func (b *SSEBroker) PublishThrottled(topic, msg string, interval time.Duration) {
+	now := time.Now()
+	b.throttle.mu.Lock()
+
+	entry, ok := b.throttle.state[topic]
+	if !ok {
+		// First call — publish immediately.
+		entry = &throttleEntry{lastSent: now}
+		b.throttle.state[topic] = entry
+		b.throttle.mu.Unlock()
+		b.Publish(topic, msg)
+		return
+	}
+
+	elapsed := now.Sub(entry.lastSent)
+	if elapsed >= interval {
+		// Interval has passed — publish immediately.
+		entry.lastSent = now
+		if entry.timer != nil {
+			entry.timer.Stop()
+			entry.timer = nil
+		}
+		entry.pending = nil
+		b.throttle.mu.Unlock()
+		b.Publish(topic, msg)
+		return
+	}
+
+	// Within interval — hold the message.
+	entry.pending = &msg
+	if entry.timer == nil {
+		remaining := interval - elapsed
+		entry.timer = time.AfterFunc(remaining, func() {
+			b.throttle.mu.Lock()
+			e := b.throttle.state[topic]
+			if e != nil && e.pending != nil {
+				m := *e.pending
+				e.pending = nil
+				e.timer = nil
+				e.lastSent = time.Now()
+				b.throttle.mu.Unlock()
+				b.Publish(topic, m)
+			} else {
+				if e != nil {
+					e.timer = nil
+				}
+				b.throttle.mu.Unlock()
+			}
+		})
+	}
+	b.throttle.mu.Unlock()
+}

--- a/throttle_test.go
+++ b/throttle_test.go
@@ -1,0 +1,147 @@
+package tavern
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishThrottled_FirstCallImmediate(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("topic")
+	defer unsub()
+
+	b.PublishThrottled("topic", "immediate", time.Second)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "immediate", msg)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("first throttled call should publish immediately")
+	}
+}
+
+func TestPublishThrottled_RateLimits(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("topic")
+	defer unsub()
+
+	interval := 100 * time.Millisecond
+
+	// First call — immediate.
+	b.PublishThrottled("topic", "msg-1", interval)
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "msg-1", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out on first message")
+	}
+
+	// Rapid calls within interval.
+	for i := 2; i <= 5; i++ {
+		b.PublishThrottled("topic", "msg-rapid", interval)
+	}
+
+	// Should get exactly one trailing message after interval.
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "msg-rapid", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for trailing throttled message")
+	}
+
+	// No more messages.
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected extra message: %s", msg)
+	case <-time.After(150 * time.Millisecond):
+		// expected
+	}
+}
+
+func TestPublishThrottled_LastMessageWins(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("topic")
+	defer unsub()
+
+	interval := 100 * time.Millisecond
+
+	// First call — immediate.
+	b.PublishThrottled("topic", "first", interval)
+	<-ch
+
+	// Rapid calls with different messages.
+	b.PublishThrottled("topic", "second", interval)
+	b.PublishThrottled("topic", "third", interval)
+	b.PublishThrottled("topic", "fourth", interval)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "fourth", msg, "trailing publish should use the latest message")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for trailing throttled message")
+	}
+}
+
+func TestPublishThrottled_IndependentTopics(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch1, unsub1 := b.Subscribe("topic-a")
+	defer unsub1()
+	ch2, unsub2 := b.Subscribe("topic-b")
+	defer unsub2()
+
+	interval := 100 * time.Millisecond
+
+	b.PublishThrottled("topic-a", "a-1", interval)
+	b.PublishThrottled("topic-b", "b-1", interval)
+
+	select {
+	case msg := <-ch1:
+		assert.Equal(t, "a-1", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out on topic-a")
+	}
+
+	select {
+	case msg := <-ch2:
+		assert.Equal(t, "b-1", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out on topic-b")
+	}
+}
+
+func TestPublishThrottled_CloseStopsTimers(t *testing.T) {
+	b := NewSSEBroker()
+
+	ch, _ := b.Subscribe("topic")
+
+	// First call immediate.
+	b.PublishThrottled("topic", "first", 5*time.Second)
+	<-ch
+
+	// Second call within interval — creates pending timer.
+	b.PublishThrottled("topic", "should-not-arrive", 5*time.Second)
+
+	b.Close()
+
+	// Verify nothing arrives.
+	select {
+	case msg, ok := <-ch:
+		if ok {
+			t.Fatalf("unexpected message after close: %s", msg)
+		}
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	require.Empty(t, b.throttle.state)
+}


### PR DESCRIPTION
## Summary

- **ReplayN**: `SetReplayPolicy(topic, n)` configures how many recent messages to cache per topic. `PublishWithReplay` appends to a ring buffer capped at n. Backward compatible (default 1).
- **PublishDebounced**: Publishes after a quiet period. Rapid calls reset the timer; only the final message is sent. Useful for search/typing indicators.
- **PublishThrottled**: Rate-limits to at most one publish per interval. First call is immediate; trailing messages coalesce. Useful for live dashboards.
- **WithDropOldest**: New broker option that discards the oldest buffered message (instead of newest) when a subscriber's channel is full. Extracted a `send()` helper used by all publish methods.
- Fixed a latent data race in `TestScheduledPublisher_WithBaseTick` (cancel + sleep was insufficient; now uses `b.Close()` to wait for publisher goroutines).

## Test plan

- [x] `go test ./... -race -count=5` passes
- [x] `go vet ./...` clean
- [ ] Verify ReplayN tests: default-1, replay-n, zero-disables, trim-existing, scoped
- [ ] Verify debounce tests: single call, timer reset, independent topics, close stops timers
- [ ] Verify throttle tests: first-immediate, rate-limits, last-message-wins, independent topics, close stops timers
- [ ] Verify drop-oldest tests: drops old, default drops newest, counts drops, works with PublishTo