### PR TITLE
feat: Last-Event-ID resumption support

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,36 @@ Clear the cache:
 broker.ClearReplay("dashboard")
 ```
 
+### Last-Event-ID resumption
+
+Track message IDs for gap-free reconnection:
+
+```go
+// Publish with an event ID
+broker.SetReplayPolicy("events", 100) // keep last 100 for resumption
+broker.PublishWithID("events", "evt-42", msg)
+broker.PublishWithID("events", "evt-43", msg2)
+```
+
+When a client reconnects, the browser sends the `Last-Event-ID` header.
+Use `SubscribeFromID` to replay only the missed messages:
+
+```go
+func sseHandler(broker *tavern.SSEBroker) http.HandlerFunc {
+    return func(w http.ResponseWriter, r *http.Request) {
+        lastID := r.Header.Get("Last-Event-ID")
+        ch, unsub := broker.SubscribeFromID("events", lastID)
+        defer unsub()
+        // ... write messages to response ...
+    }
+}
+```
+
+If `lastID` is empty (first connection), all cached messages are replayed.
+If `lastID` is found, only newer messages are replayed. If `lastID` is not
+in the replay log (too old), no replay occurs and only live messages are
+delivered.
+
 ### Debounce and throttle
 
 Control publish frequency for rapid state changes:

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -627,3 +627,69 @@ func createEvent(broker *tavern.SSEBroker, db *sql.DB) echo.HandlerFunc {
   <!-- last 20 events replayed on connect, then live updates -->
 </ul>
 ```
+
+---
+
+## 11. Resumable SSE with Last-Event-ID
+
+Use `PublishWithID` and `SubscribeFromID` for gap-free reconnection. When
+a client's connection drops, the browser automatically sends the last
+received event ID on reconnect. The server replays only the missed messages.
+
+### Go setup
+
+```go
+broker.SetReplayPolicy("notifications", 50) // keep last 50 for resumption
+
+var eventSeq atomic.Int64
+
+func publishNotification(broker *tavern.SSEBroker, payload string) {
+    id := fmt.Sprintf("evt-%d", eventSeq.Add(1))
+    msg := tavern.NewSSEMessage("notification", payload).WithID(id).String()
+    broker.PublishWithID("notifications", id, msg)
+}
+```
+
+### Go handler (SSE endpoint)
+
+```go
+func sseHandler(broker *tavern.SSEBroker) echo.HandlerFunc {
+    return func(c echo.Context) error {
+        c.Response().Header().Set("Content-Type", "text/event-stream")
+        c.Response().Header().Set("Cache-Control", "no-cache")
+        c.Response().Header().Set("Connection", "keep-alive")
+
+        lastID := c.Request().Header.Get("Last-Event-ID")
+        ch, unsub := broker.SubscribeFromID("notifications", lastID)
+        defer unsub()
+
+        for {
+            select {
+            case msg, ok := <-ch:
+                if !ok {
+                    return nil
+                }
+                if _, err := fmt.Fprint(c.Response(), msg); err != nil {
+                    return nil
+                }
+                c.Response().Flush()
+            case <-c.Request().Context().Done():
+                return nil
+            }
+        }
+    }
+}
+```
+
+### HTML
+
+```html
+<div hx-ext="sse" sse-connect="/sse/notifications" sse-swap="notification">
+  <!-- EventSource handles Last-Event-ID automatically on reconnect -->
+</div>
+```
+
+> **Tip:** Set the replay policy large enough to cover typical disconnection
+> windows (e.g., 30 seconds of messages). If the client is offline longer
+> than the buffer covers, it gets only live messages -- which is usually the
+> right trade-off.

--- a/broker.go
+++ b/broker.go
@@ -23,8 +23,9 @@ import (
 type SSEBroker struct {
 	topics            map[string]map[chan string]struct{}
 	scopedTopics      map[string]map[chan string]scopedSub
-	replayCache       map[string][]string // topic → recent messages (ring buffer)
-	replaySize        map[string]int      // topic → max messages to keep
+	replayCache       map[string][]string       // topic → recent messages (ring buffer)
+	replaySize        map[string]int            // topic → max messages to keep
+	replayLog         map[string][]ReplayEntry  // topic → ordered log with IDs for Last-Event-ID resumption
 	lastHash          map[string]uint64 // topic → FNV hash of last published message via PublishIfChanged
 	onFirst           map[string][]func(string)
 	onLast            map[string][]func(string)
@@ -114,6 +115,7 @@ func NewSSEBroker(opts ...BrokerOption) *SSEBroker {
 		scopedTopics: make(map[string]map[chan string]scopedSub),
 		replayCache:  make(map[string][]string),
 		replaySize:   make(map[string]int),
+		replayLog:    make(map[string][]ReplayEntry),
 		topicEmpty:   make(map[string]time.Time),
 		lastHash:     make(map[string]uint64),
 		onFirst:      make(map[string][]func(string)),
@@ -466,11 +468,15 @@ func (b *SSEBroker) SetReplayPolicy(topic string, n int) {
 	if n <= 0 {
 		delete(b.replaySize, topic)
 		delete(b.replayCache, topic)
+		delete(b.replayLog, topic)
 		return
 	}
 	b.replaySize[topic] = n
 	if msgs := b.replayCache[topic]; len(msgs) > n {
 		b.replayCache[topic] = msgs[len(msgs)-n:]
+	}
+	if logs := b.replayLog[topic]; len(logs) > n {
+		b.replayLog[topic] = logs[len(logs)-n:]
 	}
 }
 
@@ -480,6 +486,7 @@ func (b *SSEBroker) ClearReplay(topic string) {
 	b.mu.Lock()
 	delete(b.replayCache, topic)
 	delete(b.replaySize, topic)
+	delete(b.replayLog, topic)
 	b.mu.Unlock()
 }
 
@@ -650,6 +657,7 @@ func (b *SSEBroker) Close() {
 	close(b.done)
 	b.replayCache = nil
 	b.replaySize = nil
+	b.replayLog = nil
 	b.lastHash = nil
 	for topic, subs := range b.topics {
 		for ch := range subs {

--- a/resume.go
+++ b/resume.go
@@ -1,0 +1,132 @@
+package tavern
+
+import "time"
+
+// ReplayEntry pairs a message with its event ID for resumption support.
+type ReplayEntry struct {
+	ID  string
+	Msg string
+}
+
+// PublishWithID publishes msg to the topic with an associated event ID.
+// The message is cached in the replay log for Last-Event-ID resumption.
+// The replay log size is controlled by SetReplayPolicy (default 1).
+func (b *SSEBroker) PublishWithID(topic, id, msg string) {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return
+	}
+	maxSize := 1
+	if n, ok := b.replaySize[topic]; ok {
+		maxSize = n
+	}
+	log := b.replayLog[topic]
+	log = append(log, ReplayEntry{ID: id, Msg: msg})
+	if len(log) > maxSize {
+		log = log[len(log)-maxSize:]
+	}
+	b.replayLog[topic] = log
+
+	// Also update replayCache for regular Subscribe replay compatibility.
+	msgs := b.replayCache[topic]
+	msgs = append(msgs, msg)
+	if len(msgs) > maxSize {
+		msgs = msgs[len(msgs)-maxSize:]
+	}
+	b.replayCache[topic] = msgs
+
+	subscribers := b.topics[topic]
+	channels := make([]chan string, 0, len(subscribers))
+	for ch := range subscribers {
+		channels = append(channels, ch)
+	}
+	b.mu.Unlock()
+
+	for _, ch := range channels {
+		func() {
+			defer func() { _ = recover() }()
+			if !b.send(ch, msg) {
+				b.drops.Add(1)
+			}
+		}()
+	}
+}
+
+// SubscribeFromID subscribes to a topic and replays all cached messages
+// with IDs after lastEventID. If lastEventID is empty, all cached messages
+// are replayed (same as Subscribe). If lastEventID is not found in the
+// replay log, no replay occurs (gap too large) and only live messages
+// are delivered.
+//
+// This implements the server side of the SSE Last-Event-ID resumption
+// protocol. The HTTP handler should read the Last-Event-ID header from
+// the request and pass it here.
+func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan string, unsubscribe func()) {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		ch := make(chan string)
+		close(ch)
+		return ch, func() {}
+	}
+	ch := make(chan string, b.bufferSize)
+	if b.topics[topic] == nil {
+		b.topics[topic] = make(map[chan string]struct{})
+	}
+	b.topics[topic][ch] = struct{}{}
+	total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+	var firstHooks []func(string)
+	if total == 1 {
+		firstHooks = b.onFirst[topic]
+	}
+
+	// Find messages after lastEventID.
+	var replayMsgs []string
+	if lastEventID == "" {
+		// No Last-Event-ID: replay all cached (same as regular Subscribe).
+		replayMsgs = append([]string(nil), b.replayCache[topic]...)
+	} else {
+		log := b.replayLog[topic]
+		for i, entry := range log {
+			if entry.ID == lastEventID {
+				// Replay everything after this entry.
+				for _, e := range log[i+1:] {
+					replayMsgs = append(replayMsgs, e.Msg)
+				}
+				break
+			}
+		}
+		// If ID not found, replayMsgs stays nil: gap too large, no replay.
+	}
+
+	delete(b.topicEmpty, topic)
+	b.mu.Unlock()
+
+	for _, fn := range firstHooks {
+		go fn(topic)
+	}
+	for _, msg := range replayMsgs {
+		select {
+		case ch <- msg:
+		default:
+		}
+	}
+	return ch, func() {
+		b.mu.Lock()
+		var lastHooks []func(string)
+		if _, ok := b.topics[topic][ch]; ok {
+			delete(b.topics[topic], ch)
+			close(ch)
+			total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+			if total == 0 {
+				lastHooks = b.onLast[topic]
+				b.topicEmpty[topic] = time.Now()
+			}
+		}
+		b.mu.Unlock()
+		for _, fn := range lastHooks {
+			go fn(topic)
+		}
+	}
+}

--- a/resume_test.go
+++ b/resume_test.go
@@ -1,0 +1,214 @@
+package tavern
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishWithID_BasicDelivery(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("events")
+	defer unsub()
+
+	b.PublishWithID("events", "id-1", "hello")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "hello", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+}
+
+func TestSubscribeFromID_ReplaysAfterID(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	for i := 1; i <= 5; i++ {
+		b.PublishWithID("events", fmt.Sprintf("%d", i), fmt.Sprintf("msg-%d", i))
+	}
+
+	ch, unsub := b.SubscribeFromID("events", "3")
+	defer unsub()
+
+	var got []string
+	for range 2 {
+		select {
+		case msg := <-ch:
+			got = append(got, msg)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for replay message")
+		}
+	}
+	assert.Equal(t, []string{"msg-4", "msg-5"}, got)
+
+	// Verify no more replay messages are buffered.
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected extra message: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestSubscribeFromID_EmptyID(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	for i := 1; i <= 3; i++ {
+		b.PublishWithID("events", fmt.Sprintf("%d", i), fmt.Sprintf("msg-%d", i))
+	}
+
+	ch, unsub := b.SubscribeFromID("events", "")
+	defer unsub()
+
+	var got []string
+	for range 3 {
+		select {
+		case msg := <-ch:
+			got = append(got, msg)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for replay message")
+		}
+	}
+	assert.Equal(t, []string{"msg-1", "msg-2", "msg-3"}, got)
+}
+
+func TestSubscribeFromID_UnknownID(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	for i := 1; i <= 3; i++ {
+		b.PublishWithID("events", fmt.Sprintf("%d", i), fmt.Sprintf("msg-%d", i))
+	}
+
+	ch, unsub := b.SubscribeFromID("events", "unknown-id")
+	defer unsub()
+
+	// No replay should occur for an unknown ID.
+	select {
+	case msg := <-ch:
+		t.Fatalf("expected no replay, got: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Live messages should still work.
+	b.PublishWithID("events", "4", "live-msg")
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "live-msg", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for live message")
+	}
+}
+
+func TestSubscribeFromID_AllCaughtUp(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	for i := 1; i <= 3; i++ {
+		b.PublishWithID("events", fmt.Sprintf("%d", i), fmt.Sprintf("msg-%d", i))
+	}
+
+	// Subscribe from the latest ID: nothing to replay.
+	ch, unsub := b.SubscribeFromID("events", "3")
+	defer unsub()
+
+	select {
+	case msg := <-ch:
+		t.Fatalf("expected no replay, got: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestPublishWithID_RespectsReplayPolicy(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 3)
+	for i := 1; i <= 5; i++ {
+		b.PublishWithID("events", fmt.Sprintf("%d", i), fmt.Sprintf("msg-%d", i))
+	}
+
+	// Empty ID: replay all cached (should be last 3).
+	ch, unsub := b.SubscribeFromID("events", "")
+	defer unsub()
+
+	var got []string
+	for range 3 {
+		select {
+		case msg := <-ch:
+			got = append(got, msg)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for replay message")
+		}
+	}
+	assert.Equal(t, []string{"msg-3", "msg-4", "msg-5"}, got)
+}
+
+func TestPublishWithID_AfterClose(t *testing.T) {
+	b := NewSSEBroker()
+	b.Close()
+
+	// Should not panic.
+	require.NotPanics(t, func() {
+		b.PublishWithID("events", "id-1", "hello")
+	})
+}
+
+func TestSubscribeFromID_LifecycleHooks(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	var mu sync.Mutex
+	var fired bool
+	b.OnFirstSubscriber("events", func(topic string) {
+		mu.Lock()
+		fired = true
+		mu.Unlock()
+	})
+
+	_, unsub := b.SubscribeFromID("events", "")
+	defer unsub()
+
+	// Give the goroutine time to fire.
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	assert.True(t, fired, "OnFirstSubscriber should fire for SubscribeFromID")
+	mu.Unlock()
+}
+
+func TestPublishWithID_UpdatesRegularReplayCache(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 5)
+	for i := 1; i <= 3; i++ {
+		b.PublishWithID("events", fmt.Sprintf("%d", i), fmt.Sprintf("msg-%d", i))
+	}
+
+	// Regular Subscribe should also get the replay from PublishWithID.
+	ch, unsub := b.Subscribe("events")
+	defer unsub()
+
+	var got []string
+	for range 3 {
+		select {
+		case msg := <-ch:
+			got = append(got, msg)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for replay message")
+		}
+	}
+	assert.Equal(t, []string{"msg-1", "msg-2", "msg-3"}, got)
+}


### PR DESCRIPTION
## Summary

- Add `PublishWithID` and `SubscribeFromID` methods for SSE Last-Event-ID resumption protocol
- New `ReplayEntry` type pairs messages with event IDs in an ordered replay log (`replayLog` field on `SSEBroker`)
- `SubscribeFromID` replays only messages after the given ID (empty ID replays all cached; unknown ID skips replay)
- `PublishWithID` also populates `replayCache` so regular `Subscribe` replay remains compatible
- `SetReplayPolicy` and `ClearReplay` updated to manage the replay log alongside the existing cache
- 9 tests covering replay-after-ID, empty/unknown/caught-up cases, replay policy limits, close safety, lifecycle hooks, and regular cache compatibility

## Test plan

- [x] `go test ./... -race` passes
- [x] `go vet ./...` clean
- [x] All 9 new resume tests pass (basic delivery, replay-after-ID, empty ID, unknown ID, all-caught-up, policy limits, after-close, lifecycle hooks, regular cache compat)