### PR TITLE
feat: PublishIfChangedOOB convenience methods

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -567,6 +567,48 @@ func (b *SSEBroker) PublishIfChanged(topic, msg string) bool {
 	return true
 }
 
+// PublishIfChangedTo publishes msg to scoped subscribers of the given topic
+// only when it differs from the last message published via PublishIfChangedTo
+// for that topic+scope combination. Returns true if published, false if skipped.
+// Comparison is done via an FNV-64a hash of the message content.
+func (b *SSEBroker) PublishIfChangedTo(topic, scope, msg string) bool {
+	key := topic + "\x00" + scope
+	h := hashMsg(msg)
+
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return false
+	}
+	if prev, ok := b.lastHash[key]; ok && prev == h {
+		b.mu.Unlock()
+		return false
+	}
+	b.lastHash[key] = h
+
+	scopedSubs, exists := b.scopedTopics[topic]
+	var channels []chan string
+	if exists {
+		channels = make([]chan string, 0, len(scopedSubs))
+		for ch, sub := range scopedSubs {
+			if sub.scope == scope {
+				channels = append(channels, ch)
+			}
+		}
+	}
+	b.mu.Unlock()
+
+	for _, ch := range channels {
+		func() {
+			defer func() { _ = recover() }()
+			if !b.send(ch, msg) {
+				b.drops.Add(1)
+			}
+		}()
+	}
+	return true
+}
+
 // ClearDedup resets the deduplication state for the given topic so the next
 // call to [SSEBroker.PublishIfChanged] will always publish regardless of
 // content.

--- a/broker_test.go
+++ b/broker_test.go
@@ -1502,3 +1502,72 @@ func TestWithDropOldest_WorksWithPublishTo(t *testing.T) {
 
 	assert.Equal(t, []string{"msg-2", "msg-3"}, got)
 }
+
+func TestPublishIfChangedTo_BasicDelivery(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeScoped("t", "s1")
+	defer unsub()
+
+	ok := b.PublishIfChangedTo("t", "s1", "hello")
+	assert.True(t, ok)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "hello", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestPublishIfChangedTo_SkipsDuplicate(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeScoped("t", "s1")
+	defer unsub()
+
+	ok1 := b.PublishIfChangedTo("t", "s1", "hello")
+	assert.True(t, ok1)
+	<-ch
+
+	ok2 := b.PublishIfChangedTo("t", "s1", "hello")
+	assert.False(t, ok2)
+}
+
+func TestPublishIfChangedTo_IndependentScopes(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch1, unsub1 := b.SubscribeScoped("t", "s1")
+	defer unsub1()
+	ch2, unsub2 := b.SubscribeScoped("t", "s2")
+	defer unsub2()
+
+	// Same message to different scopes — both should publish
+	ok1 := b.PublishIfChangedTo("t", "s1", "same")
+	ok2 := b.PublishIfChangedTo("t", "s2", "same")
+	assert.True(t, ok1)
+	assert.True(t, ok2)
+
+	select {
+	case msg := <-ch1:
+		assert.Equal(t, "same", msg)
+	case <-time.After(time.Second):
+		t.Fatal("s1 timed out")
+	}
+	select {
+	case msg := <-ch2:
+		assert.Equal(t, "same", msg)
+	case <-time.After(time.Second):
+		t.Fatal("s2 timed out")
+	}
+}
+
+func TestPublishIfChangedTo_AfterClose(t *testing.T) {
+	b := NewSSEBroker()
+	b.Close()
+	ok := b.PublishIfChangedTo("t", "s", "msg")
+	assert.False(t, ok)
+}

--- a/oob.go
+++ b/oob.go
@@ -101,3 +101,21 @@ func (b *SSEBroker) PublishOOB(topic string, fragments ...Fragment) {
 func (b *SSEBroker) PublishOOBTo(topic, scope string, fragments ...Fragment) {
 	b.PublishTo(topic, scope, RenderFragments(fragments...))
 }
+
+// PublishIfChangedOOB renders the given fragments and publishes the result
+// to the topic only if it differs from the last message published via
+// [SSEBroker.PublishIfChanged] for that topic. Returns true if published
+// (content changed), false if skipped (identical).
+func (b *SSEBroker) PublishIfChangedOOB(topic string, fragments ...Fragment) bool {
+	msg := NewSSEMessage("oob", RenderFragments(fragments...)).String()
+	return b.PublishIfChanged(topic, msg)
+}
+
+// PublishIfChangedOOBTo renders the given fragments and publishes the result
+// only to scoped subscribers of the topic whose scope matches, and only if
+// the content differs from the last publish for that topic+scope. Returns
+// true if published, false if skipped.
+func (b *SSEBroker) PublishIfChangedOOBTo(topic, scope string, fragments ...Fragment) bool {
+	msg := NewSSEMessage("oob", RenderFragments(fragments...)).String()
+	return b.PublishIfChangedTo(topic, scope, msg)
+}

--- a/oob_test.go
+++ b/oob_test.go
@@ -147,6 +147,63 @@ func TestRenderFragments_EscapesID(t *testing.T) {
 	assert.Contains(t, html2, `id="x&quot;y"`)
 }
 
+func TestPublishIfChangedOOB_PublishesOnChange(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	ok := b.PublishIfChangedOOB("t", Replace("el", "<b>v1</b>"))
+	assert.True(t, ok)
+
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "v1")
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestPublishIfChangedOOB_SkipsDuplicate(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	ok1 := b.PublishIfChangedOOB("t", Replace("el", "<b>v1</b>"))
+	assert.True(t, ok1)
+	<-ch // drain
+
+	ok2 := b.PublishIfChangedOOB("t", Replace("el", "<b>v1</b>"))
+	assert.False(t, ok2)
+
+	select {
+	case <-ch:
+		t.Fatal("should not have received duplicate")
+	default:
+	}
+}
+
+func TestPublishIfChangedOOBTo_ScopedDelivery(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeScoped("t", "user-1")
+	defer unsub()
+
+	ok := b.PublishIfChangedOOBTo("t", "user-1", Replace("el", "<b>scoped</b>"))
+	assert.True(t, ok)
+
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "scoped")
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
 func TestRenderComponentError_EscapesComment(t *testing.T) {
 	// An error message containing --> must not break out of the HTML comment.
 	// escapeAttr replaces > with &gt;, turning --> into --&gt; inside the comment body.


### PR DESCRIPTION
## Summary
- Add `PublishIfChangedTo(topic, scope, msg)` to broker.go — scoped variant of `PublishIfChanged` using composite `topic\x00scope` key for independent dedup per scope
- Add `PublishIfChangedOOB(topic, fragments...)` and `PublishIfChangedOOBTo(topic, scope, fragments...)` to oob.go — render fragments via `NewSSEMessage("oob", ...)` and delegate to the dedup publishers
- Tests for all new methods: basic delivery, duplicate skipping, independent scopes, after-close safety

Closes #48

## Test plan
- [x] `go test ./... -race` passes
- [x] `go vet ./...` clean