### PR TITLE
feat: built-in per-topic metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
   - [Observability](#observability)
     - [Check for subscribers](#check-for-subscribers)
     - [Topic metrics](#topic-metrics)
+    - [Per-topic metrics](#per-topic-metrics)
   - [Topic constants](#topic-constants)
   - [Thread safety](#thread-safety)
   - [Philosophy](#philosophy)
@@ -622,6 +623,27 @@ go func() {
 	}
 }()
 ```
+
+### Per-topic metrics
+
+Enable detailed per-topic publish and drop counters with `WithMetrics`:
+
+```go
+broker := tavern.NewSSEBroker(tavern.WithMetrics())
+
+// ... publish messages ...
+
+m := broker.Metrics()
+for topic, stats := range m.TopicStats {
+    fmt.Printf("%s: published=%d dropped=%d peak_subs=%d\n",
+        topic, stats.Published, stats.Dropped, stats.PeakSubscribers)
+}
+fmt.Printf("totals: published=%d dropped=%d\n", m.TotalPublished, m.TotalDropped)
+```
+
+Metrics are opt-in — when `WithMetrics` is not set, there is zero overhead on
+publish operations. Use this to identify topics with high drop rates, track
+publish throughput, and find peak subscriber counts for capacity planning.
 
 ## Topic constants
 

--- a/broker.go
+++ b/broker.go
@@ -42,6 +42,7 @@ type SSEBroker struct {
 	dropOldest        bool
 	debounce          debouncer
 	throttle          throttler
+	metrics           *metricsState // nil when metrics disabled
 }
 
 // Topic name constants are conventions for common real-time use cases.
@@ -164,6 +165,11 @@ func (b *SSEBroker) Subscribe(topic string) (msgs <-chan string, unsubscribe fun
 	if total == 1 {
 		firstHooks = b.onFirst[topic]
 	}
+	if b.metrics != nil {
+		if total > b.metrics.peakSubs[topic] {
+			b.metrics.peakSubs[topic] = total
+		}
+	}
 	replayMsgs := append([]string(nil), b.replayCache[topic]...)
 	delete(b.topicEmpty, topic)
 	b.mu.Unlock()
@@ -216,6 +222,11 @@ func (b *SSEBroker) SubscribeScoped(topic, scope string) (msgs <-chan string, un
 	var firstHooks []func(string)
 	if total == 1 {
 		firstHooks = b.onFirst[topic]
+	}
+	if b.metrics != nil {
+		if total > b.metrics.peakSubs[topic] {
+			b.metrics.peakSubs[topic] = total
+		}
 	}
 	replayMsgs := append([]string(nil), b.replayCache[topic]...)
 	delete(b.topicEmpty, topic)
@@ -410,15 +421,24 @@ func (b *SSEBroker) Publish(topic, msg string) {
 	}
 	b.mu.RUnlock()
 
+	var sent, dropped int
 	for _, ch := range channels {
 		// Channel may have been closed by unsub() between the snapshot and now.
 		// Recover from the resulting panic rather than adding complex synchronization.
 		func() {
 			defer func() { _ = recover() }()
-			if !b.send(ch, msg) {
+			if b.send(ch, msg) {
+				sent++
+			} else {
 				b.drops.Add(1)
+				dropped++
 			}
 		}()
+	}
+	if b.metrics != nil {
+		tc := b.metrics.counter(topic)
+		tc.published.Add(int64(sent))
+		tc.dropped.Add(int64(dropped))
 	}
 }
 
@@ -449,13 +469,22 @@ func (b *SSEBroker) PublishWithReplay(topic, msg string) {
 	}
 	b.mu.Unlock()
 
+	var sent, dropped int
 	for _, ch := range channels {
 		func() {
 			defer func() { _ = recover() }()
-			if !b.send(ch, msg) {
+			if b.send(ch, msg) {
+				sent++
+			} else {
 				b.drops.Add(1)
+				dropped++
 			}
 		}()
+	}
+	if b.metrics != nil {
+		tc := b.metrics.counter(topic)
+		tc.published.Add(int64(sent))
+		tc.dropped.Add(int64(dropped))
 	}
 }
 
@@ -509,13 +538,22 @@ func (b *SSEBroker) PublishTo(topic, scope, msg string) {
 	}
 	b.mu.RUnlock()
 
+	var sent, dropped int
 	for _, ch := range channels {
 		func() {
 			defer func() { _ = recover() }()
-			if !b.send(ch, msg) {
+			if b.send(ch, msg) {
+				sent++
+			} else {
 				b.drops.Add(1)
+				dropped++
 			}
 		}()
+	}
+	if b.metrics != nil {
+		tc := b.metrics.counter(topic)
+		tc.published.Add(int64(sent))
+		tc.dropped.Add(int64(dropped))
 	}
 }
 
@@ -556,13 +594,22 @@ func (b *SSEBroker) PublishIfChanged(topic, msg string) bool {
 	}
 	b.mu.Unlock()
 
+	var sent, dropped int
 	for _, ch := range channels {
 		func() {
 			defer func() { _ = recover() }()
-			if !b.send(ch, msg) {
+			if b.send(ch, msg) {
+				sent++
+			} else {
 				b.drops.Add(1)
+				dropped++
 			}
 		}()
+	}
+	if b.metrics != nil {
+		tc := b.metrics.counter(topic)
+		tc.published.Add(int64(sent))
+		tc.dropped.Add(int64(dropped))
 	}
 	return true
 }
@@ -598,13 +645,22 @@ func (b *SSEBroker) PublishIfChangedTo(topic, scope, msg string) bool {
 	}
 	b.mu.Unlock()
 
+	var sent, dropped int
 	for _, ch := range channels {
 		func() {
 			defer func() { _ = recover() }()
-			if !b.send(ch, msg) {
+			if b.send(ch, msg) {
+				sent++
+			} else {
 				b.drops.Add(1)
+				dropped++
 			}
 		}()
+	}
+	if b.metrics != nil {
+		tc := b.metrics.counter(topic)
+		tc.published.Add(int64(sent))
+		tc.dropped.Add(int64(dropped))
 	}
 	return true
 }

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,102 @@
+package tavern
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// TopicMetrics holds per-topic counters.
+type TopicMetrics struct {
+	Published       int64
+	Dropped         int64
+	PeakSubscribers int
+}
+
+// BrokerMetrics is a point-in-time snapshot of all broker metrics.
+type BrokerMetrics struct {
+	// TopicStats maps topic name to its metrics.
+	TopicStats map[string]TopicMetrics
+	// TotalPublished is the sum of all per-topic published counts.
+	TotalPublished int64
+	// TotalDropped is the sum of all per-topic dropped counts.
+	TotalDropped int64
+}
+
+// topicCounter tracks per-topic atomic counters.
+type topicCounter struct {
+	published atomic.Int64
+	dropped   atomic.Int64
+}
+
+// metricsState holds all metrics tracking state.
+type metricsState struct {
+	mu       sync.RWMutex
+	counters map[string]*topicCounter
+	peakSubs map[string]int // protected by broker's mu, updated on subscribe
+}
+
+// counter returns the topicCounter for the given topic, creating one if needed.
+func (m *metricsState) counter(topic string) *topicCounter {
+	m.mu.RLock()
+	tc, ok := m.counters[topic]
+	m.mu.RUnlock()
+	if ok {
+		return tc
+	}
+	m.mu.Lock()
+	tc, ok = m.counters[topic]
+	if !ok {
+		tc = &topicCounter{}
+		m.counters[topic] = tc
+	}
+	m.mu.Unlock()
+	return tc
+}
+
+// WithMetrics enables per-topic publish and drop counters. When disabled
+// (the default), metrics tracking has zero overhead. Use [SSEBroker.Metrics]
+// to retrieve a snapshot.
+func WithMetrics() BrokerOption {
+	return func(b *SSEBroker) {
+		b.metrics = &metricsState{
+			counters: make(map[string]*topicCounter),
+			peakSubs: make(map[string]int),
+		}
+	}
+}
+
+// Metrics returns a point-in-time snapshot of per-topic and aggregate
+// metrics. Returns an empty [BrokerMetrics] if metrics are not enabled
+// (see [WithMetrics]).
+func (b *SSEBroker) Metrics() BrokerMetrics {
+	if b.metrics == nil {
+		return BrokerMetrics{TopicStats: make(map[string]TopicMetrics)}
+	}
+
+	// Snapshot peak subs under broker lock to avoid lock ordering issues.
+	b.mu.RLock()
+	peakSnap := make(map[string]int, len(b.metrics.peakSubs))
+	for t, p := range b.metrics.peakSubs {
+		peakSnap[t] = p
+	}
+	b.mu.RUnlock()
+
+	// Snapshot counters under metrics lock.
+	b.metrics.mu.RLock()
+	result := BrokerMetrics{
+		TopicStats: make(map[string]TopicMetrics, len(b.metrics.counters)),
+	}
+	for topic, tc := range b.metrics.counters {
+		published := tc.published.Load()
+		dropped := tc.dropped.Load()
+		result.TopicStats[topic] = TopicMetrics{
+			Published:       published,
+			Dropped:         dropped,
+			PeakSubscribers: peakSnap[topic],
+		}
+		result.TotalPublished += published
+		result.TotalDropped += dropped
+	}
+	b.metrics.mu.RUnlock()
+	return result
+}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,0 +1,214 @@
+package tavern
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWithMetrics_TracksPublished(t *testing.T) {
+	b := NewSSEBroker(WithMetrics())
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("events")
+	defer unsub()
+
+	for i := 0; i < 5; i++ {
+		b.Publish("events", "msg")
+	}
+
+	// Drain to avoid drops.
+	for i := 0; i < 5; i++ {
+		<-ch
+	}
+
+	m := b.Metrics()
+	if m.TopicStats["events"].Published != 5 {
+		t.Fatalf("expected Published=5, got %d", m.TopicStats["events"].Published)
+	}
+}
+
+func TestWithMetrics_TracksDropped(t *testing.T) {
+	b := NewSSEBroker(WithMetrics(), WithBufferSize(1))
+	defer b.Close()
+
+	_, unsub := b.Subscribe("events")
+	defer unsub()
+
+	// Publish 3 without draining; buffer=1 so at least 2 should drop.
+	for i := 0; i < 3; i++ {
+		b.Publish("events", "msg")
+	}
+
+	m := b.Metrics()
+	if m.TopicStats["events"].Dropped == 0 {
+		t.Fatal("expected Dropped > 0")
+	}
+	total := m.TopicStats["events"].Published + m.TopicStats["events"].Dropped
+	if total != 3 {
+		t.Fatalf("expected Published+Dropped=3, got %d", total)
+	}
+}
+
+func TestWithMetrics_PerTopic(t *testing.T) {
+	b := NewSSEBroker(WithMetrics())
+	defer b.Close()
+
+	ch1, unsub1 := b.Subscribe("topic-a")
+	defer unsub1()
+	ch2, unsub2 := b.Subscribe("topic-b")
+	defer unsub2()
+
+	b.Publish("topic-a", "a1")
+	b.Publish("topic-a", "a2")
+	b.Publish("topic-b", "b1")
+
+	<-ch1
+	<-ch1
+	<-ch2
+
+	m := b.Metrics()
+	if m.TopicStats["topic-a"].Published != 2 {
+		t.Fatalf("expected topic-a Published=2, got %d", m.TopicStats["topic-a"].Published)
+	}
+	if m.TopicStats["topic-b"].Published != 1 {
+		t.Fatalf("expected topic-b Published=1, got %d", m.TopicStats["topic-b"].Published)
+	}
+}
+
+func TestWithMetrics_PeakSubscribers(t *testing.T) {
+	b := NewSSEBroker(WithMetrics())
+	defer b.Close()
+
+	ch1, unsub1 := b.Subscribe("events")
+	_, unsub2 := b.Subscribe("events")
+	_, unsub3 := b.Subscribe("events")
+
+	// Unsubscribe 2, peak should still be 3.
+	unsub2()
+	unsub3()
+
+	// Publish once to create the counter entry so it shows up in Metrics.
+	b.Publish("events", "msg")
+	<-ch1
+
+	m := b.Metrics()
+	if m.TopicStats["events"].PeakSubscribers != 3 {
+		t.Fatalf("expected PeakSubscribers=3, got %d", m.TopicStats["events"].PeakSubscribers)
+	}
+	unsub1()
+}
+
+func TestWithMetrics_Aggregates(t *testing.T) {
+	b := NewSSEBroker(WithMetrics(), WithBufferSize(1))
+	defer b.Close()
+
+	ch1, unsub1 := b.Subscribe("x")
+	defer unsub1()
+	ch2, unsub2 := b.Subscribe("y")
+	defer unsub2()
+
+	b.Publish("x", "m1")
+	<-ch1
+	b.Publish("x", "m2")
+	<-ch1
+	b.Publish("y", "m3")
+	<-ch2
+
+	// Now publish to y without draining to cause a drop.
+	b.Publish("y", "fill")
+	b.Publish("y", "drop")
+
+	m := b.Metrics()
+	if m.TotalPublished < 3 {
+		t.Fatalf("expected TotalPublished >= 3, got %d", m.TotalPublished)
+	}
+	if m.TotalPublished+m.TotalDropped != 5 {
+		t.Fatalf("expected TotalPublished+TotalDropped=5, got %d", m.TotalPublished+m.TotalDropped)
+	}
+}
+
+func TestWithMetrics_Disabled(t *testing.T) {
+	b := NewSSEBroker() // no WithMetrics
+	defer b.Close()
+
+	m := b.Metrics()
+	if m.TopicStats == nil {
+		t.Fatal("expected non-nil TopicStats map when disabled")
+	}
+	if len(m.TopicStats) != 0 {
+		t.Fatalf("expected empty TopicStats, got %d entries", len(m.TopicStats))
+	}
+}
+
+func TestWithMetrics_PublishTo(t *testing.T) {
+	b := NewSSEBroker(WithMetrics())
+	defer b.Close()
+
+	ch, unsub := b.SubscribeScoped("notif", "user-1")
+	defer unsub()
+
+	b.PublishTo("notif", "user-1", "hello")
+	<-ch
+
+	m := b.Metrics()
+	if m.TopicStats["notif"].Published != 1 {
+		t.Fatalf("expected Published=1 for scoped publish, got %d", m.TopicStats["notif"].Published)
+	}
+}
+
+func TestWithMetrics_PublishIfChanged(t *testing.T) {
+	b := NewSSEBroker(WithMetrics())
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("dash")
+	defer unsub()
+
+	// First publish: should go through.
+	ok := b.PublishIfChanged("dash", "v1")
+	if !ok {
+		t.Fatal("expected first PublishIfChanged to publish")
+	}
+	<-ch
+
+	// Same content: should be skipped (NOT counted).
+	ok = b.PublishIfChanged("dash", "v1")
+	if ok {
+		t.Fatal("expected duplicate PublishIfChanged to be skipped")
+	}
+
+	// Different content: should go through.
+	ok = b.PublishIfChanged("dash", "v2")
+	if !ok {
+		t.Fatal("expected changed PublishIfChanged to publish")
+	}
+	<-ch
+
+	m := b.Metrics()
+	if m.TopicStats["dash"].Published != 2 {
+		t.Fatalf("expected Published=2 for dedup publishes, got %d", m.TopicStats["dash"].Published)
+	}
+}
+
+func TestWithMetrics_ZeroOverheadWhenDisabled(t *testing.T) {
+	b := NewSSEBroker() // no WithMetrics
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("events")
+	defer unsub()
+
+	// These should not panic.
+	b.Publish("events", "msg1")
+	b.PublishWithReplay("events", "msg2")
+	b.PublishIfChanged("events", "msg3")
+	b.PublishTo("events", "scope", "msg4")
+
+	// Drain what arrived.
+	timeout := time.After(100 * time.Millisecond)
+	for {
+		select {
+		case <-ch:
+		case <-timeout:
+			return
+		}
+	}
+}

--- a/resume.go
+++ b/resume.go
@@ -43,13 +43,22 @@ func (b *SSEBroker) PublishWithID(topic, id, msg string) {
 	}
 	b.mu.Unlock()
 
+	var sent, dropped int
 	for _, ch := range channels {
 		func() {
 			defer func() { _ = recover() }()
-			if !b.send(ch, msg) {
+			if b.send(ch, msg) {
+				sent++
+			} else {
 				b.drops.Add(1)
+				dropped++
 			}
 		}()
+	}
+	if b.metrics != nil {
+		tc := b.metrics.counter(topic)
+		tc.published.Add(int64(sent))
+		tc.dropped.Add(int64(dropped))
 	}
 }
 
@@ -79,6 +88,11 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 	var firstHooks []func(string)
 	if total == 1 {
 		firstHooks = b.onFirst[topic]
+	}
+	if b.metrics != nil {
+		if total > b.metrics.peakSubs[topic] {
+			b.metrics.peakSubs[topic] = total
+		}
 	}
 
 	// Find messages after lastEventID.


### PR DESCRIPTION
## Summary

- Add opt-in per-topic metrics via `WithMetrics()` option with zero overhead when disabled
- Track published count, dropped count, and peak subscriber count per topic
- New `Metrics()` method returns a point-in-time `BrokerMetrics` snapshot with per-topic and aggregate stats
- Instruments all publish methods (`Publish`, `PublishWithReplay`, `PublishTo`, `PublishIfChanged`, `PublishIfChangedTo`, `PublishWithID`) and all subscribe methods (`Subscribe`, `SubscribeScoped`, `SubscribeFromID`)

Closes #36

## Test plan

- [x] `TestWithMetrics_TracksPublished` -- publish 5 messages, verify count
- [x] `TestWithMetrics_TracksDropped` -- buffer size 1, verify drops counted
- [x] `TestWithMetrics_PerTopic` -- independent per-topic counts
- [x] `TestWithMetrics_PeakSubscribers` -- subscribe 3, unsub 2, peak stays 3
- [x] `TestWithMetrics_Aggregates` -- verify TotalPublished and TotalDropped sums
- [x] `TestWithMetrics_Disabled` -- no panic, empty result without WithMetrics
- [x] `TestWithMetrics_PublishTo` -- scoped publishes tracked
- [x] `TestWithMetrics_PublishIfChanged` -- dedup skips not counted
- [x] `TestWithMetrics_ZeroOverheadWhenDisabled` -- smoke test, no panics
- [x] All tests pass with `-race`