### PR TITLE
feat: taverntest helpers for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
     - [Check for subscribers](#check-for-subscribers)
     - [Topic metrics](#topic-metrics)
     - [Per-topic metrics](#per-topic-metrics)
+  - [Testing](#testing)
   - [Topic constants](#topic-constants)
   - [Thread safety](#thread-safety)
   - [Philosophy](#philosophy)
@@ -644,6 +645,37 @@ fmt.Printf("totals: published=%d dropped=%d\n", m.TotalPublished, m.TotalDropped
 Metrics are opt-in — when `WithMetrics` is not set, there is zero overhead on
 publish operations. Use this to identify topics with high drop rates, track
 publish throughput, and find peak subscriber counts for capacity planning.
+
+## Testing
+
+The `taverntest` subpackage provides helpers for testing code that uses tavern:
+
+```go
+import "github.com/catgoose/tavern/taverntest"
+
+func TestMyPublisher(t *testing.T) {
+    broker := tavern.NewSSEBroker()
+    defer broker.Close()
+
+    rec := taverntest.NewRecorder(broker, "events")
+    defer rec.Close()
+
+    // ... code under test publishes to "events" ...
+    myPublisher(broker)
+
+    rec.WaitFor(3, time.Second)
+    rec.AssertCount(t, 3)
+    rec.AssertContains(t, "expected-message")
+    rec.AssertNthMessage(t, 0, "first-message")
+}
+```
+
+`NewScopedRecorder` works the same way for scoped subscriptions:
+
+```go
+rec := taverntest.NewScopedRecorder(broker, "notifications", userID)
+defer rec.Close()
+```
 
 ## Topic constants
 

--- a/taverntest/recorder.go
+++ b/taverntest/recorder.go
@@ -1,0 +1,141 @@
+package taverntest
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/catgoose/tavern"
+)
+
+// Recorder captures messages published to a topic for test assertions.
+// It subscribes to the topic on creation and collects messages in a
+// goroutine. Use [NewRecorder] or [NewScopedRecorder] to create one.
+type Recorder struct {
+	msgs   []string
+	mu     sync.Mutex
+	unsub  func()
+	done   chan struct{}
+	closed bool
+}
+
+// NewRecorder subscribes to the given topic on the broker and starts
+// collecting messages in a background goroutine. Call [Recorder.Close]
+// when done to unsubscribe and stop collection.
+func NewRecorder(broker *tavern.SSEBroker, topic string) *Recorder {
+	ch, unsub := broker.Subscribe(topic)
+	return newRecorder(ch, unsub)
+}
+
+// NewScopedRecorder subscribes to the given topic and scope on the broker
+// and starts collecting messages. Call [Recorder.Close] when done.
+func NewScopedRecorder(broker *tavern.SSEBroker, topic, scope string) *Recorder {
+	ch, unsub := broker.SubscribeScoped(topic, scope)
+	return newRecorder(ch, unsub)
+}
+
+func newRecorder(ch <-chan string, unsub func()) *Recorder {
+	r := &Recorder{
+		unsub: unsub,
+		done:  make(chan struct{}),
+	}
+	go func() {
+		defer close(r.done)
+		for msg := range ch {
+			r.mu.Lock()
+			r.msgs = append(r.msgs, msg)
+			r.mu.Unlock()
+		}
+	}()
+	return r
+}
+
+// Close stops collecting messages and unsubscribes from the topic.
+// Safe to call multiple times.
+func (r *Recorder) Close() {
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return
+	}
+	r.closed = true
+	r.mu.Unlock()
+	r.unsub()
+	<-r.done // wait for collection goroutine to finish
+}
+
+// Messages returns a copy of all collected messages so far.
+func (r *Recorder) Messages() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := make([]string, len(r.msgs))
+	copy(cp, r.msgs)
+	return cp
+}
+
+// Len returns the number of messages collected so far.
+func (r *Recorder) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.msgs)
+}
+
+// WaitFor blocks until at least n messages have been collected or the
+// timeout elapses. Returns true if n messages were collected, false on
+// timeout.
+func (r *Recorder) WaitFor(n int, timeout time.Duration) bool {
+	deadline := time.After(timeout)
+	for {
+		r.mu.Lock()
+		count := len(r.msgs)
+		r.mu.Unlock()
+		if count >= n {
+			return true
+		}
+		select {
+		case <-deadline:
+			return false
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+// AssertCount fails the test if the number of collected messages does not
+// equal expected.
+func (r *Recorder) AssertCount(t testing.TB, expected int) {
+	t.Helper()
+	r.mu.Lock()
+	got := len(r.msgs)
+	r.mu.Unlock()
+	if got != expected {
+		t.Errorf("expected %d messages, got %d", expected, got)
+	}
+}
+
+// AssertContains fails the test if none of the collected messages equal msg.
+func (r *Recorder) AssertContains(t testing.TB, msg string) {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, m := range r.msgs {
+		if m == msg {
+			return
+		}
+	}
+	t.Errorf("expected message %q not found in %d collected messages", msg, len(r.msgs))
+}
+
+// AssertNthMessage fails the test if the n-th collected message (0-indexed)
+// does not equal expected.
+func (r *Recorder) AssertNthMessage(t testing.TB, n int, expected string) {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if n >= len(r.msgs) {
+		t.Errorf("expected message at index %d, but only %d messages collected", n, len(r.msgs))
+		return
+	}
+	if r.msgs[n] != expected {
+		t.Errorf("message[%d]: expected %q, got %q", n, expected, r.msgs[n])
+	}
+}

--- a/taverntest/recorder_test.go
+++ b/taverntest/recorder_test.go
@@ -1,0 +1,153 @@
+package taverntest_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/catgoose/tavern"
+	"github.com/catgoose/tavern/taverntest"
+)
+
+func TestRecorder_CollectsMessages(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	rec := taverntest.NewRecorder(b, "events")
+	defer rec.Close()
+
+	b.Publish("events", "msg1")
+	b.Publish("events", "msg2")
+	b.Publish("events", "msg3")
+
+	if !rec.WaitFor(3, time.Second) {
+		t.Fatal("timed out waiting for 3 messages")
+	}
+
+	rec.AssertCount(t, 3)
+	rec.AssertNthMessage(t, 0, "msg1")
+	rec.AssertNthMessage(t, 1, "msg2")
+	rec.AssertNthMessage(t, 2, "msg3")
+}
+
+func TestRecorder_AssertContains(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	rec := taverntest.NewRecorder(b, "events")
+	defer rec.Close()
+
+	b.Publish("events", "hello")
+	b.Publish("events", "world")
+
+	if !rec.WaitFor(2, time.Second) {
+		t.Fatal("timed out")
+	}
+
+	rec.AssertContains(t, "hello")
+	rec.AssertContains(t, "world")
+}
+
+func TestRecorder_Messages_ReturnsCopy(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	rec := taverntest.NewRecorder(b, "events")
+	defer rec.Close()
+
+	b.Publish("events", "msg1")
+	rec.WaitFor(1, time.Second)
+
+	msgs := rec.Messages()
+	if len(msgs) != 1 || msgs[0] != "msg1" {
+		t.Fatalf("unexpected messages: %v", msgs)
+	}
+
+	// Mutating the returned slice should not affect the recorder
+	msgs[0] = "mutated"
+	rec.AssertNthMessage(t, 0, "msg1")
+}
+
+func TestRecorder_WaitFor_Timeout(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	rec := taverntest.NewRecorder(b, "events")
+	defer rec.Close()
+
+	// Don't publish anything — WaitFor should timeout
+	ok := rec.WaitFor(1, 50*time.Millisecond)
+	if ok {
+		t.Fatal("expected timeout")
+	}
+}
+
+func TestRecorder_Close_Idempotent(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	rec := taverntest.NewRecorder(b, "events")
+	rec.Close()
+	rec.Close() // should not panic
+}
+
+func TestScopedRecorder(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	rec1 := taverntest.NewScopedRecorder(b, "notif", "user-1")
+	defer rec1.Close()
+	rec2 := taverntest.NewScopedRecorder(b, "notif", "user-2")
+	defer rec2.Close()
+
+	b.PublishTo("notif", "user-1", "for-user-1")
+	b.PublishTo("notif", "user-2", "for-user-2")
+
+	if !rec1.WaitFor(1, time.Second) {
+		t.Fatal("rec1 timed out")
+	}
+	if !rec2.WaitFor(1, time.Second) {
+		t.Fatal("rec2 timed out")
+	}
+
+	rec1.AssertCount(t, 1)
+	rec1.AssertContains(t, "for-user-1")
+	rec2.AssertCount(t, 1)
+	rec2.AssertContains(t, "for-user-2")
+}
+
+func TestRecorder_Len(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	rec := taverntest.NewRecorder(b, "events")
+	defer rec.Close()
+
+	if rec.Len() != 0 {
+		t.Fatal("expected 0 messages initially")
+	}
+
+	b.Publish("events", "msg")
+	rec.WaitFor(1, time.Second)
+
+	if rec.Len() != 1 {
+		t.Fatal("expected 1 message")
+	}
+}
+
+func TestRecorder_CloseStopsCollection(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	rec := taverntest.NewRecorder(b, "events")
+
+	b.Publish("events", "before")
+	rec.WaitFor(1, time.Second)
+
+	rec.Close()
+
+	b.Publish("events", "after")
+	time.Sleep(50 * time.Millisecond)
+
+	rec.AssertCount(t, 1)
+	rec.AssertContains(t, "before")
+}


### PR DESCRIPTION
## Summary

- Adds `taverntest` subpackage with `Recorder` type for capturing and asserting on published messages in tests
- `NewRecorder` and `NewScopedRecorder` subscribe to topics and collect messages in a background goroutine
- Includes `WaitFor`, `AssertCount`, `AssertContains`, `AssertNthMessage`, `Messages`, and `Len` helpers
- Full test suite with race detector coverage
- README updated with Testing section and TOC entry

Closes #46