### PR TITLE
feat: PublishLazyOOB

### DIFF
--- a/oob.go
+++ b/oob.go
@@ -121,3 +121,61 @@ func (b *SSEBroker) PublishIfChangedOOBTo(topic, scope string, fragments ...Frag
 	msg := NewSSEMessage("oob", RenderFragments(fragments...)).String()
 	return b.PublishIfChangedTo(topic, scope, msg)
 }
+
+// PublishLazyOOB calls renderFn only if the topic has subscribers, then
+// publishes the rendered fragments. This avoids expensive rendering (DB
+// queries, template execution) when nobody is listening. If renderFn returns
+// no fragments, no message is published.
+func (b *SSEBroker) PublishLazyOOB(topic string, renderFn func() []Fragment) {
+	if !b.HasSubscribers(topic) {
+		return
+	}
+	fragments := renderFn()
+	if len(fragments) == 0 {
+		return
+	}
+	b.PublishOOB(topic, fragments...)
+}
+
+// PublishLazyIfChangedOOB calls renderFn only if the topic has subscribers,
+// then publishes the rendered fragments only if the content differs from the
+// last publish. Combines the subscriber guard with deduplication. Returns true
+// if published (content changed), false if skipped (no subscribers, no
+// fragments, or identical content).
+func (b *SSEBroker) PublishLazyIfChangedOOB(topic string, renderFn func() []Fragment) bool {
+	if !b.HasSubscribers(topic) {
+		return false
+	}
+	fragments := renderFn()
+	if len(fragments) == 0 {
+		return false
+	}
+	return b.PublishIfChangedOOB(topic, fragments...)
+}
+
+// PublishLazyOOBTo calls renderFn only if the topic has subscribers, then
+// publishes the rendered fragments to scoped subscribers matching the scope.
+func (b *SSEBroker) PublishLazyOOBTo(topic, scope string, renderFn func() []Fragment) {
+	if !b.HasSubscribers(topic) {
+		return
+	}
+	fragments := renderFn()
+	if len(fragments) == 0 {
+		return
+	}
+	b.PublishOOBTo(topic, scope, fragments...)
+}
+
+// PublishLazyIfChangedOOBTo calls renderFn only if the topic has subscribers,
+// then publishes the rendered fragments to scoped subscribers only if the
+// content differs from the last publish for that topic+scope.
+func (b *SSEBroker) PublishLazyIfChangedOOBTo(topic, scope string, renderFn func() []Fragment) bool {
+	if !b.HasSubscribers(topic) {
+		return false
+	}
+	fragments := renderFn()
+	if len(fragments) == 0 {
+		return false
+	}
+	return b.PublishIfChangedOOBTo(topic, scope, fragments...)
+}

--- a/oob_test.go
+++ b/oob_test.go
@@ -210,6 +210,125 @@ func TestPublishIfChangedOOBTo_ScopedDelivery(t *testing.T) {
 	}
 }
 
+func TestPublishLazyOOB_SkipsWithoutSubscribers(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	called := false
+	b.PublishLazyOOB("t", func() []Fragment {
+		called = true
+		return []Fragment{Replace("el", "<b>hi</b>")}
+	})
+	assert.False(t, called, "renderFn should not be called without subscribers")
+}
+
+func TestPublishLazyOOB_CallsWithSubscribers(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	b.PublishLazyOOB("t", func() []Fragment {
+		return []Fragment{Replace("el", "<b>hi</b>")}
+	})
+
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "hi")
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestPublishLazyOOB_EmptyFragments(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	b.PublishLazyOOB("t", func() []Fragment {
+		return nil
+	})
+
+	select {
+	case <-ch:
+		t.Fatal("should not receive message for empty fragments")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestPublishLazyIfChangedOOB_SkipsDuplicate(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	render := func() []Fragment {
+		return []Fragment{Replace("el", "<b>same</b>")}
+	}
+
+	ok1 := b.PublishLazyIfChangedOOB("t", render)
+	assert.True(t, ok1)
+	<-ch
+
+	ok2 := b.PublishLazyIfChangedOOB("t", render)
+	assert.False(t, ok2)
+}
+
+func TestPublishLazyIfChangedOOB_NoSubscribers(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	called := false
+	ok := b.PublishLazyIfChangedOOB("t", func() []Fragment {
+		called = true
+		return []Fragment{Replace("el", "<b>hi</b>")}
+	})
+	assert.False(t, ok)
+	assert.False(t, called)
+}
+
+func TestPublishLazyOOBTo_ScopedDelivery(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeScoped("t", "user-1")
+	defer unsub()
+
+	b.PublishLazyOOBTo("t", "user-1", func() []Fragment {
+		return []Fragment{Replace("el", "<b>scoped</b>")}
+	})
+
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "scoped")
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestPublishLazyIfChangedOOBTo_ScopedDedup(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeScoped("t", "s1")
+	defer unsub()
+
+	render := func() []Fragment {
+		return []Fragment{Replace("el", "<b>same</b>")}
+	}
+
+	ok1 := b.PublishLazyIfChangedOOBTo("t", "s1", render)
+	assert.True(t, ok1)
+	<-ch
+
+	ok2 := b.PublishLazyIfChangedOOBTo("t", "s1", render)
+	assert.False(t, ok2)
+}
+
 func TestRenderComponentError_EscapesComment(t *testing.T) {
 	// An error message containing --> must not break out of the HTML comment.
 	// escapeAttr replaces > with &gt;, turning --> into --&gt; inside the comment body.


### PR DESCRIPTION
## Summary
- Add `PublishLazyOOB`, `PublishLazyIfChangedOOB`, `PublishLazyOOBTo`, and `PublishLazyIfChangedOOBTo` methods that combine the `HasSubscribers` guard with render + publish into a single call
- The render function only runs if subscribers exist, avoiding expensive rendering (DB queries, template execution) when nobody is listening
- Includes tests for subscriber guard, empty fragment handling, deduplication, and scoped delivery

Closes #56