### PR TITLE
feat: built-in SSE HTTP handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   - [Why](#why)
   - [Install](#install)
   - [Quick start](#quick-start)
+    - [Built-in SSE handler](#built-in-sse-handler)
   - [Core concepts](#core-concepts)
     - [Subscribe and unsubscribe](#subscribe-and-unsubscribe)
     - [Publish](#publish)
@@ -178,6 +179,30 @@ func sseHandler(broker *tavern.SSEBroker) echo.HandlerFunc {
 		}
 	}
 }
+```
+
+### Built-in SSE handler
+
+Or use the built-in handler that does the same thing in one line:
+
+```go
+// Standard library
+mux.Handle("/sse/events", broker.SSEHandler("events"))
+
+// Echo
+e.GET("/sse/events", echo.WrapHandler(broker.SSEHandler("events")))
+```
+
+The built-in handler sets SSE headers, handles `Last-Event-ID` resumption, and
+streams messages with flush. Override the write step for custom formatting:
+
+```go
+mux.Handle("/sse", broker.SSEHandler("events",
+    tavern.WithSSEWriter(func(w http.ResponseWriter, msg string) error {
+        // use htmx-go, custom framing, logging, etc.
+        return myCustomWrite(w, msg)
+    }),
+))
 ```
 
 ## Core concepts

--- a/handler.go
+++ b/handler.go
@@ -1,0 +1,99 @@
+package tavern
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// SSEWriterFunc writes a message to the HTTP response. It is called for each
+// message received from the subscriber channel. The default writer calls
+// fmt.Fprint followed by Flush. Override with [WithSSEWriter] to use custom
+// formatting (e.g., htmx-go).
+type SSEWriterFunc func(w http.ResponseWriter, msg string) error
+
+// SSEHandlerOption configures the SSE handler.
+type SSEHandlerOption func(*sseHandler)
+
+// WithSSEWriter overrides the default message writer. The provided function
+// is called for each message and is responsible for writing to the response
+// and flushing if needed. Use this to integrate with libraries like htmx-go
+// or to add custom SSE formatting.
+func WithSSEWriter(fn SSEWriterFunc) SSEHandlerOption {
+	return func(h *sseHandler) {
+		h.writer = fn
+	}
+}
+
+type sseHandler struct {
+	broker *SSEBroker
+	topic  string
+	writer SSEWriterFunc
+}
+
+// SSEHandler returns an [http.Handler] that streams SSE messages for the
+// given topic. It handles Content-Type headers, Last-Event-ID resumption
+// via [SSEBroker.SubscribeFromID], and the streaming select loop.
+//
+// The default writer calls fmt.Fprint followed by http.Flusher.Flush for
+// each message. Override with [WithSSEWriter] for custom formatting.
+//
+//	// Standard library
+//	mux.Handle("/sse/dashboard", broker.SSEHandler("dashboard"))
+//
+//	// Echo
+//	e.GET("/sse/dashboard", echo.WrapHandler(broker.SSEHandler("dashboard")))
+//
+//	// Custom writer (e.g., htmx-go)
+//	mux.Handle("/sse", broker.SSEHandler("events",
+//	    tavern.WithSSEWriter(func(w http.ResponseWriter, msg string) error {
+//	        return htmx.WriteSSE(w, msg)
+//	    }),
+//	))
+func (b *SSEBroker) SSEHandler(topic string, opts ...SSEHandlerOption) http.Handler {
+	h := &sseHandler{
+		broker: b,
+		topic:  topic,
+		writer: defaultSSEWriter,
+	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
+}
+
+func defaultSSEWriter(w http.ResponseWriter, msg string) error {
+	if _, err := fmt.Fprint(w, msg); err != nil {
+		return err
+	}
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+	return nil
+}
+
+func (h *sseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Set SSE headers.
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	// Subscribe with Last-Event-ID resumption.
+	lastID := r.Header.Get("Last-Event-ID")
+	ch, unsub := h.broker.SubscribeFromID(h.topic, lastID)
+	defer unsub()
+
+	// Stream loop.
+	for {
+		select {
+		case msg, ok := <-ch:
+			if !ok {
+				return // broker closed
+			}
+			if err := h.writer(w, msg); err != nil {
+				return // client disconnected
+			}
+		case <-r.Context().Done():
+			return // client disconnected
+		}
+	}
+}

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,179 @@
+package tavern
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// flushRecorder wraps httptest.ResponseRecorder to implement http.Flusher.
+type flushRecorder struct {
+	*httptest.ResponseRecorder
+	flushed int
+}
+
+func (f *flushRecorder) Flush() {
+	f.flushed++
+	f.ResponseRecorder.Flush()
+}
+
+func newFlushRecorder() *flushRecorder {
+	return &flushRecorder{ResponseRecorder: httptest.NewRecorder()}
+}
+
+func TestSSEHandler_BasicStreaming(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	handler := b.SSEHandler("events")
+
+	// Publish a message before starting the handler
+	// (use PublishWithReplay so the subscriber gets it)
+	b.PublishWithReplay("events", "hello")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse", nil)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	// Wait for the replayed message to be written
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	assert.Contains(t, rec.Body.String(), "hello")
+	assert.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"))
+	assert.Equal(t, "no-cache", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "keep-alive", rec.Header().Get("Connection"))
+}
+
+func TestSSEHandler_LastEventID(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	b.PublishWithID("events", "1", "msg-1")
+	b.PublishWithID("events", "2", "msg-2")
+	b.PublishWithID("events", "3", "msg-3")
+
+	handler := b.SSEHandler("events")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse", nil)
+	req.Header.Set("Last-Event-ID", "1") // should replay 2 and 3
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "msg-2")
+	assert.Contains(t, body, "msg-3")
+	assert.NotContains(t, body, "msg-1")
+}
+
+func TestSSEHandler_CustomWriter(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	var written []string
+	handler := b.SSEHandler("events", WithSSEWriter(func(w http.ResponseWriter, msg string) error {
+		written = append(written, msg)
+		return nil
+	}))
+
+	b.PublishWithReplay("events", "custom-msg")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse", nil)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	require.Len(t, written, 1)
+	assert.Equal(t, "custom-msg", written[0])
+}
+
+func TestSSEHandler_BrokerClose(t *testing.T) {
+	b := NewSSEBroker()
+
+	handler := b.SSEHandler("events")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse", nil)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	b.Close()
+
+	select {
+	case <-done:
+		// handler returned after broker close
+	case <-time.After(time.Second):
+		t.Fatal("handler did not return after broker close")
+	}
+}
+
+func TestSSEHandler_Flushes(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	handler := b.SSEHandler("events")
+
+	b.PublishWithReplay("events", "flush-test")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse", nil)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	assert.Greater(t, rec.flushed, 0, "expected at least one flush")
+}
+
+// contextWithCancel creates a cancellable context from a request.
+func contextWithCancel(r *http.Request) (context.Context, context.CancelFunc) {
+	return context.WithCancel(r.Context())
+}


### PR DESCRIPTION
## Summary

- Add `SSEHandler` method on `SSEBroker` that returns an `http.Handler` for SSE endpoints, eliminating ~20 lines of boilerplate per endpoint
- Handles Content-Type headers, `Last-Event-ID` resumption via `SubscribeFromID`, and the streaming select loop
- Pluggable write step via `WithSSEWriter` option for custom formatting (e.g., htmx-go)
- Works with standard library `ServeMux`, Echo (`echo.WrapHandler`), and any other router

## Test plan

- [x] `TestSSEHandler_BasicStreaming` — verifies message delivery and correct SSE headers
- [x] `TestSSEHandler_LastEventID` — verifies `Last-Event-ID` resumption replays only missed messages
- [x] `TestSSEHandler_CustomWriter` — verifies `WithSSEWriter` overrides the default writer
- [x] `TestSSEHandler_BrokerClose` — verifies handler returns when broker is closed
- [x] `TestSSEHandler_Flushes` — verifies the default writer calls `Flush`
- [x] All tests pass with `-race`

Closes #57