### PR TITLE
feat: SSE retry directive for graceful deploys

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -738,6 +738,55 @@ func (b *SSEBroker) sendKeepalive() {
 	}
 }
 
+// SetRetry sends an SSE retry directive to all subscribers of the given topic,
+// including both unscoped and scoped subscribers. The browser's EventSource
+// stores this value and uses it for the next reconnect attempt. Call before
+// [SSEBroker.Close] in a graceful shutdown sequence to prevent clients from
+// thundering-herding against new pods.
+func (b *SSEBroker) SetRetry(topic string, d time.Duration) {
+	msg := fmt.Sprintf("retry: %d\n\n", d.Milliseconds())
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for ch := range b.topics[topic] {
+		select {
+		case ch <- msg:
+		default:
+		}
+	}
+	for ch := range b.scopedTopics[topic] {
+		select {
+		case ch <- msg:
+		default:
+		}
+	}
+}
+
+// SetRetryAll sends an SSE retry directive to all subscribers across all
+// topics, including both unscoped and scoped subscribers. This is a
+// convenience for graceful shutdown scenarios where every connected client
+// should back off before reconnecting.
+func (b *SSEBroker) SetRetryAll(d time.Duration) {
+	msg := fmt.Sprintf("retry: %d\n\n", d.Milliseconds())
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for _, subs := range b.topics {
+		for ch := range subs {
+			select {
+			case ch <- msg:
+			default:
+			}
+		}
+	}
+	for _, subs := range b.scopedTopics {
+		for ch := range subs {
+			select {
+			case ch <- msg:
+			default:
+			}
+		}
+	}
+}
+
 // Close shuts down the broker. It first waits for all publisher goroutines
 // started via [SSEBroker.RunPublisher] to return, then closes all subscriber
 // channels and removes all topics. After Close returns, any pending reads on

--- a/broker_test.go
+++ b/broker_test.go
@@ -1571,3 +1571,73 @@ func TestPublishIfChangedTo_AfterClose(t *testing.T) {
 	ok := b.PublishIfChangedTo("t", "s", "msg")
 	assert.False(t, ok)
 }
+
+func TestSetRetry_SendsDirective(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	b.SetRetry("t", 30*time.Second)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "retry: 30000\n\n", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestSetRetry_ReachesScopedSubscribers(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeScoped("t", "user-1")
+	defer unsub()
+
+	b.SetRetry("t", 5*time.Second)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "retry: 5000\n\n", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestSetRetryAll_AllTopics(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch1, unsub1 := b.Subscribe("a")
+	defer unsub1()
+	ch2, unsub2 := b.Subscribe("b")
+	defer unsub2()
+	ch3, unsub3 := b.SubscribeScoped("c", "s1")
+	defer unsub3()
+
+	b.SetRetryAll(10 * time.Second)
+
+	expected := "retry: 10000\n\n"
+	for _, ch := range []<-chan string{ch1, ch2, ch3} {
+		select {
+		case msg := <-ch:
+			assert.Equal(t, expected, msg)
+		case <-time.After(time.Second):
+			t.Fatal("timed out")
+		}
+	}
+}
+
+func TestSetRetry_NoSubscribers(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+	assert.NotPanics(t, func() { b.SetRetry("empty", time.Second) })
+}
+
+func TestSetRetryAll_EmptyBroker(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+	assert.NotPanics(t, func() { b.SetRetryAll(time.Second) })
+}


### PR DESCRIPTION
## Summary

- Add `SetRetry(topic, duration)` to send an SSE `retry:` directive to all subscribers (unscoped and scoped) of a given topic
- Add `SetRetryAll(duration)` to send the directive to every subscriber across all topics
- Both methods use direct channel sends under RLock (like `sendKeepalive`) to reach all subscriber types

Closes #61