### PR TITLE
feat: multiplexed subscriptions (SubscribeMulti)

### DIFF
--- a/multi.go
+++ b/multi.go
@@ -1,0 +1,76 @@
+package tavern
+
+import "sync"
+
+// TopicMessage pairs a message with the topic it was published on.
+type TopicMessage struct {
+	Topic string
+	Data  string
+}
+
+// SubscribeMulti subscribes to multiple topics and returns a single channel
+// that receives [TopicMessage] values tagged with their source topic. The
+// returned unsubscribe function removes the subscriber from all topics at
+// once. Each topic counts toward its own subscriber total (lifecycle hooks
+// fire correctly).
+//
+// This eliminates the need for reflect.Select when a single SSE connection
+// serves multiple topics.
+func (b *SSEBroker) SubscribeMulti(topics ...string) (msgs <-chan TopicMessage, unsubscribe func()) {
+	out := make(chan TopicMessage, b.bufferSize)
+	unsubs := make([]func(), 0, len(topics))
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for _, topic := range topics {
+		ch, unsub := b.Subscribe(topic)
+		unsubs = append(unsubs, unsub)
+		t := topic
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case msg, ok := <-ch:
+					if !ok {
+						return
+					}
+					select {
+					case out <- TopicMessage{Topic: t, Data: msg}:
+					case <-done:
+						return
+					}
+				case <-done:
+					return
+				}
+			}
+		}()
+	}
+
+	var closeOnce sync.Once
+	closeOut := func() {
+		closeOnce.Do(func() { close(out) })
+	}
+
+	var unsubOnce sync.Once
+	doUnsub := func() {
+		unsubOnce.Do(func() {
+			close(done)
+			for _, unsub := range unsubs {
+				unsub()
+			}
+		})
+	}
+
+	// Close out when all fan-in goroutines exit (e.g. broker closed).
+	go func() {
+		wg.Wait()
+		closeOut()
+	}()
+
+	return out, func() {
+		doUnsub()
+		wg.Wait()
+		closeOut()
+	}
+}

--- a/multi_test.go
+++ b/multi_test.go
@@ -1,0 +1,124 @@
+package tavern
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubscribeMulti_ReceivesFromAllTopics(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMulti("a", "b", "c")
+	defer unsub()
+
+	b.Publish("a", "from-a")
+	b.Publish("b", "from-b")
+	b.Publish("c", "from-c")
+
+	received := make(map[string]string)
+	for range 3 {
+		select {
+		case msg := <-ch:
+			received[msg.Topic] = msg.Data
+		case <-time.After(time.Second):
+			t.Fatalf("timed out, got %d/3", len(received))
+		}
+	}
+
+	assert.Equal(t, "from-a", received["a"])
+	assert.Equal(t, "from-b", received["b"])
+	assert.Equal(t, "from-c", received["c"])
+}
+
+func TestSubscribeMulti_UnsubscribeStopsAll(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMulti("a", "b")
+	unsub()
+
+	// Channel should be closed after unsub
+	_, ok := <-ch
+	assert.False(t, ok, "channel should be closed after unsubscribe")
+}
+
+func TestSubscribeMulti_CountsPerTopic(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeMulti("a", "b")
+	defer unsub()
+
+	assert.True(t, b.HasSubscribers("a"))
+	assert.True(t, b.HasSubscribers("b"))
+	assert.Equal(t, 2, b.SubscriberCount())
+}
+
+func TestSubscribeMulti_LifecycleHooks(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	fired := make(chan string, 2)
+	b.OnFirstSubscriber("x", func(topic string) { fired <- topic })
+	b.OnFirstSubscriber("y", func(topic string) { fired <- topic })
+
+	_, unsub := b.SubscribeMulti("x", "y")
+	defer unsub()
+
+	topics := make([]string, 0, 2)
+	for range 2 {
+		select {
+		case topic := <-fired:
+			topics = append(topics, topic)
+		case <-time.After(time.Second):
+			break
+		}
+	}
+	sort.Strings(topics)
+	assert.Equal(t, []string{"x", "y"}, topics)
+}
+
+func TestSubscribeMulti_BrokerClose(t *testing.T) {
+	b := NewSSEBroker()
+
+	ch, unsub := b.SubscribeMulti("a", "b")
+	defer unsub()
+
+	b.Close()
+
+	// Drain any remaining messages, channel should eventually close
+	for range ch {
+	}
+	// If we get here, channel was closed — test passes
+}
+
+func TestSubscribeMulti_DoubleUnsub(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeMulti("a")
+	unsub()
+	assert.NotPanics(t, func() { unsub() })
+}
+
+func TestSubscribeMulti_SingleTopic(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMulti("only")
+	defer unsub()
+
+	b.Publish("only", "hello")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "only", msg.Topic)
+		assert.Equal(t, "hello", msg.Data)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `SubscribeMulti` method that subscribes to multiple topics and returns a single `<-chan TopicMessage` tagged with the source topic
- Add `TopicMessage` type pairing topic name with message data
- Each topic counts toward its own subscriber total so lifecycle hooks (`OnFirstSubscriber`/`OnLastUnsubscribe`) fire correctly
- Fan-in goroutines are properly cleaned up on both explicit unsubscribe and broker close
- Double-unsubscribe is safe (protected by `sync.Once`)

Closes #58

## Test plan
- [x] `TestSubscribeMulti_ReceivesFromAllTopics` - messages from all topics arrive tagged correctly
- [x] `TestSubscribeMulti_UnsubscribeStopsAll` - channel closed after unsub
- [x] `TestSubscribeMulti_CountsPerTopic` - per-topic subscriber counts are correct
- [x] `TestSubscribeMulti_LifecycleHooks` - `OnFirstSubscriber` fires for each topic
- [x] `TestSubscribeMulti_BrokerClose` - channel drains and closes on broker shutdown
- [x] `TestSubscribeMulti_DoubleUnsub` - no panic on double unsubscribe
- [x] `TestSubscribeMulti_SingleTopic` - works with a single topic
- [x] All tests pass with `-race`