### PR TITLE
feat: snapshot + delta stream (closes #60)

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -1,0 +1,81 @@
+package tavern
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// SubscribeWithSnapshot subscribes to a topic and immediately sends the
+// result of snapshotFn as the first message before any live publishes.
+// The snapshot function runs while the subscription is being registered,
+// ensuring no messages are missed between the snapshot and live stream.
+// If snapshotFn returns an empty string, no snapshot is sent.
+//
+// This eliminates the dual-render pattern where page handlers and publishers
+// independently render the same initial state.
+func (b *SSEBroker) SubscribeWithSnapshot(topic string, snapshotFn func() string) (msgs <-chan string, unsubscribe func()) {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		ch := make(chan string)
+		close(ch)
+		return ch, func() {}
+	}
+	ch := make(chan string, b.bufferSize)
+	if b.topics[topic] == nil {
+		b.topics[topic] = make(map[chan string]struct{})
+	}
+	b.topics[topic][ch] = struct{}{}
+	total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+	var firstHooks []func(string)
+	if total == 1 {
+		firstHooks = b.onFirst[topic]
+	}
+	if b.metrics != nil {
+		if total > b.metrics.peakSubs[topic] {
+			b.metrics.peakSubs[topic] = total
+		}
+	}
+	if b.evictThreshold > 0 {
+		b.dropCountsMu.Lock()
+		b.dropCounts[ch] = &atomic.Int64{}
+		b.dropCountsMu.Unlock()
+	}
+	delete(b.topicEmpty, topic)
+	b.mu.Unlock()
+
+	for _, fn := range firstHooks {
+		go fn(topic)
+	}
+
+	// Send snapshot as first message
+	if snap := snapshotFn(); snap != "" {
+		select {
+		case ch <- snap:
+		default:
+		}
+	}
+
+	return ch, func() {
+		b.mu.Lock()
+		var lastHooks []func(string)
+		if _, ok := b.topics[topic][ch]; ok {
+			delete(b.topics[topic], ch)
+			close(ch)
+			total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+			if total == 0 {
+				lastHooks = b.onLast[topic]
+				b.topicEmpty[topic] = time.Now()
+			}
+		}
+		b.mu.Unlock()
+		if b.evictThreshold > 0 {
+			b.dropCountsMu.Lock()
+			delete(b.dropCounts, ch)
+			b.dropCountsMu.Unlock()
+		}
+		for _, fn := range lastHooks {
+			go fn(topic)
+		}
+	}
+}

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -1,0 +1,107 @@
+package tavern
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubscribeWithSnapshot_ReceivesSnapshot(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeWithSnapshot("t", func() string {
+		return "initial-state"
+	})
+	defer unsub()
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "initial-state", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for snapshot")
+	}
+}
+
+func TestSubscribeWithSnapshot_ThenLiveMessages(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeWithSnapshot("t", func() string {
+		return "snapshot"
+	})
+	defer unsub()
+
+	// Drain snapshot
+	<-ch
+
+	// Live message
+	b.Publish("t", "live")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "live", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for live message")
+	}
+}
+
+func TestSubscribeWithSnapshot_EmptySnapshotSkipped(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeWithSnapshot("t", func() string {
+		return ""
+	})
+	defer unsub()
+
+	b.Publish("t", "live")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "live", msg) // first message is live, not snapshot
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestSubscribeWithSnapshot_LifecycleHooks(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	fired := make(chan string, 1)
+	b.OnFirstSubscriber("t", func(topic string) { fired <- topic })
+
+	_, unsub := b.SubscribeWithSnapshot("t", func() string { return "snap" })
+	defer unsub()
+
+	select {
+	case got := <-fired:
+		assert.Equal(t, "t", got)
+	case <-time.After(time.Second):
+		t.Fatal("hook did not fire")
+	}
+}
+
+func TestSubscribeWithSnapshot_AfterClose(t *testing.T) {
+	b := NewSSEBroker()
+	b.Close()
+
+	ch, unsub := b.SubscribeWithSnapshot("t", func() string { return "snap" })
+	defer unsub()
+
+	_, ok := <-ch
+	assert.False(t, ok)
+}
+
+func TestSubscribeWithSnapshot_CountsSubscriber(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeWithSnapshot("t", func() string { return "" })
+	defer unsub()
+
+	assert.True(t, b.HasSubscribers("t"))
+	assert.Equal(t, 1, b.SubscriberCount())
+}


### PR DESCRIPTION
## Summary

- Adds `SubscribeWithSnapshot` method to `SSEBroker` that sends a computed snapshot as the first message before live publishes
- Snapshot function runs after subscription registration, ensuring no messages are missed between snapshot and live stream
- Empty snapshots are skipped; lifecycle hooks, metrics, and eviction counters all work identically to `Subscribe`

## Test plan

- [x] Snapshot received as first message
- [x] Live messages follow snapshot
- [x] Empty snapshot string is skipped
- [x] OnFirstSubscriber hook fires
- [x] After-close returns closed channel
- [x] HasSubscribers/SubscriberCount reflect snapshot subscribers
- [x] All tests pass with `-race`