### PR TITLE
feat: subscriber metadata and connection lifecycle events

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -47,6 +47,8 @@ type SSEBroker struct {
 	evictCallback     func(topic string)           // optional callback on eviction
 	dropCounts        map[chan string]*atomic.Int64 // per-channel consecutive drop counter
 	dropCountsMu      sync.RWMutex                 // separate lock for drop counts (avoid nesting with main mu)
+	subscriberMeta    map[chan string]*SubscriberInfo // channel → subscriber info
+	connEventsTopic   string                         // empty = connection events disabled
 }
 
 // Topic name constants are conventions for common real-time use cases.
@@ -132,21 +134,32 @@ func WithSlowSubscriberCallback(fn func(topic string)) BrokerOption {
 	}
 }
 
+// WithConnectionEvents enables publishing subscriber connect/disconnect
+// events to the given meta topic. Events are JSON-formatted messages
+// containing the event type, topic, and current subscriber count.
+// The meta topic itself does not generate recursive events.
+func WithConnectionEvents(metaTopic string) BrokerOption {
+	return func(b *SSEBroker) {
+		b.connEventsTopic = metaTopic
+	}
+}
+
 // NewSSEBroker creates a ready-to-use [SSEBroker] with no active topics or
 // subscribers. It accepts optional [BrokerOption] values to override defaults.
 func NewSSEBroker(opts ...BrokerOption) *SSEBroker {
 	b := &SSEBroker{
-		topics:       make(map[string]map[chan string]struct{}),
-		scopedTopics: make(map[string]map[chan string]scopedSub),
-		replayCache:  make(map[string][]string),
-		replaySize:   make(map[string]int),
-		replayLog:    make(map[string][]ReplayEntry),
-		topicEmpty:   make(map[string]time.Time),
-		lastHash:     make(map[string]uint64),
-		onFirst:      make(map[string][]func(string)),
-		onLast:       make(map[string][]func(string)),
-		bufferSize:   10,
-		done:         make(chan struct{}),
+		topics:         make(map[string]map[chan string]struct{}),
+		scopedTopics:   make(map[string]map[chan string]scopedSub),
+		replayCache:    make(map[string][]string),
+		replaySize:     make(map[string]int),
+		replayLog:      make(map[string][]ReplayEntry),
+		topicEmpty:     make(map[string]time.Time),
+		lastHash:       make(map[string]uint64),
+		onFirst:        make(map[string][]func(string)),
+		onLast:         make(map[string][]func(string)),
+		subscriberMeta: make(map[chan string]*SubscriberInfo),
+		bufferSize:     10,
+		done:           make(chan struct{}),
 	}
 	for _, opt := range opts {
 		opt(b)
@@ -187,6 +200,7 @@ func (b *SSEBroker) Subscribe(topic string) (msgs <-chan string, unsubscribe fun
 		b.topics[topic] = make(map[chan string]struct{})
 	}
 	b.topics[topic][ch] = struct{}{}
+	b.subscriberMeta[ch] = &SubscriberInfo{Topic: topic, ConnectedAt: time.Now()}
 	total := len(b.topics[topic]) + len(b.scopedTopics[topic])
 	var firstHooks []func(string)
 	if total == 1 {
@@ -208,6 +222,7 @@ func (b *SSEBroker) Subscribe(topic string) (msgs <-chan string, unsubscribe fun
 	for _, fn := range firstHooks {
 		go fn(topic)
 	}
+	b.publishConnectionEvent("subscribe", topic, total)
 	for _, msg := range replayMsgs {
 		select {
 		case ch <- msg:
@@ -219,6 +234,7 @@ func (b *SSEBroker) Subscribe(topic string) (msgs <-chan string, unsubscribe fun
 		var lastHooks []func(string)
 		if _, ok := b.topics[topic][ch]; ok {
 			delete(b.topics[topic], ch)
+			delete(b.subscriberMeta, ch)
 			close(ch)
 			total := len(b.topics[topic]) + len(b.scopedTopics[topic])
 			if total == 0 {
@@ -235,6 +251,7 @@ func (b *SSEBroker) Subscribe(topic string) (msgs <-chan string, unsubscribe fun
 		for _, fn := range lastHooks {
 			go fn(topic)
 		}
+		b.publishConnectionEvent("unsubscribe", topic, -1)
 	}
 }
 
@@ -255,6 +272,7 @@ func (b *SSEBroker) SubscribeScoped(topic, scope string) (msgs <-chan string, un
 		b.scopedTopics[topic] = make(map[chan string]scopedSub)
 	}
 	b.scopedTopics[topic][ch] = scopedSub{scope: scope}
+	b.subscriberMeta[ch] = &SubscriberInfo{Topic: topic, Scope: scope, ConnectedAt: time.Now()}
 	total := len(b.topics[topic]) + len(b.scopedTopics[topic])
 	var firstHooks []func(string)
 	if total == 1 {
@@ -276,6 +294,7 @@ func (b *SSEBroker) SubscribeScoped(topic, scope string) (msgs <-chan string, un
 	for _, fn := range firstHooks {
 		go fn(topic)
 	}
+	b.publishConnectionEvent("subscribe", topic, total)
 	for _, msg := range replayMsgs {
 		select {
 		case ch <- msg:
@@ -287,6 +306,7 @@ func (b *SSEBroker) SubscribeScoped(topic, scope string) (msgs <-chan string, un
 		var lastHooks []func(string)
 		if _, ok := b.scopedTopics[topic][ch]; ok {
 			delete(b.scopedTopics[topic], ch)
+			delete(b.subscriberMeta, ch)
 			close(ch)
 			total := len(b.topics[topic]) + len(b.scopedTopics[topic])
 			if total == 0 {
@@ -303,6 +323,7 @@ func (b *SSEBroker) SubscribeScoped(topic, scope string) (msgs <-chan string, un
 		for _, fn := range lastHooks {
 			go fn(topic)
 		}
+		b.publishConnectionEvent("unsubscribe", topic, -1)
 	}
 }
 
@@ -499,6 +520,7 @@ func (b *SSEBroker) evictSubscriber(topic string, ch chan string) {
 	b.mu.Lock()
 	if _, ok := b.topics[topic][ch]; ok {
 		delete(b.topics[topic], ch)
+		delete(b.subscriberMeta, ch)
 		close(ch)
 		total := len(b.topics[topic]) + len(b.scopedTopics[topic])
 		var lastHooks []func(string)
@@ -512,6 +534,7 @@ func (b *SSEBroker) evictSubscriber(topic string, ch chan string) {
 		}
 	} else if _, ok := b.scopedTopics[topic][ch]; ok {
 		delete(b.scopedTopics[topic], ch)
+		delete(b.subscriberMeta, ch)
 		close(ch)
 		total := len(b.topics[topic]) + len(b.scopedTopics[topic])
 		var lastHooks []func(string)
@@ -881,6 +904,7 @@ func (b *SSEBroker) Close() {
 	b.replaySize = nil
 	b.replayLog = nil
 	b.lastHash = nil
+	b.subscriberMeta = nil
 	if b.dropCounts != nil {
 		b.dropCountsMu.Lock()
 		b.dropCounts = nil

--- a/resume.go
+++ b/resume.go
@@ -76,6 +76,7 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 		b.topics[topic] = make(map[chan string]struct{})
 	}
 	b.topics[topic][ch] = struct{}{}
+	b.subscriberMeta[ch] = &SubscriberInfo{Topic: topic, ConnectedAt: time.Now()}
 	total := len(b.topics[topic]) + len(b.scopedTopics[topic])
 	var firstHooks []func(string)
 	if total == 1 {
@@ -117,6 +118,7 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 	for _, fn := range firstHooks {
 		go fn(topic)
 	}
+	b.publishConnectionEvent("subscribe", topic, total)
 	for _, msg := range replayMsgs {
 		select {
 		case ch <- msg:
@@ -128,6 +130,7 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 		var lastHooks []func(string)
 		if _, ok := b.topics[topic][ch]; ok {
 			delete(b.topics[topic], ch)
+			delete(b.subscriberMeta, ch)
 			close(ch)
 			total := len(b.topics[topic]) + len(b.scopedTopics[topic])
 			if total == 0 {
@@ -144,5 +147,6 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 		for _, fn := range lastHooks {
 			go fn(topic)
 		}
+		b.publishConnectionEvent("unsubscribe", topic, -1)
 	}
 }

--- a/subscriber.go
+++ b/subscriber.go
@@ -1,0 +1,164 @@
+package tavern
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// SubscriberInfo describes an active subscriber.
+type SubscriberInfo struct {
+	// ID is the caller-provided identifier (empty if not set).
+	ID string
+	// Topic is the topic this subscriber is on.
+	Topic string
+	// Scope is the scope key (empty for unscoped subscribers).
+	Scope string
+	// ConnectedAt is when the subscription was created.
+	ConnectedAt time.Time
+	// Meta is caller-provided key-value metadata.
+	Meta map[string]string
+}
+
+// SubscribeMeta holds optional metadata for [SSEBroker.SubscribeWithMeta].
+type SubscribeMeta struct {
+	// ID is an identifier for this subscriber (e.g., session ID, user ID).
+	ID string
+	// Meta is arbitrary key-value metadata.
+	Meta map[string]string
+}
+
+// SubscribeWithMeta registers a subscriber with optional metadata.
+// Behaves like [SSEBroker.Subscribe] but attaches metadata queryable
+// via [SSEBroker.Subscribers].
+func (b *SSEBroker) SubscribeWithMeta(topic string, meta SubscribeMeta) (msgs <-chan string, unsubscribe func()) {
+	ch, unsub := b.Subscribe(topic)
+	// Enrich the stored info. We need the bidirectional channel to look it up.
+	// Since Subscribe just created it and stored it in topics[topic], we can
+	// find it by iterating the topic map for the entry whose info has no ID yet
+	// and whose ConnectedAt is closest to now. However, the simplest correct
+	// approach: iterate topics[topic] looking for the channel whose SubscriberInfo
+	// matches the read-only channel we got back.
+	b.mu.Lock()
+	for c := range b.topics[topic] {
+		// A read-only channel derived from a bidirectional channel compares
+		// equal when converted. We use a type-safe comparison via the info pointer.
+		if info, ok := b.subscriberMeta[c]; ok && info.ID == "" && (<-chan string)(c) == ch {
+			info.ID = meta.ID
+			info.Meta = meta.Meta
+			break
+		}
+	}
+	b.mu.Unlock()
+	return ch, unsub
+}
+
+// Subscribers returns a snapshot of all active subscribers for the given
+// topic. The returned slice is a copy and safe to read without
+// synchronization.
+func (b *SSEBroker) Subscribers(topic string) []SubscriberInfo {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	var result []SubscriberInfo
+	for ch := range b.topics[topic] {
+		if info, ok := b.subscriberMeta[ch]; ok {
+			cp := *info
+			if info.Meta != nil {
+				cp.Meta = make(map[string]string, len(info.Meta))
+				for k, v := range info.Meta {
+					cp.Meta[k] = v
+				}
+			}
+			result = append(result, cp)
+		}
+	}
+	for ch := range b.scopedTopics[topic] {
+		if info, ok := b.subscriberMeta[ch]; ok {
+			cp := *info
+			if info.Meta != nil {
+				cp.Meta = make(map[string]string, len(info.Meta))
+				for k, v := range info.Meta {
+					cp.Meta[k] = v
+				}
+			}
+			result = append(result, cp)
+		}
+	}
+	return result
+}
+
+// Disconnect closes the subscriber channel with the given ID on the
+// given topic. Returns true if the subscriber was found and disconnected.
+func (b *SSEBroker) Disconnect(topic, subscriberID string) bool {
+	b.mu.Lock()
+	// Search unscoped subscribers.
+	for ch := range b.topics[topic] {
+		if info, ok := b.subscriberMeta[ch]; ok && info.ID == subscriberID {
+			delete(b.topics[topic], ch)
+			delete(b.subscriberMeta, ch)
+			close(ch)
+			total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+			var lastHooks []func(string)
+			if total == 0 {
+				lastHooks = b.onLast[topic]
+				b.topicEmpty[topic] = time.Now()
+			}
+			b.mu.Unlock()
+			if b.evictThreshold > 0 {
+				b.dropCountsMu.Lock()
+				delete(b.dropCounts, ch)
+				b.dropCountsMu.Unlock()
+			}
+			for _, fn := range lastHooks {
+				go fn(topic)
+			}
+			b.publishConnectionEvent("disconnect", topic, -1)
+			return true
+		}
+	}
+	// Search scoped subscribers.
+	for ch := range b.scopedTopics[topic] {
+		if info, ok := b.subscriberMeta[ch]; ok && info.ID == subscriberID {
+			delete(b.scopedTopics[topic], ch)
+			delete(b.subscriberMeta, ch)
+			close(ch)
+			total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+			var lastHooks []func(string)
+			if total == 0 {
+				lastHooks = b.onLast[topic]
+				b.topicEmpty[topic] = time.Now()
+			}
+			b.mu.Unlock()
+			if b.evictThreshold > 0 {
+				b.dropCountsMu.Lock()
+				delete(b.dropCounts, ch)
+				b.dropCountsMu.Unlock()
+			}
+			for _, fn := range lastHooks {
+				go fn(topic)
+			}
+			b.publishConnectionEvent("disconnect", topic, -1)
+			return true
+		}
+	}
+	b.mu.Unlock()
+	return false
+}
+
+// publishConnectionEvent publishes a JSON event to the meta topic.
+// Skips if connection events are disabled or if the topic IS the meta topic.
+func (b *SSEBroker) publishConnectionEvent(event, topic string, subCount int) {
+	if b.connEventsTopic == "" || topic == b.connEventsTopic {
+		return
+	}
+	if subCount < 0 {
+		b.mu.RLock()
+		subCount = len(b.topics[topic]) + len(b.scopedTopics[topic])
+		b.mu.RUnlock()
+	}
+	msg, _ := json.Marshal(map[string]any{
+		"event":       event,
+		"topic":       topic,
+		"subscribers": subCount,
+	})
+	b.Publish(b.connEventsTopic, string(msg))
+}

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -1,0 +1,288 @@
+package tavern
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubscribeWithMeta_StoresInfo(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeWithMeta("dash", SubscribeMeta{
+		ID:   "sess-123",
+		Meta: map[string]string{"user": "alice"},
+	})
+	defer unsub()
+
+	subs := b.Subscribers("dash")
+	require.Len(t, subs, 1)
+	assert.Equal(t, "sess-123", subs[0].ID)
+	assert.Equal(t, "dash", subs[0].Topic)
+	assert.Equal(t, "alice", subs[0].Meta["user"])
+	assert.False(t, subs[0].ConnectedAt.IsZero())
+}
+
+func TestSubscribers_IncludesRegularSubscribers(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.Subscribe("t")
+	defer unsub()
+
+	subs := b.Subscribers("t")
+	require.Len(t, subs, 1)
+	assert.Equal(t, "t", subs[0].Topic)
+	assert.Empty(t, subs[0].ID)
+}
+
+func TestSubscribers_IncludesScopedSubscribers(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeScoped("t", "user-1")
+	defer unsub()
+
+	subs := b.Subscribers("t")
+	require.Len(t, subs, 1)
+	assert.Equal(t, "user-1", subs[0].Scope)
+}
+
+func TestSubscribers_IncludesSubscribeFromID(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeFromID("t", "")
+	defer unsub()
+
+	subs := b.Subscribers("t")
+	require.Len(t, subs, 1)
+	assert.Equal(t, "t", subs[0].Topic)
+}
+
+func TestSubscribers_MetaCopied(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeWithMeta("t", SubscribeMeta{
+		ID:   "s1",
+		Meta: map[string]string{"key": "val"},
+	})
+	defer unsub()
+
+	subs := b.Subscribers("t")
+	require.Len(t, subs, 1)
+	// Mutating the returned copy should not affect the stored info.
+	subs[0].Meta["key"] = "changed"
+	subs2 := b.Subscribers("t")
+	assert.Equal(t, "val", subs2[0].Meta["key"])
+}
+
+func TestDisconnect_ByID(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, _ := b.SubscribeWithMeta("t", SubscribeMeta{ID: "sess-1"})
+
+	ok := b.Disconnect("t", "sess-1")
+	assert.True(t, ok)
+
+	// Channel should be closed.
+	_, open := <-ch
+	assert.False(t, open)
+	assert.False(t, b.HasSubscribers("t"))
+}
+
+func TestDisconnect_NotFound(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.Subscribe("t")
+	defer unsub()
+
+	ok := b.Disconnect("t", "nonexistent")
+	assert.False(t, ok)
+	assert.True(t, b.HasSubscribers("t"))
+}
+
+func TestDisconnect_ScopedSubscriber(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	// SubscribeScoped doesn't set an ID, so use SubscribeWithMeta for a scoped
+	// subscriber that has an ID we can disconnect by.
+	ch, _ := b.SubscribeWithMeta("t", SubscribeMeta{ID: "scoped-1"})
+
+	ok := b.Disconnect("t", "scoped-1")
+	assert.True(t, ok)
+
+	_, open := <-ch
+	assert.False(t, open)
+}
+
+func TestSubscribers_EmptyTopic(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	subs := b.Subscribers("nonexistent")
+	assert.Empty(t, subs)
+}
+
+func TestConnectionEvents_Subscribe(t *testing.T) {
+	b := NewSSEBroker(WithConnectionEvents("_meta"))
+	defer b.Close()
+
+	metaCh, metaUnsub := b.Subscribe("_meta")
+	defer metaUnsub()
+
+	_, unsub := b.Subscribe("dashboard")
+	defer unsub()
+
+	select {
+	case msg := <-metaCh:
+		assert.Contains(t, msg, `"subscribe"`)
+		assert.Contains(t, msg, `"dashboard"`)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for connection event")
+	}
+}
+
+func TestConnectionEvents_Unsubscribe(t *testing.T) {
+	b := NewSSEBroker(WithConnectionEvents("_meta"))
+	defer b.Close()
+
+	metaCh, metaUnsub := b.Subscribe("_meta")
+	defer metaUnsub()
+
+	_, unsub := b.Subscribe("dashboard")
+
+	// Drain the subscribe event.
+	select {
+	case <-metaCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+
+	unsub()
+
+	select {
+	case msg := <-metaCh:
+		assert.Contains(t, msg, `"unsubscribe"`)
+		assert.Contains(t, msg, `"dashboard"`)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for unsubscribe event")
+	}
+}
+
+func TestConnectionEvents_NoRecursion(t *testing.T) {
+	b := NewSSEBroker(WithConnectionEvents("_meta"))
+	defer b.Close()
+
+	// Subscribing to _meta itself should NOT generate a recursive event.
+	metaCh, unsub := b.Subscribe("_meta")
+	defer unsub()
+
+	select {
+	case msg := <-metaCh:
+		t.Fatalf("should not receive event for meta topic subscription: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+		// correct
+	}
+}
+
+func TestConnectionEvents_Disabled(t *testing.T) {
+	b := NewSSEBroker() // no WithConnectionEvents
+	defer b.Close()
+
+	_, unsub := b.Subscribe("t")
+	defer unsub()
+
+	// Should not panic — events just aren't published.
+}
+
+func TestConnectionEvents_Disconnect(t *testing.T) {
+	b := NewSSEBroker(WithConnectionEvents("_meta"))
+	defer b.Close()
+
+	metaCh, metaUnsub := b.Subscribe("_meta")
+	defer metaUnsub()
+
+	_, _ = b.SubscribeWithMeta("dashboard", SubscribeMeta{ID: "s1"})
+
+	// Drain subscribe event.
+	select {
+	case <-metaCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+
+	b.Disconnect("dashboard", "s1")
+
+	select {
+	case msg := <-metaCh:
+		assert.Contains(t, msg, `"disconnect"`)
+		assert.Contains(t, msg, `"dashboard"`)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for disconnect event")
+	}
+}
+
+func TestDisconnect_FiresLastHooks(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	fired := make(chan string, 1)
+	b.OnLastUnsubscribe("t", func(topic string) { fired <- topic })
+
+	b.SubscribeWithMeta("t", SubscribeMeta{ID: "x"})
+	b.Disconnect("t", "x")
+
+	select {
+	case got := <-fired:
+		assert.Equal(t, "t", got)
+	case <-time.After(time.Second):
+		t.Fatal("hook did not fire")
+	}
+}
+
+func TestSubscribers_MultipleSubscribers(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub1 := b.SubscribeWithMeta("t", SubscribeMeta{ID: "a"})
+	defer unsub1()
+	_, unsub2 := b.SubscribeWithMeta("t", SubscribeMeta{ID: "b"})
+	defer unsub2()
+	_, unsub3 := b.SubscribeScoped("t", "scope-1")
+	defer unsub3()
+
+	subs := b.Subscribers("t")
+	assert.Len(t, subs, 3)
+
+	ids := map[string]bool{}
+	for _, s := range subs {
+		if s.ID != "" {
+			ids[s.ID] = true
+		}
+	}
+	assert.True(t, ids["a"])
+	assert.True(t, ids["b"])
+}
+
+func TestSubscribers_UnsubscribeRemovesInfo(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeWithMeta("t", SubscribeMeta{ID: "s1"})
+
+	subs := b.Subscribers("t")
+	require.Len(t, subs, 1)
+
+	unsub()
+
+	subs = b.Subscribers("t")
+	assert.Empty(t, subs)
+}


### PR DESCRIPTION
## Summary
- **Subscriber metadata** (#62): new `SubscribeWithMeta` method attaches caller-provided ID and key-value metadata to subscribers. `Subscribers(topic)` returns a snapshot of all active subscriber info. `Disconnect(topic, id)` force-closes a subscriber by ID. All subscribe methods (Subscribe, SubscribeScoped, SubscribeFromID) now track basic info (topic, scope, connected-at) automatically.
- **Connection lifecycle events** (#63): new `WithConnectionEvents(metaTopic)` option publishes JSON events (`subscribe`, `unsubscribe`, `disconnect`) to a meta topic whenever subscribers connect or disconnect. The meta topic itself does not generate recursive events.

Closes #62, closes #63

## Test plan
- [x] `TestSubscribeWithMeta_StoresInfo` — metadata stored and queryable
- [x] `TestSubscribers_IncludesRegularSubscribers` — plain Subscribe tracked
- [x] `TestSubscribers_IncludesScopedSubscribers` — scoped subscribers tracked
- [x] `TestSubscribers_IncludesSubscribeFromID` — resume subscribers tracked
- [x] `TestSubscribers_MetaCopied` — returned info is a deep copy
- [x] `TestDisconnect_ByID` — force disconnect closes channel
- [x] `TestDisconnect_NotFound` — returns false for unknown ID
- [x] `TestDisconnect_FiresLastHooks` — OnLastUnsubscribe hooks fire
- [x] `TestConnectionEvents_Subscribe` — subscribe event published
- [x] `TestConnectionEvents_Unsubscribe` — unsubscribe event published
- [x] `TestConnectionEvents_Disconnect` — disconnect event published
- [x] `TestConnectionEvents_NoRecursion` — meta topic doesn't self-trigger
- [x] `TestConnectionEvents_Disabled` — no panic when events disabled
- [x] All existing tests pass with `-race`