### PR TITLE
fix: resolve golangci-lint errors

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -37,7 +37,7 @@ func TestSSEHandler_BasicStreaming(t *testing.T) {
 	b.PublishWithReplay("events", "hello")
 
 	rec := newFlushRecorder()
-	req := httptest.NewRequest("GET", "/sse", nil)
+	req := httptest.NewRequest("GET", "/sse", http.NoBody)
 	ctx, cancel := contextWithCancel(req)
 	req = req.WithContext(ctx)
 
@@ -70,7 +70,7 @@ func TestSSEHandler_LastEventID(t *testing.T) {
 	handler := b.SSEHandler("events")
 
 	rec := newFlushRecorder()
-	req := httptest.NewRequest("GET", "/sse", nil)
+	req := httptest.NewRequest("GET", "/sse", http.NoBody)
 	req.Header.Set("Last-Event-ID", "1") // should replay 2 and 3
 	ctx, cancel := contextWithCancel(req)
 	req = req.WithContext(ctx)
@@ -104,7 +104,7 @@ func TestSSEHandler_CustomWriter(t *testing.T) {
 	b.PublishWithReplay("events", "custom-msg")
 
 	rec := newFlushRecorder()
-	req := httptest.NewRequest("GET", "/sse", nil)
+	req := httptest.NewRequest("GET", "/sse", http.NoBody)
 	ctx, cancel := contextWithCancel(req)
 	req = req.WithContext(ctx)
 
@@ -128,7 +128,7 @@ func TestSSEHandler_BrokerClose(t *testing.T) {
 	handler := b.SSEHandler("events")
 
 	rec := newFlushRecorder()
-	req := httptest.NewRequest("GET", "/sse", nil)
+	req := httptest.NewRequest("GET", "/sse", http.NoBody)
 
 	done := make(chan struct{})
 	go func() {
@@ -156,7 +156,7 @@ func TestSSEHandler_Flushes(t *testing.T) {
 	b.PublishWithReplay("events", "flush-test")
 
 	rec := newFlushRecorder()
-	req := httptest.NewRequest("GET", "/sse", nil)
+	req := httptest.NewRequest("GET", "/sse", http.NoBody)
 	ctx, cancel := contextWithCancel(req)
 	req = req.WithContext(ctx)
 

--- a/multi_test.go
+++ b/multi_test.go
@@ -70,12 +70,13 @@ func TestSubscribeMulti_LifecycleHooks(t *testing.T) {
 	defer unsub()
 
 	topics := make([]string, 0, 2)
+loop:
 	for range 2 {
 		select {
 		case topic := <-fired:
 			topics = append(topics, topic)
 		case <-time.After(time.Second):
-			break
+			break loop
 		}
 	}
 	sort.Strings(topics)

--- a/subscriber.go
+++ b/subscriber.go
@@ -42,7 +42,8 @@ func (b *SSEBroker) SubscribeWithMeta(topic string, meta SubscribeMeta) (msgs <-
 	for c := range b.topics[topic] {
 		// A read-only channel derived from a bidirectional channel compares
 		// equal when converted. We use a type-safe comparison via the info pointer.
-		if info, ok := b.subscriberMeta[c]; ok && info.ID == "" && (<-chan string)(c) == ch {
+		readOnly := (<-chan string)(c) //nolint:gocritic // parens required for channel type conversion
+		if info, ok := b.subscriberMeta[c]; ok && info.ID == "" && readOnly == ch {
 			info.ID = meta.ID
 			info.Meta = meta.Meta
 			break
@@ -92,53 +93,57 @@ func (b *SSEBroker) Disconnect(topic, subscriberID string) bool {
 	b.mu.Lock()
 	// Search unscoped subscribers.
 	for ch := range b.topics[topic] {
-		if info, ok := b.subscriberMeta[ch]; ok && info.ID == subscriberID {
-			delete(b.topics[topic], ch)
-			delete(b.subscriberMeta, ch)
-			close(ch)
-			total := len(b.topics[topic]) + len(b.scopedTopics[topic])
-			var lastHooks []func(string)
-			if total == 0 {
-				lastHooks = b.onLast[topic]
-				b.topicEmpty[topic] = time.Now()
-			}
-			b.mu.Unlock()
-			if b.evictThreshold > 0 {
-				b.dropCountsMu.Lock()
-				delete(b.dropCounts, ch)
-				b.dropCountsMu.Unlock()
-			}
-			for _, fn := range lastHooks {
-				go fn(topic)
-			}
-			b.publishConnectionEvent("disconnect", topic, -1)
-			return true
+		info, ok := b.subscriberMeta[ch]
+		if !ok || info.ID != subscriberID {
+			continue
 		}
+		delete(b.topics[topic], ch)
+		delete(b.subscriberMeta, ch)
+		close(ch)
+		total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+		var lastHooks []func(string)
+		if total == 0 {
+			lastHooks = b.onLast[topic]
+			b.topicEmpty[topic] = time.Now()
+		}
+		b.mu.Unlock()
+		if b.evictThreshold > 0 {
+			b.dropCountsMu.Lock()
+			delete(b.dropCounts, ch)
+			b.dropCountsMu.Unlock()
+		}
+		for _, fn := range lastHooks {
+			go fn(topic)
+		}
+		b.publishConnectionEvent("disconnect", topic, -1)
+		return true
 	}
 	// Search scoped subscribers.
 	for ch := range b.scopedTopics[topic] {
-		if info, ok := b.subscriberMeta[ch]; ok && info.ID == subscriberID {
-			delete(b.scopedTopics[topic], ch)
-			delete(b.subscriberMeta, ch)
-			close(ch)
-			total := len(b.topics[topic]) + len(b.scopedTopics[topic])
-			var lastHooks []func(string)
-			if total == 0 {
-				lastHooks = b.onLast[topic]
-				b.topicEmpty[topic] = time.Now()
-			}
-			b.mu.Unlock()
-			if b.evictThreshold > 0 {
-				b.dropCountsMu.Lock()
-				delete(b.dropCounts, ch)
-				b.dropCountsMu.Unlock()
-			}
-			for _, fn := range lastHooks {
-				go fn(topic)
-			}
-			b.publishConnectionEvent("disconnect", topic, -1)
-			return true
+		info, ok := b.subscriberMeta[ch]
+		if !ok || info.ID != subscriberID {
+			continue
 		}
+		delete(b.scopedTopics[topic], ch)
+		delete(b.subscriberMeta, ch)
+		close(ch)
+		total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+		var lastHooks []func(string)
+		if total == 0 {
+			lastHooks = b.onLast[topic]
+			b.topicEmpty[topic] = time.Now()
+		}
+		b.mu.Unlock()
+		if b.evictThreshold > 0 {
+			b.dropCountsMu.Lock()
+			delete(b.dropCounts, ch)
+			b.dropCountsMu.Unlock()
+		}
+		for _, fn := range lastHooks {
+			go fn(topic)
+		}
+		b.publishConnectionEvent("disconnect", topic, -1)
+		return true
 	}
 	b.mu.Unlock()
 	return false

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -198,7 +198,7 @@ func TestConnectionEvents_Disabled(t *testing.T) {
 	defer b.Close()
 
 	_, unsub := b.Subscribe("t")
-	defer unsub()
+	unsub()
 
 	// Should not panic — events just aren't published.
 }


### PR DESCRIPTION
## Summary
- Replace `nil` with `http.NoBody` in handler_test.go (3 occurrences)
- Extract channel type conversion to variable to avoid false-positive typeUnparen lint in subscriber.go
- Reduce nesting in Disconnect loops by inverting conditions with `continue` in subscriber.go
- Remove unnecessary `defer` before return in subscriber_test.go
- Add labeled break to escape outer loop from select in multi_test.go

## Test plan
- [x] `golangci-lint run ./...` passes with 0 issues
- [x] `go test ./... -race` passes