### PR TITLE
feat: batch/transaction API for buffered publish

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1,0 +1,157 @@
+package tavern
+
+import "sync"
+
+// publishOp represents a buffered publish operation.
+type publishOp struct {
+	topic     string
+	scope     string // empty for unscoped Publish
+	msg       string
+	scoped    bool // true for PublishTo/PublishOOBTo
+}
+
+// PublishBatch buffers publish operations and flushes them as a single write
+// per subscriber. Create one via [SSEBroker.Batch]. Multiple goroutines may
+// call Publish/PublishTo concurrently, but Flush and Discard must be called
+// at most once and not concurrently with publishes.
+type PublishBatch struct {
+	broker *SSEBroker
+	mu     sync.Mutex
+	ops    []publishOp
+}
+
+// Batch creates a new [PublishBatch] that buffers publish calls against this
+// broker. Call [PublishBatch.Flush] to send all buffered messages or
+// [PublishBatch.Discard] to throw them away.
+func (b *SSEBroker) Batch() *PublishBatch {
+	return &PublishBatch{broker: b}
+}
+
+// Publish buffers a message for all subscribers of the given topic.
+func (pb *PublishBatch) Publish(topic, msg string) {
+	pb.mu.Lock()
+	pb.ops = append(pb.ops, publishOp{topic: topic, msg: msg})
+	pb.mu.Unlock()
+}
+
+// PublishTo buffers a scoped message for subscribers matching the scope.
+func (pb *PublishBatch) PublishTo(topic, scope, msg string) {
+	pb.mu.Lock()
+	pb.ops = append(pb.ops, publishOp{topic: topic, scope: scope, msg: msg, scoped: true})
+	pb.mu.Unlock()
+}
+
+// PublishOOB buffers OOB fragments for all subscribers of the given topic.
+func (pb *PublishBatch) PublishOOB(topic string, fragments ...Fragment) {
+	pb.Publish(topic, RenderFragments(fragments...))
+}
+
+// PublishOOBTo buffers OOB fragments for scoped subscribers matching the scope.
+func (pb *PublishBatch) PublishOOBTo(topic, scope string, fragments ...Fragment) {
+	pb.PublishTo(topic, scope, RenderFragments(fragments...))
+}
+
+// Discard clears all buffered operations without sending anything.
+func (pb *PublishBatch) Discard() {
+	pb.mu.Lock()
+	pb.ops = nil
+	pb.mu.Unlock()
+}
+
+// Flush sends all buffered messages. For each subscriber, messages are
+// concatenated into a single channel send to minimise SSE writes. Flush
+// should be called at most once; the batch is empty afterwards.
+func (pb *PublishBatch) Flush() {
+	pb.mu.Lock()
+	ops := pb.ops
+	pb.ops = nil
+	pb.mu.Unlock()
+
+	if len(ops) == 0 {
+		return
+	}
+
+	b := pb.broker
+
+	// Build a map of channel → concatenated message.
+	// We need to resolve each op to its target channels.
+	chanMsgs := make(map[chan string]string)
+
+	// Track topics touched for metrics.
+	type metricsAcc struct {
+		sent    int
+		dropped int
+	}
+	topicMetrics := make(map[string]*metricsAcc)
+
+	b.mu.RLock()
+	for _, op := range ops {
+		if op.scoped {
+			scopedSubs := b.scopedTopics[op.topic]
+			for ch, sub := range scopedSubs {
+				if sub.scope == op.scope {
+					chanMsgs[ch] += op.msg
+				}
+			}
+		} else {
+			for ch := range b.topics[op.topic] {
+				chanMsgs[ch] += op.msg
+			}
+		}
+	}
+	b.mu.RUnlock()
+
+	// Now send one concatenated message per channel.
+	for ch, msg := range chanMsgs {
+		// Determine topic for metrics/eviction by looking up subscriber info.
+		topic := ""
+		if b.metrics != nil || b.evictThreshold > 0 {
+			b.mu.RLock()
+			if info, ok := b.subscriberMeta[ch]; ok {
+				topic = info.Topic
+			}
+			b.mu.RUnlock()
+		}
+
+		func() {
+			defer func() { _ = recover() }()
+			if b.send(ch, msg) {
+				if b.evictThreshold > 0 {
+					b.resetDropCount(ch)
+				}
+				if b.metrics != nil && topic != "" {
+					acc := topicMetrics[topic]
+					if acc == nil {
+						acc = &metricsAcc{}
+						topicMetrics[topic] = acc
+					}
+					acc.sent++
+				}
+			} else {
+				b.drops.Add(1)
+				if b.evictThreshold > 0 && topic != "" {
+					if b.incrementDropCount(ch) >= int64(b.evictThreshold) {
+						b.evictSubscriber(topic, ch)
+					}
+				}
+				if b.metrics != nil && topic != "" {
+					acc := topicMetrics[topic]
+					if acc == nil {
+						acc = &metricsAcc{}
+						topicMetrics[topic] = acc
+					}
+					acc.dropped++
+				}
+			}
+		}()
+	}
+
+	// Update metrics.
+	if b.metrics != nil {
+		for topic, acc := range topicMetrics {
+			tc := b.metrics.counter(topic)
+			tc.published.Add(int64(acc.sent))
+			tc.dropped.Add(int64(acc.dropped))
+		}
+	}
+}

--- a/batch_test.go
+++ b/batch_test.go
@@ -1,0 +1,399 @@
+package tavern
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func recv(ch <-chan string, timeout time.Duration) (string, bool) {
+	select {
+	case msg := <-ch:
+		return msg, true
+	case <-time.After(timeout):
+		return "", false
+	}
+}
+
+func TestBatchPublish(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	batch := b.Batch()
+	batch.Publish("t", "one")
+	batch.Publish("t", "two")
+	batch.Flush()
+
+	msg, ok := recv(ch, time.Second)
+	require.True(t, ok, "expected a message")
+	assert.Contains(t, msg, "one")
+	assert.Contains(t, msg, "two")
+
+	// Only one channel send should have happened.
+	select {
+	case <-ch:
+		t.Fatal("expected exactly one channel send, got a second")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestBatchPublishOOB(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	batch := b.Batch()
+	batch.PublishOOB("t", Replace("el-1", "<p>a</p>"))
+	batch.PublishOOB("t", Replace("el-2", "<p>b</p>"))
+	batch.Flush()
+
+	msg, ok := recv(ch, time.Second)
+	require.True(t, ok)
+	assert.Contains(t, msg, `id="el-1"`)
+	assert.Contains(t, msg, `id="el-2"`)
+
+	select {
+	case <-ch:
+		t.Fatal("expected exactly one send")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestBatchPublishToScoped(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch1, unsub1 := b.SubscribeScoped("t", "user:1")
+	defer unsub1()
+	ch2, unsub2 := b.SubscribeScoped("t", "user:2")
+	defer unsub2()
+
+	batch := b.Batch()
+	batch.PublishTo("t", "user:1", "for-user-1")
+	batch.PublishTo("t", "user:2", "for-user-2")
+	batch.Flush()
+
+	msg1, ok := recv(ch1, time.Second)
+	require.True(t, ok)
+	assert.Equal(t, "for-user-1", msg1)
+
+	msg2, ok := recv(ch2, time.Second)
+	require.True(t, ok)
+	assert.Equal(t, "for-user-2", msg2)
+}
+
+func TestBatchPublishOOBToScoped(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeScoped("t", "admin")
+	defer unsub()
+
+	batch := b.Batch()
+	batch.PublishOOBTo("t", "admin", Replace("stats", "<b>42</b>"))
+	batch.PublishOOBTo("t", "admin", Append("log", "<li>event</li>"))
+	batch.Flush()
+
+	msg, ok := recv(ch, time.Second)
+	require.True(t, ok)
+	assert.Contains(t, msg, `id="stats"`)
+	assert.Contains(t, msg, `id="log"`)
+}
+
+func TestBatchDiscard(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	batch := b.Batch()
+	batch.Publish("t", "should-not-arrive")
+	batch.Discard()
+	batch.Flush() // flush after discard should be no-op
+
+	select {
+	case msg := <-ch:
+		t.Fatalf("expected no message, got %q", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestBatchEmptyFlush(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	// Flush with no buffered ops should not panic.
+	batch := b.Batch()
+	batch.Flush()
+}
+
+func TestBatchNoSubscribers(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	// Publishing to a topic with no subscribers should not panic.
+	batch := b.Batch()
+	batch.Publish("ghost", "hello")
+	batch.Flush()
+}
+
+func TestBatchMixedTopics(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	chA, unsubA := b.Subscribe("topicA")
+	defer unsubA()
+	chB, unsubB := b.Subscribe("topicB")
+	defer unsubB()
+
+	batch := b.Batch()
+	batch.Publish("topicA", "a1")
+	batch.Publish("topicB", "b1")
+	batch.Publish("topicA", "a2")
+	batch.Flush()
+
+	msgA, ok := recv(chA, time.Second)
+	require.True(t, ok)
+	assert.Contains(t, msgA, "a1")
+	assert.Contains(t, msgA, "a2")
+	assert.NotContains(t, msgA, "b1")
+
+	msgB, ok := recv(chB, time.Second)
+	require.True(t, ok)
+	assert.Equal(t, "b1", msgB)
+}
+
+func TestBatchConcurrentPublish(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	batch := b.Batch()
+	var wg sync.WaitGroup
+	for i := range 10 {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			batch.Publish("t", strings.Repeat("x", n+1))
+		}(i)
+	}
+	wg.Wait()
+	batch.Flush()
+
+	msg, ok := recv(ch, time.Second)
+	require.True(t, ok)
+	// All 10 publishes should be concatenated into one send.
+	// Total length = 1+2+3+...+10 = 55
+	assert.Len(t, msg, 55)
+
+	select {
+	case <-ch:
+		t.Fatal("expected exactly one send")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestBatchMixedScopedAndUnscoped(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	// Unscoped subscriber gets Publish but not PublishTo.
+	chAll, unsubAll := b.Subscribe("t")
+	defer unsubAll()
+
+	// Scoped subscriber gets PublishTo but not Publish.
+	chScoped, unsubScoped := b.SubscribeScoped("t", "s1")
+	defer unsubScoped()
+
+	batch := b.Batch()
+	batch.Publish("t", "broadcast")
+	batch.PublishTo("t", "s1", "scoped-msg")
+	batch.Flush()
+
+	msgAll, ok := recv(chAll, time.Second)
+	require.True(t, ok)
+	assert.Equal(t, "broadcast", msgAll)
+
+	msgScoped, ok := recv(chScoped, time.Second)
+	require.True(t, ok)
+	assert.Equal(t, "scoped-msg", msgScoped)
+}
+
+func TestBatchMultipleSubscribersSameTopic(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	const n = 5
+	channels := make([]<-chan string, n)
+	unsubs := make([]func(), n)
+	for i := range n {
+		channels[i], unsubs[i] = b.Subscribe("t")
+	}
+	t.Cleanup(func() {
+		for i := range n {
+			unsubs[i]()
+		}
+	})
+
+	batch := b.Batch()
+	batch.Publish("t", "hello")
+	batch.Publish("t", " world")
+	batch.Flush()
+
+	for i := range n {
+		msg, ok := recv(channels[i], time.Second)
+		require.True(t, ok, "subscriber %d should receive message", i)
+		assert.Equal(t, "hello world", msg)
+	}
+}
+
+func TestBatchScopedIsolation(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch1, unsub1 := b.SubscribeScoped("t", "a")
+	defer unsub1()
+	ch2, unsub2 := b.SubscribeScoped("t", "b")
+	defer unsub2()
+
+	batch := b.Batch()
+	batch.PublishTo("t", "a", "only-a")
+	batch.Flush()
+
+	msg, ok := recv(ch1, time.Second)
+	require.True(t, ok)
+	assert.Equal(t, "only-a", msg)
+
+	select {
+	case msg := <-ch2:
+		t.Fatalf("scope b should not receive message, got %q", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestBatchOOBConcatenation(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	batch := b.Batch()
+	batch.PublishOOB("t", Replace("a", "<p>1</p>"))
+	batch.PublishOOB("t", Delete("b"))
+	batch.PublishOOB("t", Append("c", "<li>new</li>"))
+	batch.Flush()
+
+	msg, ok := recv(ch, time.Second)
+	require.True(t, ok)
+
+	// All three fragments in a single message.
+	assert.Contains(t, msg, `id="a"`)
+	assert.Contains(t, msg, `id="b"`)
+	assert.Contains(t, msg, `id="c"`)
+	assert.Contains(t, msg, `hx-swap-oob="delete"`)
+	assert.Contains(t, msg, `hx-swap-oob="outerHTML"`)
+	assert.Contains(t, msg, `hx-swap-oob="beforeend"`)
+}
+
+func TestBatchFlushOrder(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	batch := b.Batch()
+	batch.Publish("t", "A")
+	batch.Publish("t", "B")
+	batch.Publish("t", "C")
+	batch.Flush()
+
+	msg, ok := recv(ch, time.Second)
+	require.True(t, ok)
+	// Messages are concatenated in order.
+	assert.Equal(t, "ABC", msg)
+}
+
+func TestBatchScopedMultipleOpsToSameScope(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeScoped("t", "u1")
+	defer unsub()
+
+	batch := b.Batch()
+	batch.PublishTo("t", "u1", "first")
+	batch.PublishTo("t", "u1", "second")
+	batch.Flush()
+
+	msg, ok := recv(ch, time.Second)
+	require.True(t, ok)
+	assert.Equal(t, "firstsecond", msg)
+
+	select {
+	case <-ch:
+		t.Fatal("expected exactly one send")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestBatchDropCountsAsSingle(t *testing.T) {
+	// Use a tiny buffer so we can test the drop path.
+	b := NewSSEBroker(WithBufferSize(1))
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	// Fill the buffer so the batch flush will drop.
+	b.Publish("t", "fill")
+
+	batch := b.Batch()
+	batch.Publish("t", "will-drop")
+	batch.Flush()
+
+	// Drain the original fill message.
+	msg, ok := recv(ch, time.Second)
+	require.True(t, ok)
+	assert.Equal(t, "fill", msg)
+
+	// The batch message was dropped; verify drop counter incremented.
+	assert.GreaterOrEqual(t, b.PublishDrops(), int64(1))
+}
+
+func TestBatchMultipleScopedSubscribersSameScope(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch1, unsub1 := b.SubscribeScoped("t", "team")
+	defer unsub1()
+	ch2, unsub2 := b.SubscribeScoped("t", "team")
+	defer unsub2()
+
+	batch := b.Batch()
+	batch.PublishTo("t", "team", "msg")
+	batch.Flush()
+
+	msgs := make([]string, 2)
+	var ok bool
+	msgs[0], ok = recv(ch1, time.Second)
+	require.True(t, ok)
+	msgs[1], ok = recv(ch2, time.Second)
+	require.True(t, ok)
+	sort.Strings(msgs)
+	assert.Equal(t, []string{"msg", "msg"}, msgs)
+}


### PR DESCRIPTION
## Summary

- Adds `PublishBatch` type with `Publish`, `PublishTo`, `PublishOOB`, `PublishOOBTo`, `Flush`, and `Discard` methods
- `Flush()` concatenates all buffered messages into a single channel send per subscriber, reducing SSE writes for atomic multi-update scenarios
- Thread-safe for concurrent publishes; integrates with existing metrics, drop counting, and slow-subscriber eviction

## Test plan

- [x] Basic batch publish (multiple messages concatenated into one send)
- [x] OOB fragment batching (multiple fragments in one SSE data field)
- [x] Scoped publish (`PublishTo` / `PublishOOBTo`) with correct isolation
- [x] Mixed scoped and unscoped in same batch
- [x] `Discard()` prevents delivery
- [x] Empty flush (no-op, no panic)
- [x] Flush to topic with no subscribers (no panic)
- [x] Concurrent publish to batch from multiple goroutines
- [x] Drop counting when subscriber buffer is full
- [x] Multiple subscribers on same topic each get concatenated message
- [x] Message ordering preserved within concatenation
- [x] `golangci-lint run ./...` passes
- [x] `go test ./...` passes

Closes #83