### PR TITLE
feat: named topic groups with single SSE handler

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -52,6 +52,10 @@ type SSEBroker struct {
 	onReplayGap       map[string][]ReplayGapCallback  // topic → gap callbacks
 	replayGapStrategy map[string]GapStrategy          // topic → gap strategy
 	replayGapSnapshot map[string]func() string        // topic → snapshot func for gap fallback
+	groups            map[string]*groupDef           // static topic groups
+	groupsMu          sync.RWMutex                   // protects groups
+	dynGroups         map[string]*dynamicGroupDef    // dynamic topic groups
+	dynGroupsMu       sync.RWMutex                   // protects dynGroups
 }
 
 // Topic name constants are conventions for common real-time use cases.
@@ -170,6 +174,7 @@ func NewSSEBroker(opts ...BrokerOption) *SSEBroker {
 	for _, opt := range opts {
 		opt(b)
 	}
+	initGroupFields(b)
 	b.debounce.timers = make(map[string]*debounceEntry)
 	b.throttle.state = make(map[string]*throttleEntry)
 	if b.evictThreshold > 0 {

--- a/group.go
+++ b/group.go
@@ -1,0 +1,154 @@
+package tavern
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// groupDef is a static topic group definition.
+type groupDef struct {
+	topics []string
+}
+
+// dynamicGroupDef is a dynamic topic group evaluated per-request.
+type dynamicGroupDef struct {
+	fn func(r *http.Request) []string
+}
+
+// groupHandler serves a multiplexed SSE stream for a set of topics.
+type groupHandler struct {
+	broker *SSEBroker
+	topics []string
+	writer SSEWriterFunc
+}
+
+// dynamicGroupHandler serves a multiplexed SSE stream for topics resolved per-request.
+type dynamicGroupHandler struct {
+	broker *SSEBroker
+	fn     func(r *http.Request) []string
+	writer SSEWriterFunc
+}
+
+// DefineGroup registers a named static topic group. The group can later be
+// served via [SSEBroker.GroupHandler]. Defining a group with the same name
+// again replaces the previous definition.
+func (b *SSEBroker) DefineGroup(name string, topics []string) {
+	b.groupsMu.Lock()
+	defer b.groupsMu.Unlock()
+	cp := make([]string, len(topics))
+	copy(cp, topics)
+	b.groups[name] = &groupDef{topics: cp}
+}
+
+// GroupHandler returns an [http.Handler] that streams SSE messages for all
+// topics in the named static group. Each message is formatted with the topic
+// as the SSE event type and the published data as the data field.
+//
+// GroupHandler accepts the same [SSEHandlerOption] values as [SSEBroker.SSEHandler].
+// If the group name has not been defined, the handler responds with 404.
+func (b *SSEBroker) GroupHandler(name string, opts ...SSEHandlerOption) http.Handler {
+	b.groupsMu.RLock()
+	g, ok := b.groups[name]
+	b.groupsMu.RUnlock()
+	if !ok {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, fmt.Sprintf("group %q not defined", name), http.StatusNotFound)
+		})
+	}
+	h := &groupHandler{
+		broker: b,
+		topics: g.topics,
+		writer: defaultSSEWriter,
+	}
+	for _, opt := range opts {
+		adapter := &sseHandler{}
+		opt(adapter)
+		if adapter.writer != nil {
+			h.writer = adapter.writer
+		}
+	}
+	return h
+}
+
+// DynamicGroup registers a named dynamic topic group. The provided function is
+// evaluated per-request to determine which topics a given connection should
+// subscribe to. This enables per-request authorization — different users can
+// receive different topic sets from the same endpoint.
+func (b *SSEBroker) DynamicGroup(name string, fn func(r *http.Request) []string) {
+	b.dynGroupsMu.Lock()
+	defer b.dynGroupsMu.Unlock()
+	b.dynGroups[name] = &dynamicGroupDef{fn: fn}
+}
+
+// DynamicGroupHandler returns an [http.Handler] that streams SSE messages for
+// topics determined per-request by the dynamic group's function. Each message
+// is formatted with the topic as the SSE event type.
+//
+// DynamicGroupHandler accepts the same [SSEHandlerOption] values as
+// [SSEBroker.SSEHandler]. If the group name has not been defined, the handler
+// responds with 404.
+func (b *SSEBroker) DynamicGroupHandler(name string, opts ...SSEHandlerOption) http.Handler {
+	b.dynGroupsMu.RLock()
+	g, ok := b.dynGroups[name]
+	b.dynGroupsMu.RUnlock()
+	if !ok {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, fmt.Sprintf("dynamic group %q not defined", name), http.StatusNotFound)
+		})
+	}
+	h := &dynamicGroupHandler{
+		broker: b,
+		fn:     g.fn,
+		writer: defaultSSEWriter,
+	}
+	for _, opt := range opts {
+		adapter := &sseHandler{}
+		opt(adapter)
+		if adapter.writer != nil {
+			h.writer = adapter.writer
+		}
+	}
+	return h
+}
+
+func (h *groupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	serveGroupSSE(w, r, h.broker, h.topics, h.writer)
+}
+
+func (h *dynamicGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	topics := h.fn(r)
+	serveGroupSSE(w, r, h.broker, topics, h.writer)
+}
+
+// serveGroupSSE is the shared streaming loop for static and dynamic group
+// handlers. It subscribes to all topics via SubscribeMulti and writes each
+// message as an SSE event with the topic as the event type.
+func serveGroupSSE(w http.ResponseWriter, r *http.Request, broker *SSEBroker, topics []string, writer SSEWriterFunc) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	ch, unsub := broker.SubscribeMulti(topics...)
+	defer unsub()
+
+	for {
+		select {
+		case msg, ok := <-ch:
+			if !ok {
+				return // broker closed
+			}
+			sseMsg := NewSSEMessage(msg.Topic, msg.Data).String()
+			if err := writer(w, sseMsg); err != nil {
+				return // client disconnected
+			}
+		case <-r.Context().Done():
+			return // client disconnected
+		}
+	}
+}
+
+// initGroupFields initializes the group-related maps on the broker.
+func initGroupFields(b *SSEBroker) {
+	b.groups = make(map[string]*groupDef)
+	b.dynGroups = make(map[string]*dynamicGroupDef)
+}

--- a/group_test.go
+++ b/group_test.go
@@ -1,0 +1,513 @@
+package tavern
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefineGroup_Basic(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.DefineGroup("dash", []string{"metrics", "alerts"})
+
+	b.groupsMu.RLock()
+	g, ok := b.groups["dash"]
+	b.groupsMu.RUnlock()
+
+	require.True(t, ok)
+	assert.Equal(t, []string{"metrics", "alerts"}, g.topics)
+}
+
+func TestDefineGroup_ReplacePrevious(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.DefineGroup("dash", []string{"a"})
+	b.DefineGroup("dash", []string{"b", "c"})
+
+	b.groupsMu.RLock()
+	g := b.groups["dash"]
+	b.groupsMu.RUnlock()
+
+	assert.Equal(t, []string{"b", "c"}, g.topics)
+}
+
+func TestDefineGroup_CopiesSlice(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	topics := []string{"a", "b"}
+	b.DefineGroup("g", topics)
+	topics[0] = "mutated"
+
+	b.groupsMu.RLock()
+	g := b.groups["g"]
+	b.groupsMu.RUnlock()
+
+	assert.Equal(t, "a", g.topics[0], "should not be affected by mutation of original slice")
+}
+
+func TestGroupHandler_NotDefined(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	handler := b.GroupHandler("nonexistent")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/sse/group", http.NoBody)
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "not defined")
+}
+
+func TestGroupHandler_StreamsMultipleTopics(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.DefineGroup("dash", []string{"metrics", "alerts"})
+	handler := b.GroupHandler("dash")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/dash", http.NoBody)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	// Give handler time to subscribe.
+	time.Sleep(50 * time.Millisecond)
+
+	b.Publish("metrics", "cpu=42")
+	b.Publish("alerts", "disk-full")
+
+	// Wait for messages to flow through.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "event: metrics")
+	assert.Contains(t, body, "data: cpu=42")
+	assert.Contains(t, body, "event: alerts")
+	assert.Contains(t, body, "data: disk-full")
+}
+
+func TestGroupHandler_SSEHeaders(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.DefineGroup("g", []string{"a"})
+	handler := b.GroupHandler("g")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/g", http.NoBody)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	<-done
+
+	assert.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"))
+	assert.Equal(t, "no-cache", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "keep-alive", rec.Header().Get("Connection"))
+}
+
+func TestGroupHandler_CustomWriter(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	var written []string
+	b.DefineGroup("g", []string{"t"})
+	handler := b.GroupHandler("g", WithSSEWriter(func(w http.ResponseWriter, msg string) error {
+		written = append(written, msg)
+		return nil
+	}))
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/g", http.NoBody)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	b.Publish("t", "hello")
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	require.Len(t, written, 1)
+	assert.Contains(t, written[0], "event: t")
+	assert.Contains(t, written[0], "data: hello")
+}
+
+func TestGroupHandler_ConnectionCloseUnsubscribes(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.DefineGroup("g", []string{"a", "b"})
+	handler := b.GroupHandler("g")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/g", http.NoBody)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	assert.True(t, b.HasSubscribers("a"))
+	assert.True(t, b.HasSubscribers("b"))
+
+	cancel()
+	<-done
+
+	// Give unsubscribe time to propagate.
+	time.Sleep(50 * time.Millisecond)
+	assert.False(t, b.HasSubscribers("a"))
+	assert.False(t, b.HasSubscribers("b"))
+}
+
+func TestGroupHandler_LifecycleHooksPerTopic(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	firstFired := make(chan string, 3)
+	lastFired := make(chan string, 3)
+	for _, topic := range []string{"x", "y", "z"} {
+		b.OnFirstSubscriber(topic, func(t string) { firstFired <- t })
+		b.OnLastUnsubscribe(topic, func(t string) { lastFired <- t })
+	}
+
+	b.DefineGroup("g", []string{"x", "y", "z"})
+	handler := b.GroupHandler("g")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/g", http.NoBody)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	// Collect OnFirstSubscriber fires.
+	firstTopics := collectTopics(t, firstFired, 3, time.Second)
+	assert.ElementsMatch(t, []string{"x", "y", "z"}, firstTopics)
+
+	cancel()
+	<-done
+
+	// Collect OnLastUnsubscribe fires.
+	lastTopics := collectTopics(t, lastFired, 3, time.Second)
+	assert.ElementsMatch(t, []string{"x", "y", "z"}, lastTopics)
+}
+
+func TestGroupHandler_BrokerClose(t *testing.T) {
+	b := NewSSEBroker()
+
+	b.DefineGroup("g", []string{"a"})
+	handler := b.GroupHandler("g")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/g", http.NoBody)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	b.Close()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not return after broker close")
+	}
+}
+
+func TestDynamicGroup_Basic(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.DynamicGroup("user-dash", func(_ *http.Request) []string {
+		return []string{"metrics", "alerts"}
+	})
+
+	handler := b.DynamicGroupHandler("user-dash")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/user-dash", http.NoBody)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	b.Publish("metrics", "cpu=99")
+	b.Publish("alerts", "warning")
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "event: metrics")
+	assert.Contains(t, body, "data: cpu=99")
+	assert.Contains(t, body, "event: alerts")
+	assert.Contains(t, body, "data: warning")
+}
+
+func TestDynamicGroupHandler_NotDefined(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	handler := b.DynamicGroupHandler("nonexistent")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/sse/dyn", http.NoBody)
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "not defined")
+}
+
+func TestDynamicGroup_PerRequestAuthorization(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.DynamicGroup("auth-dash", func(r *http.Request) []string {
+		topics := []string{"public"}
+		if r.Header.Get("X-Admin") == "true" {
+			topics = append(topics, "admin-only")
+		}
+		return topics
+	})
+
+	// Admin request — should see both topics.
+	handler := b.DynamicGroupHandler("auth-dash")
+
+	adminRec := newFlushRecorder()
+	adminReq := httptest.NewRequest("GET", "/sse/dash", http.NoBody)
+	adminReq.Header.Set("X-Admin", "true")
+	adminCtx, adminCancel := contextWithCancel(adminReq)
+	adminReq = adminReq.WithContext(adminCtx)
+
+	adminDone := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(adminRec, adminReq)
+		close(adminDone)
+	}()
+
+	// Regular request — should only see public.
+	userRec := newFlushRecorder()
+	userReq := httptest.NewRequest("GET", "/sse/dash", http.NoBody)
+	userCtx, userCancel := contextWithCancel(userReq)
+	userReq = userReq.WithContext(userCtx)
+
+	userDone := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(userRec, userReq)
+		close(userDone)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	b.Publish("public", "hello-everyone")
+	b.Publish("admin-only", "secret-data")
+
+	time.Sleep(50 * time.Millisecond)
+	adminCancel()
+	userCancel()
+	<-adminDone
+	<-userDone
+
+	adminBody := adminRec.Body.String()
+	assert.Contains(t, adminBody, "data: hello-everyone")
+	assert.Contains(t, adminBody, "data: secret-data")
+
+	userBody := userRec.Body.String()
+	assert.Contains(t, userBody, "data: hello-everyone")
+	assert.NotContains(t, userBody, "secret-data")
+}
+
+func TestDynamicGroup_LifecycleHooks(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	firstFired := make(chan string, 2)
+	lastFired := make(chan string, 2)
+	for _, topic := range []string{"a", "b"} {
+		b.OnFirstSubscriber(topic, func(t string) { firstFired <- t })
+		b.OnLastUnsubscribe(topic, func(t string) { lastFired <- t })
+	}
+
+	b.DynamicGroup("dyn", func(_ *http.Request) []string {
+		return []string{"a", "b"}
+	})
+	handler := b.DynamicGroupHandler("dyn")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/dyn", http.NoBody)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	firstTopics := collectTopics(t, firstFired, 2, time.Second)
+	assert.ElementsMatch(t, []string{"a", "b"}, firstTopics)
+
+	cancel()
+	<-done
+
+	lastTopics := collectTopics(t, lastFired, 2, time.Second)
+	assert.ElementsMatch(t, []string{"a", "b"}, lastTopics)
+}
+
+func TestDynamicGroup_ConnectionCloseUnsubscribes(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.DynamicGroup("dyn", func(_ *http.Request) []string {
+		return []string{"x", "y"}
+	})
+	handler := b.DynamicGroupHandler("dyn")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/dyn", http.NoBody)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	assert.True(t, b.HasSubscribers("x"))
+	assert.True(t, b.HasSubscribers("y"))
+
+	cancel()
+	<-done
+	time.Sleep(50 * time.Millisecond)
+
+	assert.False(t, b.HasSubscribers("x"))
+	assert.False(t, b.HasSubscribers("y"))
+}
+
+func TestGroupHandler_SSEMessageFormat(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.DefineGroup("g", []string{"topic1"})
+	handler := b.GroupHandler("g")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/g", http.NoBody)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	b.Publish("topic1", "payload")
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+	// Should contain properly formatted SSE with event type = topic name.
+	assert.Contains(t, body, "event: topic1\n")
+	assert.Contains(t, body, "data: payload\n")
+	// Message should end with double newline (SSE spec).
+	assert.True(t, strings.Contains(body, "\n\n"), "SSE message should be terminated by double newline")
+}
+
+func TestGroupHandler_MultilineData(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.DefineGroup("g", []string{"t"})
+	handler := b.GroupHandler("g")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/g", http.NoBody)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	b.Publish("t", "line1\nline2")
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "data: line1\n")
+	assert.Contains(t, body, "data: line2\n")
+}
+
+// collectTopics drains n topic names from ch within the given timeout.
+func collectTopics(t *testing.T, ch <-chan string, n int, timeout time.Duration) []string {
+	t.Helper()
+	topics := make([]string, 0, n)
+	deadline := time.After(timeout)
+	for range n {
+		select {
+		case topic := <-ch:
+			topics = append(topics, topic)
+		case <-deadline:
+			t.Fatalf("timed out collecting topics, got %d/%d: %v", len(topics), n, topics)
+		}
+	}
+	return topics
+}


### PR DESCRIPTION
## Summary

- Add `DefineGroup`/`GroupHandler` for static topic groups — define once, serve a single SSE endpoint that multiplexes all topics
- Add `DynamicGroup`/`DynamicGroupHandler` for per-request topic resolution — different users can get different topic sets based on request context (e.g., authorization)
- Built on `SubscribeMulti` internally; lifecycle hooks (`OnFirstSubscriber`/`OnLastUnsubscribe`) fire per-topic correctly; connection close unsubscribes atomically from all topics
- `GroupHandler` supports the same `SSEHandlerOption` values as `SSEHandler` (e.g., `WithSSEWriter`)

## Test plan

- [x] Static group definition, replacement, and slice copy safety
- [x] GroupHandler streams from multiple topics with correct SSE formatting
- [x] GroupHandler returns 404 for undefined groups
- [x] SSE headers set correctly
- [x] Custom writer via WithSSEWriter
- [x] Connection close unsubscribes from all topics
- [x] Lifecycle hooks fire per-topic on subscribe and unsubscribe
- [x] Broker close terminates group handler
- [x] Dynamic group basic streaming
- [x] Dynamic group per-request authorization (admin vs regular user)
- [x] Dynamic group lifecycle hooks
- [x] Dynamic group connection cleanup
- [x] SSE message format validation (event type, data fields, double newline terminator)
- [x] Multiline data handling
- [x] All tests pass: `go test ./...`
- [x] Linting passes: `golangci-lint run ./...`

Closes #81