### PR TITLE
feat: replay gap detection and fallback (closes #86)

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -49,6 +49,9 @@ type SSEBroker struct {
 	dropCountsMu      sync.RWMutex                 // separate lock for drop counts (avoid nesting with main mu)
 	subscriberMeta    map[chan string]*SubscriberInfo // channel → subscriber info
 	connEventsTopic   string                         // empty = connection events disabled
+	onReplayGap       map[string][]ReplayGapCallback  // topic → gap callbacks
+	replayGapStrategy map[string]GapStrategy          // topic → gap strategy
+	replayGapSnapshot map[string]func() string        // topic → snapshot func for gap fallback
 }
 
 // Topic name constants are conventions for common real-time use cases.
@@ -157,9 +160,12 @@ func NewSSEBroker(opts ...BrokerOption) *SSEBroker {
 		lastHash:       make(map[string]uint64),
 		onFirst:        make(map[string][]func(string)),
 		onLast:         make(map[string][]func(string)),
-		subscriberMeta: make(map[chan string]*SubscriberInfo),
-		bufferSize:     10,
-		done:           make(chan struct{}),
+		subscriberMeta:    make(map[chan string]*SubscriberInfo),
+		onReplayGap:       make(map[string][]ReplayGapCallback),
+		replayGapStrategy: make(map[string]GapStrategy),
+		replayGapSnapshot: make(map[string]func() string),
+		bufferSize:        10,
+		done:              make(chan struct{}),
 	}
 	for _, opt := range opts {
 		opt(b)
@@ -629,6 +635,8 @@ func (b *SSEBroker) SetReplayPolicy(topic string, n int) {
 		delete(b.replaySize, topic)
 		delete(b.replayCache, topic)
 		delete(b.replayLog, topic)
+		delete(b.replayGapStrategy, topic)
+		delete(b.replayGapSnapshot, topic)
 		return
 	}
 	b.replaySize[topic] = n
@@ -647,6 +655,8 @@ func (b *SSEBroker) ClearReplay(topic string) {
 	delete(b.replayCache, topic)
 	delete(b.replaySize, topic)
 	delete(b.replayLog, topic)
+	delete(b.replayGapStrategy, topic)
+	delete(b.replayGapSnapshot, topic)
 	b.mu.Unlock()
 }
 
@@ -905,6 +915,9 @@ func (b *SSEBroker) Close() {
 	b.replayLog = nil
 	b.lastHash = nil
 	b.subscriberMeta = nil
+	b.onReplayGap = nil
+	b.replayGapStrategy = nil
+	b.replayGapSnapshot = nil
 	if b.dropCounts != nil {
 		b.dropCountsMu.Lock()
 		b.dropCounts = nil

--- a/gap.go
+++ b/gap.go
@@ -1,0 +1,69 @@
+package tavern
+
+// GapStrategy determines how the broker responds when a subscriber reconnects
+// with a Last-Event-ID that is no longer in the replay log (i.e., the log has
+// rolled over and the requested ID is gone).
+type GapStrategy int
+
+const (
+	// GapSilent is the default strategy. When a gap is detected, no replay
+	// occurs and the subscriber receives only live messages going forward.
+	// This preserves backwards compatibility with the existing behaviour.
+	GapSilent GapStrategy = iota
+
+	// GapFallbackToSnapshot uses the configured SnapshotFunc to generate a
+	// full-state snapshot and delivers it to the subscriber before live
+	// messages begin. This ensures the client can rebuild its state even
+	// when the replay log has rolled over.
+	GapFallbackToSnapshot
+)
+
+// ReplayGapCallback is invoked when a replay gap is detected for a subscriber.
+// It receives the subscriber's info and the Last-Event-ID that could not be
+// found in the replay log.
+type ReplayGapCallback func(sub *SubscriberInfo, lastEventID string)
+
+// OnReplayGap registers a callback that fires when a subscriber reconnects
+// with a Last-Event-ID that is no longer present in the replay log for the
+// given topic. The callback runs in its own goroutine and does not block the
+// subscription. Multiple callbacks per topic are allowed and all will fire.
+// Calling this on a closed broker is a no-op.
+func (b *SSEBroker) OnReplayGap(topic string, fn ReplayGapCallback) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return
+	}
+	b.onReplayGap[topic] = append(b.onReplayGap[topic], fn)
+}
+
+// SetReplayGapPolicy configures the gap strategy and optional snapshot
+// function for the given topic. When a subscriber reconnects with a
+// Last-Event-ID that has rolled out of the replay log:
+//
+//   - [GapSilent]: no special action (default, backwards compatible).
+//   - [GapFallbackToSnapshot]: call snapshotFn and deliver the result as
+//     the first message to the subscriber, preceded by a
+//     "event: tavern-replay-gap" control event.
+//
+// The snapshotFn parameter is only used with [GapFallbackToSnapshot] and
+// may be nil for other strategies.
+func (b *SSEBroker) SetReplayGapPolicy(topic string, strategy GapStrategy, snapshotFn func() string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return
+	}
+	b.replayGapStrategy[topic] = strategy
+	if snapshotFn != nil {
+		b.replayGapSnapshot[topic] = snapshotFn
+	} else {
+		delete(b.replayGapSnapshot, topic)
+	}
+}
+
+// replayGapControlEvent returns the wire-format SSE control event that
+// notifies clients a replay gap was detected.
+func replayGapControlEvent(lastEventID string) string {
+	return NewSSEMessage("tavern-replay-gap", lastEventID).String()
+}

--- a/gap_test.go
+++ b/gap_test.go
@@ -1,0 +1,394 @@
+package tavern
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubscribeFromID_GapSilentDefault(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 3)
+	// Publish 5 messages so IDs 1-2 roll out of the log.
+	for i := 1; i <= 5; i++ {
+		b.PublishWithID("events", fmt.Sprintf("%d", i), fmt.Sprintf("msg-%d", i))
+	}
+
+	// Subscribe with a rolled-out ID. Default strategy is GapSilent.
+	ch, unsub := b.SubscribeFromID("events", "1")
+	defer unsub()
+
+	// No replay or gap event should arrive.
+	select {
+	case msg := <-ch:
+		t.Fatalf("expected no message with GapSilent default, got: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Live messages still work.
+	b.PublishWithID("events", "6", "live")
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "live", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for live message")
+	}
+}
+
+func TestSubscribeFromID_GapControlEvent(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 2)
+	b.PublishWithID("events", "1", "msg-1")
+	b.PublishWithID("events", "2", "msg-2")
+	b.PublishWithID("events", "3", "msg-3")
+	// ID "1" is now evicted (policy size 2, log has IDs 2,3).
+
+	// Set a non-silent gap strategy so the control event is sent.
+	b.SetReplayGapPolicy("events", GapFallbackToSnapshot, func() string { return "" })
+
+	ch, unsub := b.SubscribeFromID("events", "1")
+	defer unsub()
+
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-replay-gap")
+		assert.Contains(t, msg, "data: 1")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for gap control event")
+	}
+}
+
+func TestSubscribeFromID_GapFallbackToSnapshot(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 2)
+	b.PublishWithID("events", "1", "msg-1")
+	b.PublishWithID("events", "2", "msg-2")
+	b.PublishWithID("events", "3", "msg-3")
+
+	snapshotData := "<div>full state</div>"
+	b.SetReplayGapPolicy("events", GapFallbackToSnapshot, func() string {
+		return snapshotData
+	})
+
+	ch, unsub := b.SubscribeFromID("events", "1")
+	defer unsub()
+
+	// First message: control event.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-replay-gap")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for gap control event")
+	}
+
+	// Second message: snapshot.
+	select {
+	case msg := <-ch:
+		assert.Equal(t, snapshotData, msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for snapshot")
+	}
+
+	// No more buffered messages (no replay since ID was not found).
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected extra message: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestSubscribeFromID_GapSnapshotEmpty(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 2)
+	b.PublishWithID("events", "1", "msg-1")
+	b.PublishWithID("events", "2", "msg-2")
+	b.PublishWithID("events", "3", "msg-3")
+
+	b.SetReplayGapPolicy("events", GapFallbackToSnapshot, func() string {
+		return "" // empty snapshot
+	})
+
+	ch, unsub := b.SubscribeFromID("events", "1")
+	defer unsub()
+
+	// Should get control event but no snapshot.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-replay-gap")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for gap control event")
+	}
+
+	select {
+	case msg := <-ch:
+		t.Fatalf("expected no snapshot for empty return, got: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestOnReplayGap_CallbackFires(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 2)
+	b.PublishWithID("events", "1", "msg-1")
+	b.PublishWithID("events", "2", "msg-2")
+	b.PublishWithID("events", "3", "msg-3")
+
+	var mu sync.Mutex
+	var capturedSub *SubscriberInfo
+	var capturedID string
+
+	b.OnReplayGap("events", func(sub *SubscriberInfo, lastEventID string) {
+		mu.Lock()
+		capturedSub = sub
+		capturedID = lastEventID
+		mu.Unlock()
+	})
+
+	// Callbacks fire even with default GapSilent strategy.
+	_, unsub := b.SubscribeFromID("events", "1")
+	defer unsub()
+
+	// Give callback goroutine time to fire.
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotNil(t, capturedSub)
+	assert.Equal(t, "events", capturedSub.Topic)
+	assert.Equal(t, "1", capturedID)
+}
+
+func TestOnReplayGap_MultipleCallbacks(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 2)
+	b.PublishWithID("events", "1", "msg-1")
+	b.PublishWithID("events", "2", "msg-2")
+	b.PublishWithID("events", "3", "msg-3")
+
+	var mu sync.Mutex
+	var count int
+
+	b.OnReplayGap("events", func(_ *SubscriberInfo, _ string) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+	})
+	b.OnReplayGap("events", func(_ *SubscriberInfo, _ string) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+	})
+
+	_, unsub := b.SubscribeFromID("events", "1")
+	defer unsub()
+
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	assert.Equal(t, 2, count, "both callbacks should fire")
+	mu.Unlock()
+}
+
+func TestOnReplayGap_NoGapNoCallback(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	b.PublishWithID("events", "1", "msg-1")
+	b.PublishWithID("events", "2", "msg-2")
+
+	var fired bool
+	b.OnReplayGap("events", func(_ *SubscriberInfo, _ string) {
+		fired = true
+	})
+
+	// ID "1" is in the log, so no gap.
+	_, unsub := b.SubscribeFromID("events", "1")
+	defer unsub()
+
+	time.Sleep(50 * time.Millisecond)
+	assert.False(t, fired, "callback should not fire when ID is found")
+}
+
+func TestOnReplayGap_EmptyLastEventID(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	b.PublishWithID("events", "1", "msg-1")
+
+	var fired bool
+	b.OnReplayGap("events", func(_ *SubscriberInfo, _ string) {
+		fired = true
+	})
+
+	// Empty Last-Event-ID means "replay all", not a gap.
+	_, unsub := b.SubscribeFromID("events", "")
+	defer unsub()
+
+	time.Sleep(50 * time.Millisecond)
+	assert.False(t, fired, "callback should not fire for empty Last-Event-ID")
+}
+
+func TestOnReplayGap_ClosedBrokerNoop(t *testing.T) {
+	b := NewSSEBroker()
+	b.Close()
+
+	// Should not panic.
+	require.NotPanics(t, func() {
+		b.OnReplayGap("events", func(_ *SubscriberInfo, _ string) {})
+	})
+}
+
+func TestSetReplayGapPolicy_ClosedBrokerNoop(t *testing.T) {
+	b := NewSSEBroker()
+	b.Close()
+
+	require.NotPanics(t, func() {
+		b.SetReplayGapPolicy("events", GapFallbackToSnapshot, func() string { return "snap" })
+	})
+}
+
+func TestGapControlEventFormat(t *testing.T) {
+	msg := replayGapControlEvent("abc-123")
+	assert.True(t, strings.HasPrefix(msg, "event: tavern-replay-gap\n"))
+	assert.Contains(t, msg, "data: abc-123")
+	assert.True(t, strings.HasSuffix(msg, "\n\n"), "SSE messages must end with double newline")
+}
+
+func TestSubscribeFromID_GapWithLiveMessages(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 2)
+	b.PublishWithID("events", "1", "msg-1")
+	b.PublishWithID("events", "2", "msg-2")
+	b.PublishWithID("events", "3", "msg-3")
+
+	b.SetReplayGapPolicy("events", GapFallbackToSnapshot, func() string {
+		return "<snapshot>"
+	})
+
+	ch, unsub := b.SubscribeFromID("events", "1")
+	defer unsub()
+
+	// Drain control event and snapshot.
+	<-ch
+	<-ch
+
+	// Live messages should still arrive.
+	b.PublishWithID("events", "4", "live")
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "live", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for live message")
+	}
+}
+
+func TestSetReplayGapPolicy_ClearedBySetReplayPolicy(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 5)
+	b.SetReplayGapPolicy("events", GapFallbackToSnapshot, func() string { return "snap" })
+
+	// Disabling replay should also clear gap policy.
+	b.SetReplayPolicy("events", 0)
+
+	b.mu.RLock()
+	_, hasStrategy := b.replayGapStrategy["events"]
+	_, hasSnapshot := b.replayGapSnapshot["events"]
+	b.mu.RUnlock()
+
+	assert.False(t, hasStrategy)
+	assert.False(t, hasSnapshot)
+}
+
+func TestSetReplayGapPolicy_ClearedByClearReplay(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 5)
+	b.SetReplayGapPolicy("events", GapFallbackToSnapshot, func() string { return "snap" })
+
+	b.ClearReplay("events")
+
+	b.mu.RLock()
+	_, hasStrategy := b.replayGapStrategy["events"]
+	_, hasSnapshot := b.replayGapSnapshot["events"]
+	b.mu.RUnlock()
+
+	assert.False(t, hasStrategy)
+	assert.False(t, hasSnapshot)
+}
+
+func TestSetReplayGapPolicy_NilSnapshotFn(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 2)
+	// First set with a snapshot function.
+	b.SetReplayGapPolicy("events", GapFallbackToSnapshot, func() string { return "snap" })
+	// Then set with nil to clear the snapshot function.
+	b.SetReplayGapPolicy("events", GapFallbackToSnapshot, nil)
+
+	b.PublishWithID("events", "1", "msg-1")
+	b.PublishWithID("events", "2", "msg-2")
+	b.PublishWithID("events", "3", "msg-3")
+
+	ch, unsub := b.SubscribeFromID("events", "1")
+	defer unsub()
+
+	// Should get control event but no snapshot (snapshotFn is nil).
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-replay-gap")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for gap control event")
+	}
+
+	select {
+	case msg := <-ch:
+		t.Fatalf("expected no snapshot when snapshotFn is nil, got: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestSubscribeFromID_GapSilentNoControlEvent(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 2)
+	b.PublishWithID("events", "1", "msg-1")
+	b.PublishWithID("events", "2", "msg-2")
+	b.PublishWithID("events", "3", "msg-3")
+
+	// Explicitly set GapSilent — should behave same as default.
+	b.SetReplayGapPolicy("events", GapSilent, nil)
+
+	ch, unsub := b.SubscribeFromID("events", "1")
+	defer unsub()
+
+	// GapSilent should not send a control event.
+	select {
+	case msg := <-ch:
+		t.Fatalf("expected no message with GapSilent, got: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+}

--- a/handler_test.go
+++ b/handler_test.go
@@ -173,6 +173,45 @@ func TestSSEHandler_Flushes(t *testing.T) {
 	assert.Greater(t, rec.flushed, 0, "expected at least one flush")
 }
 
+func TestSSEHandler_GapDetection(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 2)
+	b.PublishWithID("events", "1", "msg-1")
+	b.PublishWithID("events", "2", "msg-2")
+	b.PublishWithID("events", "3", "msg-3")
+	// ID "1" has rolled out of the log.
+
+	b.SetReplayGapPolicy("events", GapFallbackToSnapshot, func() string {
+		return "event: snapshot\ndata: full-state\n\n"
+	})
+
+	handler := b.SSEHandler("events")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse", http.NoBody)
+	req.Header.Set("Last-Event-ID", "1") // gap: ID not in log
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "event: tavern-replay-gap")
+	assert.Contains(t, body, "full-state")
+	// Should not contain the original messages since the ID was not found.
+	assert.NotContains(t, body, "msg-1")
+}
+
 // contextWithCancel creates a cancellable context from a request.
 func contextWithCancel(r *http.Request) (context.Context, context.CancelFunc) {
 	return context.WithCancel(r.Context())

--- a/resume.go
+++ b/resume.go
@@ -90,13 +90,16 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 
 	// Find messages after lastEventID.
 	var replayMsgs []string
+	var gapDetected bool
 	if lastEventID == "" {
 		// No Last-Event-ID: replay all cached (same as regular Subscribe).
 		replayMsgs = append([]string(nil), b.replayCache[topic]...)
 	} else {
 		log := b.replayLog[topic]
+		found := false
 		for i, entry := range log {
 			if entry.ID == lastEventID {
+				found = true
 				// Replay everything after this entry.
 				for _, e := range log[i+1:] {
 					replayMsgs = append(replayMsgs, e.Msg)
@@ -104,8 +107,21 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 				break
 			}
 		}
-		// If ID not found, replayMsgs stays nil: gap too large, no replay.
+		if !found {
+			gapDetected = true
+		}
 	}
+
+	// Collect gap handling state while still holding the lock.
+	var gapCallbacks []ReplayGapCallback
+	var gapStrategy GapStrategy
+	var gapSnapshotFn func() string
+	if gapDetected {
+		gapCallbacks = b.onReplayGap[topic]
+		gapStrategy = b.replayGapStrategy[topic]
+		gapSnapshotFn = b.replayGapSnapshot[topic]
+	}
+	subInfo := b.subscriberMeta[ch]
 
 	if b.evictThreshold > 0 {
 		b.dropCountsMu.Lock()
@@ -119,6 +135,31 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 		go fn(topic)
 	}
 	b.publishConnectionEvent("subscribe", topic, total)
+
+	// Handle replay gap: fire callbacks, optionally send control event and snapshot.
+	if gapDetected {
+		// Fire registered gap callbacks regardless of strategy.
+		for _, fn := range gapCallbacks {
+			go fn(subInfo, lastEventID)
+		}
+		// For non-silent strategies, send control event and apply the strategy.
+		if gapStrategy != GapSilent {
+			controlMsg := replayGapControlEvent(lastEventID)
+			select {
+			case ch <- controlMsg:
+			default:
+			}
+			if gapStrategy == GapFallbackToSnapshot && gapSnapshotFn != nil {
+				if snap := gapSnapshotFn(); snap != "" {
+					select {
+					case ch <- snap:
+					default:
+					}
+				}
+			}
+		}
+	}
+
 	for _, msg := range replayMsgs {
 		select {
 		case ch <- msg:


### PR DESCRIPTION
## Summary

- Adds gap detection when `SubscribeFromID` cannot find the requested `Last-Event-ID` in the replay log (log rollover)
- Introduces `GapStrategy` type with `GapSilent` (default, backwards compatible) and `GapFallbackToSnapshot` strategies
- New `OnReplayGap(topic, callback)` API for observing gaps regardless of strategy
- New `SetReplayGapPolicy(topic, strategy, snapshotFn)` API to configure per-topic gap handling
- When `GapFallbackToSnapshot` is active, sends an `event: tavern-replay-gap` control event followed by the snapshot
- SSEHandler automatically benefits since it delegates to `SubscribeFromID`

## Test plan

- [x] `GapSilent` default preserves existing behavior (no control event, no snapshot)
- [x] `GapFallbackToSnapshot` sends control event + snapshot
- [x] `OnReplayGap` callbacks fire on gap detection (even with `GapSilent`)
- [x] No gap triggered for empty `Last-Event-ID` or found IDs
- [x] Gap policies cleaned up by `SetReplayPolicy(0)` and `ClearReplay`
- [x] SSEHandler integration test with `Last-Event-ID` gap
- [x] Closed broker no-ops
- [x] All tests pass: `go test ./...`
- [x] Linting passes: `golangci-lint run ./...`

Closes #86