### PR TITLE
feat: publish middleware chain

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -56,6 +56,8 @@ type SSEBroker struct {
 	groupsMu          sync.RWMutex                   // protects groups
 	dynGroups         map[string]*dynamicGroupDef    // dynamic topic groups
 	dynGroupsMu       sync.RWMutex                   // protects dynGroups
+	middlewares       []Middleware                    // global publish middleware
+	topicMiddlewares  []topicMiddleware               // topic-scoped publish middleware
 }
 
 // Topic name constants are conventions for common real-time use cases.
@@ -575,6 +577,14 @@ func (b *SSEBroker) evictSubscriber(topic string, ch chan string) {
 // silently dropped for that subscriber rather than blocking the publisher.
 // Publishing to a topic with no subscribers is a no-op.
 func (b *SSEBroker) Publish(topic, msg string) {
+	dispatch := b.applyMiddleware(topic, b.publishDirect)
+	dispatch(topic, msg)
+}
+
+// publishDirect fans out msg to unscoped subscribers without applying
+// middleware.  It is the terminal function in the middleware chain for
+// [SSEBroker.Publish].
+func (b *SSEBroker) publishDirect(topic, msg string) {
 	b.mu.RLock()
 	subscribers, exists := b.topics[topic]
 	if !exists || len(subscribers) == 0 {
@@ -600,6 +610,13 @@ func (b *SSEBroker) Publish(topic, msg string) {
 // the most recent message per topic is retained. Use [SSEBroker.ClearReplay]
 // to remove the cached message for a topic.
 func (b *SSEBroker) PublishWithReplay(topic, msg string) {
+	dispatch := b.applyMiddleware(topic, b.publishWithReplayDirect)
+	dispatch(topic, msg)
+}
+
+// publishWithReplayDirect caches msg for replay and fans it out to
+// unscoped subscribers without applying middleware.
+func (b *SSEBroker) publishWithReplayDirect(topic, msg string) {
 	b.mu.Lock()
 	if b.closed {
 		b.mu.Unlock()
@@ -670,6 +687,15 @@ func (b *SSEBroker) ClearReplay(topic string) {
 // the message is silently dropped. Publishing to a topic or scope with no
 // matching subscribers is a no-op.
 func (b *SSEBroker) PublishTo(topic, scope, msg string) {
+	dispatch := b.applyMiddleware(topic, func(t, m string) {
+		b.publishToDirect(t, scope, m)
+	})
+	dispatch(topic, msg)
+}
+
+// publishToDirect fans out msg to scoped subscribers without applying
+// middleware.
+func (b *SSEBroker) publishToDirect(topic, scope, msg string) {
 	b.mu.RLock()
 	scopedSubs, exists := b.scopedTopics[topic]
 	if !exists || len(scopedSubs) == 0 {
@@ -720,21 +746,10 @@ func (b *SSEBroker) PublishIfChanged(topic, msg string) bool {
 		return false
 	}
 	b.lastHash[topic] = h
-
-	// Snapshot subscribers while we hold the lock.
-	subscribers := b.topics[topic]
-	channels := make([]chan string, 0, len(subscribers))
-	for ch := range subscribers {
-		channels = append(channels, ch)
-	}
 	b.mu.Unlock()
 
-	sent, dropped := b.publishToChannels(topic, channels, msg)
-	if b.metrics != nil {
-		tc := b.metrics.counter(topic)
-		tc.published.Add(int64(sent))
-		tc.dropped.Add(int64(dropped))
-	}
+	dispatch := b.applyMiddleware(topic, b.publishDirect)
+	dispatch(topic, msg)
 	return true
 }
 
@@ -756,25 +771,12 @@ func (b *SSEBroker) PublishIfChangedTo(topic, scope, msg string) bool {
 		return false
 	}
 	b.lastHash[key] = h
-
-	scopedSubs, exists := b.scopedTopics[topic]
-	var channels []chan string
-	if exists {
-		channels = make([]chan string, 0, len(scopedSubs))
-		for ch, sub := range scopedSubs {
-			if sub.scope == scope {
-				channels = append(channels, ch)
-			}
-		}
-	}
 	b.mu.Unlock()
 
-	sent, dropped := b.publishToChannels(topic, channels, msg)
-	if b.metrics != nil {
-		tc := b.metrics.counter(topic)
-		tc.published.Add(int64(sent))
-		tc.dropped.Add(int64(dropped))
-	}
+	dispatch := b.applyMiddleware(topic, func(t, m string) {
+		b.publishToDirect(t, scope, m)
+	})
+	dispatch(topic, msg)
 	return true
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -1,0 +1,101 @@
+package tavern
+
+import "strings"
+
+// PublishFunc is the function signature for publish operations.
+// Middleware wraps this to intercept, transform, or swallow publishes.
+type PublishFunc func(topic, msg string)
+
+// Middleware wraps a [PublishFunc] to add cross-cutting behaviour to the
+// publish pipeline.  Middleware is called in registration order (first
+// registered = outermost) and may transform the message, add side-effects,
+// or swallow the publish entirely by not calling next.
+type Middleware func(next PublishFunc) PublishFunc
+
+// topicMiddleware pairs a pattern with a middleware function.
+type topicMiddleware struct {
+	pattern    string
+	middleware Middleware
+}
+
+// Use registers global middleware that runs on every publish regardless of
+// topic.  Middleware executes in registration order (first registered =
+// outermost wrapper).  It must be called before any publishes; adding
+// middleware while publishing is safe but the new middleware only takes
+// effect on subsequent publishes.
+func (b *SSEBroker) Use(mw Middleware) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.middlewares = append(b.middlewares, mw)
+}
+
+// UseTopics registers middleware that runs only when the topic matches
+// the given pattern.  Pattern matching uses simple wildcard rules:
+//   - An asterisk (*) matches any sequence of characters within a single
+//     segment (between colons).
+//   - A pattern without wildcards must match the topic exactly.
+//
+// Examples: "orders:*" matches "orders:list" and "orders:detail" but not
+// "orders:detail:item".
+func (b *SSEBroker) UseTopics(pattern string, mw Middleware) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.topicMiddlewares = append(b.topicMiddlewares, topicMiddleware{
+		pattern:    pattern,
+		middleware: mw,
+	})
+}
+
+// applyMiddleware builds the middleware chain for the given topic and returns
+// a PublishFunc that, when called, runs the chain and then calls base.
+// The chain is: global middleware (outermost first) → matching topic
+// middleware (outermost first) → base.
+func (b *SSEBroker) applyMiddleware(topic string, base PublishFunc) PublishFunc {
+	b.mu.RLock()
+	// Fast path: no middleware registered.
+	if len(b.middlewares) == 0 && len(b.topicMiddlewares) == 0 {
+		b.mu.RUnlock()
+		return base
+	}
+	// Snapshot the slices under read lock.
+	globals := make([]Middleware, len(b.middlewares))
+	copy(globals, b.middlewares)
+	var topicMWs []Middleware
+	for _, tm := range b.topicMiddlewares {
+		if matchPattern(tm.pattern, topic) {
+			topicMWs = append(topicMWs, tm.middleware)
+		}
+	}
+	b.mu.RUnlock()
+
+	// Build the chain inside-out: base ← topic[last] ← … ← topic[0] ← global[last] ← … ← global[0].
+	fn := base
+	for i := len(topicMWs) - 1; i >= 0; i-- {
+		fn = topicMWs[i](fn)
+	}
+	for i := len(globals) - 1; i >= 0; i-- {
+		fn = globals[i](fn)
+	}
+	return fn
+}
+
+// matchPattern reports whether topic matches the wildcard pattern.
+// The pattern is split on ":" separators and each segment is compared
+// individually.  A "*" segment matches any non-empty segment.  A segment
+// without wildcards must match exactly.
+func matchPattern(pattern, topic string) bool {
+	patParts := strings.Split(pattern, ":")
+	topParts := strings.Split(topic, ":")
+	if len(patParts) != len(topParts) {
+		return false
+	}
+	for i, pp := range patParts {
+		if pp == "*" {
+			continue
+		}
+		if pp != topParts[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,513 @@
+package tavern
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiddlewareGlobal(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.Use(func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			next(topic, strings.ToUpper(msg))
+		}
+	})
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	b.Publish("t", "hello")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "HELLO", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestMiddlewareChainOrder(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	// First registered = outermost. Outermost runs first, transforms msg,
+	// then passes to inner. So first prepends "[first]", second sees that
+	// and prepends "[second]", producing "[second][first]x".
+	b.Use(func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			next(topic, "[first]"+msg)
+		}
+	})
+	b.Use(func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			next(topic, "[second]"+msg)
+		}
+	})
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	b.Publish("t", "x")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "[second][first]x", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestMiddlewareSwallow(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.Use(func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			// swallow — don't call next
+		}
+	})
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	b.Publish("t", "should not arrive")
+
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected message: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+}
+
+func TestMiddlewareTopicScoped(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.UseTopics("orders:*", func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			next(topic, "[orders]"+msg)
+		}
+	})
+
+	chOrders, unsubOrders := b.Subscribe("orders:list")
+	defer unsubOrders()
+
+	chOther, unsubOther := b.Subscribe("users:list")
+	defer unsubOther()
+
+	b.Publish("orders:list", "data")
+	b.Publish("users:list", "data")
+
+	select {
+	case msg := <-chOrders:
+		assert.Equal(t, "[orders]data", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out on orders")
+	}
+
+	select {
+	case msg := <-chOther:
+		assert.Equal(t, "data", msg, "non-matching topic should not have middleware applied")
+	case <-time.After(time.Second):
+		t.Fatal("timed out on users")
+	}
+}
+
+func TestMiddlewareGlobalAndTopicCombined(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.Use(func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			next(topic, "[global]"+msg)
+		}
+	})
+	b.UseTopics("admin:*", func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			next(topic, "[admin]"+msg)
+		}
+	})
+
+	ch, unsub := b.Subscribe("admin:users")
+	defer unsub()
+
+	b.Publish("admin:users", "x")
+
+	select {
+	case msg := <-ch:
+		// global outermost runs first, topic inner runs second
+		assert.Equal(t, "[admin][global]x", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestMiddlewarePublishTo(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.Use(func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			next(topic, "[mw]"+msg)
+		}
+	})
+
+	ch, unsub := b.SubscribeScoped("t", "user1")
+	defer unsub()
+
+	b.PublishTo("t", "user1", "hello")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "[mw]hello", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestMiddlewarePublishOOB(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.Use(func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			next(topic, "[mw]"+msg)
+		}
+	})
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	b.PublishOOB("t", Replace("el", "<p>hi</p>"))
+
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "[mw]")
+		assert.Contains(t, msg, "hx-swap-oob")
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestMiddlewarePublishOOBTo(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.Use(func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			next(topic, "[mw]"+msg)
+		}
+	})
+
+	ch, unsub := b.SubscribeScoped("t", "s1")
+	defer unsub()
+
+	b.PublishOOBTo("t", "s1", Replace("el", "<p>hi</p>"))
+
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "[mw]")
+		assert.Contains(t, msg, "hx-swap-oob")
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestMiddlewarePublishWithReplay(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.Use(func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			next(topic, "[mw]"+msg)
+		}
+	})
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	b.PublishWithReplay("t", "hello")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "[mw]hello", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestMiddlewarePublishIfChanged(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.Use(func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			next(topic, "[mw]"+msg)
+		}
+	})
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	ok := b.PublishIfChanged("t", "hello")
+	require.True(t, ok)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "[mw]hello", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestMiddlewarePublishIfChangedTo(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.Use(func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			next(topic, "[mw]"+msg)
+		}
+	})
+
+	ch, unsub := b.SubscribeScoped("t", "s1")
+	defer unsub()
+
+	ok := b.PublishIfChangedTo("t", "s1", "hello")
+	require.True(t, ok)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "[mw]hello", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestMiddlewarePublishThrottled(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.Use(func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			next(topic, "[mw]"+msg)
+		}
+	})
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	b.PublishThrottled("t", "hello", time.Second)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "[mw]hello", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestMiddlewarePublishDebounced(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.Use(func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			next(topic, "[mw]"+msg)
+		}
+	})
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	b.PublishDebounced("t", "hello", 10*time.Millisecond)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "[mw]hello", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestMatchPattern(t *testing.T) {
+	tests := []struct {
+		pattern string
+		topic   string
+		want    bool
+	}{
+		{"orders:*", "orders:list", true},
+		{"orders:*", "orders:detail", true},
+		{"orders:*", "orders:detail:item", false},
+		{"*:list", "orders:list", true},
+		{"*:*", "orders:list", true},
+		{"orders:list", "orders:list", true},
+		{"orders:list", "orders:detail", false},
+		{"admin", "admin", true},
+		{"admin", "admin:users", false},
+		{"*", "anything", true},
+		{"a:b:*", "a:b:c", true},
+		{"a:b:*", "a:b", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.pattern+"_"+tt.topic, func(t *testing.T) {
+			assert.Equal(t, tt.want, matchPattern(tt.pattern, tt.topic))
+		})
+	}
+}
+
+func TestMiddlewareSideEffect(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	var logged atomic.Int64
+	b.Use(func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			logged.Add(1)
+			next(topic, msg)
+		}
+	})
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	b.Publish("t", "a")
+	b.Publish("t", "b")
+
+	<-ch
+	<-ch
+
+	assert.Equal(t, int64(2), logged.Load())
+}
+
+func TestMiddlewareConcurrentPublish(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	var count atomic.Int64
+	b.Use(func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			count.Add(1)
+			next(topic, msg)
+		}
+	})
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	const n = 100
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			b.Publish("t", "msg")
+		}()
+	}
+	wg.Wait()
+
+	// Drain what we can.
+	drained := 0
+	for {
+		select {
+		case <-ch:
+			drained++
+		default:
+			goto done
+		}
+	}
+done:
+	assert.Equal(t, int64(n), count.Load())
+	assert.Greater(t, drained, 0)
+}
+
+func TestMiddlewareNoMiddleware(t *testing.T) {
+	// Ensure publish works normally with no middleware registered.
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	b.Publish("t", "hello")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "hello", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestMiddlewareTopicSwallow(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.UseTopics("admin:*", func(_ PublishFunc) PublishFunc {
+		return func(_, _ string) {
+			// swallow all admin publishes
+		}
+	})
+
+	ch, unsub := b.Subscribe("admin:secret")
+	defer unsub()
+
+	chPublic, unsubPublic := b.Subscribe("public:news")
+	defer unsubPublic()
+
+	b.Publish("admin:secret", "classified")
+	b.Publish("public:news", "headline")
+
+	// admin should be swallowed
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected message on admin topic: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// public should go through
+	select {
+	case msg := <-chPublic:
+		assert.Equal(t, "headline", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out on public topic")
+	}
+}
+
+func TestMiddlewareMultipleTopicPatterns(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.UseTopics("a:*", func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			next(topic, "[a]"+msg)
+		}
+	})
+	b.UseTopics("*:x", func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			next(topic, "[x]"+msg)
+		}
+	})
+
+	ch, unsub := b.Subscribe("a:x")
+	defer unsub()
+
+	b.Publish("a:x", "data")
+
+	select {
+	case msg := <-ch:
+		// Both topic middlewares match; first registered is outermost
+		assert.Equal(t, "[x][a]data", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Use()` for global publish middleware and `UseTopics()` for topic-scoped middleware with wildcard pattern matching (`orders:*`, `*:list`, etc.)
- Middleware wraps all publish variants: `Publish`, `PublishTo`, `PublishWithReplay`, `PublishIfChanged`, `PublishIfChangedTo`, and transitively covers OOB, throttled, and debounced publishes
- Middleware can transform messages, add side effects (logging, audit), or swallow publishes entirely by not calling `next`

## Test plan
- [x] Global middleware transforms messages across all topics
- [x] Chain ordering: first registered = outermost wrapper
- [x] Swallowing: middleware that doesn't call next prevents delivery
- [x] Topic-scoped middleware only runs on matching topics
- [x] Combined global + topic middleware applies in correct order
- [x] Middleware applies to PublishTo, PublishOOB, PublishOOBTo, PublishWithReplay, PublishIfChanged, PublishIfChangedTo, PublishThrottled, PublishDebounced
- [x] Pattern matching covers wildcards, exact match, multi-segment
- [x] Side-effect counting middleware works under concurrent publish
- [x] No middleware registered = no overhead (fast path)
- [x] All existing tests continue to pass
- [x] golangci-lint clean

Closes #87