### PR TITLE
feat: expand taverntest with testing utilities

### DIFF
--- a/taverntest/capture.go
+++ b/taverntest/capture.go
@@ -1,0 +1,158 @@
+package taverntest
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/catgoose/tavern"
+)
+
+// Capture subscribes to a real broker and collects messages for assertion.
+// Unlike [Recorder], Capture provides assertion methods that accept expected
+// messages directly, making tests more declarative.
+type Capture struct {
+	msgs  []string
+	mu    sync.Mutex
+	unsub func()
+	done  chan struct{}
+}
+
+// NewCapture subscribes to the given topic on the broker and starts
+// collecting messages in a background goroutine. Call [Capture.Close]
+// when done to unsubscribe and stop collection.
+func NewCapture(broker *tavern.SSEBroker, topic string) *Capture {
+	ch, unsub := broker.Subscribe(topic)
+	return newCapture(ch, unsub)
+}
+
+// NewScopedCapture subscribes to the given topic and scope on the broker
+// and starts collecting messages. Call [Capture.Close] when done.
+func NewScopedCapture(broker *tavern.SSEBroker, topic, scope string) *Capture {
+	ch, unsub := broker.SubscribeScoped(topic, scope)
+	return newCapture(ch, unsub)
+}
+
+func newCapture(ch <-chan string, unsub func()) *Capture {
+	c := &Capture{
+		unsub: unsub,
+		done:  make(chan struct{}),
+	}
+	go func() {
+		defer close(c.done)
+		for msg := range ch {
+			c.mu.Lock()
+			c.msgs = append(c.msgs, msg)
+			c.mu.Unlock()
+		}
+	}()
+	return c
+}
+
+// Close stops collecting and unsubscribes. Safe to call multiple times.
+func (c *Capture) Close() {
+	c.unsub()
+	<-c.done
+}
+
+// Messages returns a copy of all collected messages so far.
+func (c *Capture) Messages() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cp := make([]string, len(c.msgs))
+	copy(cp, c.msgs)
+	return cp
+}
+
+// waitFor blocks until at least n messages are collected or timeout elapses.
+func (c *Capture) waitFor(n int, timeout time.Duration) bool {
+	deadline := time.After(timeout)
+	for {
+		c.mu.Lock()
+		count := len(c.msgs)
+		c.mu.Unlock()
+		if count >= n {
+			return true
+		}
+		select {
+		case <-deadline:
+			return false
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+// AssertReceived fails the test if the collected messages do not contain all
+// of the expected messages (in any order). It waits up to 1 second for
+// messages to arrive.
+func (c *Capture) AssertReceived(t testing.TB, expected ...string) {
+	t.Helper()
+	if !c.waitFor(len(expected), time.Second) {
+		c.mu.Lock()
+		got := len(c.msgs)
+		c.mu.Unlock()
+		t.Fatalf("timed out waiting for %d messages, got %d", len(expected), got)
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, exp := range expected {
+		found := false
+		for _, msg := range c.msgs {
+			if msg == exp {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected message %q not found in %d collected messages", exp, len(c.msgs))
+		}
+	}
+}
+
+// AssertReceivedWithin is like [Capture.AssertReceived] but with a custom timeout.
+func (c *Capture) AssertReceivedWithin(t testing.TB, timeout time.Duration, expected ...string) {
+	t.Helper()
+	if !c.waitFor(len(expected), timeout) {
+		c.mu.Lock()
+		got := len(c.msgs)
+		c.mu.Unlock()
+		t.Fatalf("timed out after %v waiting for %d messages, got %d", timeout, len(expected), got)
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, exp := range expected {
+		found := false
+		for _, msg := range c.msgs {
+			if msg == exp {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected message %q not found in %d collected messages", exp, len(c.msgs))
+		}
+	}
+}
+
+// AssertReceivedExactly fails the test if the collected messages do not match
+// the expected messages exactly (same order, same count). It waits up to 1
+// second for messages to arrive.
+func (c *Capture) AssertReceivedExactly(t testing.TB, expected ...string) {
+	t.Helper()
+	if !c.waitFor(len(expected), time.Second) {
+		c.mu.Lock()
+		got := len(c.msgs)
+		c.mu.Unlock()
+		t.Fatalf("timed out waiting for %d messages, got %d", len(expected), got)
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.msgs) != len(expected) {
+		t.Fatalf("expected %d messages, got %d", len(expected), len(c.msgs))
+	}
+	for i, exp := range expected {
+		if c.msgs[i] != exp {
+			t.Errorf("message[%d]: expected %q, got %q", i, exp, c.msgs[i])
+		}
+	}
+}

--- a/taverntest/capture_test.go
+++ b/taverntest/capture_test.go
@@ -1,0 +1,110 @@
+package taverntest_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/catgoose/tavern"
+	"github.com/catgoose/tavern/taverntest"
+)
+
+func TestCapture_AssertReceived(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	capt := taverntest.NewCapture(b, "events")
+	defer capt.Close()
+
+	b.Publish("events", "alpha")
+	b.Publish("events", "beta")
+	b.Publish("events", "gamma")
+
+	capt.AssertReceived(t, "alpha", "gamma") // order-independent
+}
+
+func TestCapture_AssertReceivedWithin(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	capt := taverntest.NewCapture(b, "events")
+	defer capt.Close()
+
+	b.Publish("events", "fast")
+
+	capt.AssertReceivedWithin(t, 500*time.Millisecond, "fast")
+}
+
+func TestCapture_AssertReceivedExactly(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	capt := taverntest.NewCapture(b, "events")
+	defer capt.Close()
+
+	b.Publish("events", "first")
+	b.Publish("events", "second")
+
+	capt.AssertReceivedExactly(t, "first", "second")
+}
+
+func TestCapture_Messages(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	capt := taverntest.NewCapture(b, "events")
+	defer capt.Close()
+
+	b.Publish("events", "msg1")
+	b.Publish("events", "msg2")
+
+	capt.AssertReceived(t, "msg1", "msg2")
+
+	msgs := capt.Messages()
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+
+	// Mutating returned slice should not affect capture
+	msgs[0] = "mutated"
+	fresh := capt.Messages()
+	if fresh[0] != "msg1" {
+		t.Error("Messages() should return a copy")
+	}
+}
+
+func TestCapture_ScopedCapture(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	cap1 := taverntest.NewScopedCapture(b, "notif", "user-1")
+	defer cap1.Close()
+	cap2 := taverntest.NewScopedCapture(b, "notif", "user-2")
+	defer cap2.Close()
+
+	b.PublishTo("notif", "user-1", "for-1")
+	b.PublishTo("notif", "user-2", "for-2")
+
+	cap1.AssertReceived(t, "for-1")
+	cap2.AssertReceived(t, "for-2")
+}
+
+func TestCapture_Close(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	capt := taverntest.NewCapture(b, "events")
+
+	b.Publish("events", "before")
+	capt.AssertReceived(t, "before")
+
+	capt.Close()
+
+	// Publishing after close should not panic or affect capture
+	b.Publish("events", "after")
+	time.Sleep(50 * time.Millisecond)
+
+	msgs := capt.Messages()
+	if len(msgs) != 1 {
+		t.Errorf("expected 1 message after close, got %d", len(msgs))
+	}
+}

--- a/taverntest/mock_broker.go
+++ b/taverntest/mock_broker.go
@@ -1,0 +1,133 @@
+package taverntest
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/catgoose/tavern"
+)
+
+// publishedCall records a single Publish or PublishOOB call.
+type publishedCall struct {
+	Topic    string
+	Msg      string
+	Scope    string // non-empty for scoped publishes
+	OOB      bool
+	Fragments []tavern.Fragment
+}
+
+// MockBroker records publish calls for test assertions. It does not deliver
+// messages to any subscribers; use it when you want to verify that application
+// code publishes the right messages without running a real broker.
+type MockBroker struct {
+	mu   sync.Mutex
+	calls []publishedCall
+}
+
+// NewMockBroker creates a ready-to-use MockBroker.
+func NewMockBroker() *MockBroker {
+	return &MockBroker{}
+}
+
+// Publish records a publish call for the given topic and message.
+func (m *MockBroker) Publish(topic, msg string) {
+	m.mu.Lock()
+	m.calls = append(m.calls, publishedCall{Topic: topic, Msg: msg})
+	m.mu.Unlock()
+}
+
+// PublishTo records a scoped publish call.
+func (m *MockBroker) PublishTo(topic, scope, msg string) {
+	m.mu.Lock()
+	m.calls = append(m.calls, publishedCall{Topic: topic, Msg: msg, Scope: scope})
+	m.mu.Unlock()
+}
+
+// PublishOOB records an OOB publish call. The fragments are rendered via
+// [tavern.RenderFragments] so that AssertPublished can match on the rendered
+// output, and the raw fragments are also stored for inspection.
+func (m *MockBroker) PublishOOB(topic string, fragments ...tavern.Fragment) {
+	rendered := tavern.RenderFragments(fragments...)
+	m.mu.Lock()
+	m.calls = append(m.calls, publishedCall{
+		Topic:     topic,
+		Msg:       rendered,
+		OOB:       true,
+		Fragments: fragments,
+	})
+	m.mu.Unlock()
+}
+
+// PublishOOBTo records a scoped OOB publish call.
+func (m *MockBroker) PublishOOBTo(topic, scope string, fragments ...tavern.Fragment) {
+	rendered := tavern.RenderFragments(fragments...)
+	m.mu.Lock()
+	m.calls = append(m.calls, publishedCall{
+		Topic:     topic,
+		Msg:       rendered,
+		Scope:     scope,
+		OOB:       true,
+		Fragments: fragments,
+	})
+	m.mu.Unlock()
+}
+
+// Calls returns a copy of all recorded publish calls.
+func (m *MockBroker) Calls() []publishedCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]publishedCall, len(m.calls))
+	copy(cp, m.calls)
+	return cp
+}
+
+// Reset clears all recorded calls.
+func (m *MockBroker) Reset() {
+	m.mu.Lock()
+	m.calls = nil
+	m.mu.Unlock()
+}
+
+// callsForTopic returns all recorded calls matching topic.
+func (m *MockBroker) callsForTopic(topic string) []publishedCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var result []publishedCall
+	for _, c := range m.calls {
+		if c.Topic == topic {
+			result = append(result, c)
+		}
+	}
+	return result
+}
+
+// AssertPublished fails the test if no call matches the given topic and message.
+func (m *MockBroker) AssertPublished(t testing.TB, topic, msg string) {
+	t.Helper()
+	calls := m.callsForTopic(topic)
+	for _, c := range calls {
+		if c.Msg == msg {
+			return
+		}
+	}
+	t.Errorf("expected publish(%q, %q) not found in %d calls for topic", topic, msg, len(calls))
+}
+
+// AssertPublishedCount fails the test if the number of calls for the given
+// topic does not equal n.
+func (m *MockBroker) AssertPublishedCount(t testing.TB, topic string, n int) {
+	t.Helper()
+	calls := m.callsForTopic(topic)
+	if len(calls) != n {
+		t.Errorf("expected %d publishes to %q, got %d", n, topic, len(calls))
+	}
+}
+
+// AssertNotPublished fails the test if any call was recorded for the given topic.
+func (m *MockBroker) AssertNotPublished(t testing.TB, topic string) {
+	t.Helper()
+	calls := m.callsForTopic(topic)
+	if len(calls) > 0 {
+		t.Errorf("expected no publishes to %q, got %d", topic, len(calls))
+	}
+}

--- a/taverntest/mock_broker_test.go
+++ b/taverntest/mock_broker_test.go
@@ -1,0 +1,122 @@
+package taverntest_test
+
+import (
+	"testing"
+
+	"github.com/catgoose/tavern"
+	"github.com/catgoose/tavern/taverntest"
+)
+
+func TestMockBroker_Publish(t *testing.T) {
+	m := taverntest.NewMockBroker()
+
+	m.Publish("events", "hello")
+	m.Publish("events", "world")
+	m.Publish("other", "bye")
+
+	m.AssertPublished(t, "events", "hello")
+	m.AssertPublished(t, "events", "world")
+	m.AssertPublished(t, "other", "bye")
+	m.AssertPublishedCount(t, "events", 2)
+	m.AssertPublishedCount(t, "other", 1)
+}
+
+func TestMockBroker_PublishTo(t *testing.T) {
+	m := taverntest.NewMockBroker()
+
+	m.PublishTo("notif", "user-1", "msg-for-1")
+
+	m.AssertPublished(t, "notif", "msg-for-1")
+	m.AssertPublishedCount(t, "notif", 1)
+
+	calls := m.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].Scope != "user-1" {
+		t.Errorf("expected scope %q, got %q", "user-1", calls[0].Scope)
+	}
+}
+
+func TestMockBroker_PublishOOB(t *testing.T) {
+	m := taverntest.NewMockBroker()
+
+	frag := tavern.Replace("status", "<span>online</span>")
+	m.PublishOOB("dashboard", frag)
+
+	rendered := tavern.RenderFragments(frag)
+	m.AssertPublished(t, "dashboard", rendered)
+	m.AssertPublishedCount(t, "dashboard", 1)
+
+	calls := m.Calls()
+	if !calls[0].OOB {
+		t.Error("expected OOB flag to be true")
+	}
+	if len(calls[0].Fragments) != 1 {
+		t.Fatalf("expected 1 fragment, got %d", len(calls[0].Fragments))
+	}
+	if calls[0].Fragments[0].ID != "status" {
+		t.Errorf("expected fragment ID %q, got %q", "status", calls[0].Fragments[0].ID)
+	}
+}
+
+func TestMockBroker_PublishOOBTo(t *testing.T) {
+	m := taverntest.NewMockBroker()
+
+	frag := tavern.Replace("badge", "<span>3</span>")
+	m.PublishOOBTo("notif", "user-1", frag)
+
+	rendered := tavern.RenderFragments(frag)
+	m.AssertPublished(t, "notif", rendered)
+
+	calls := m.Calls()
+	if calls[0].Scope != "user-1" {
+		t.Errorf("expected scope %q, got %q", "user-1", calls[0].Scope)
+	}
+	if !calls[0].OOB {
+		t.Error("expected OOB flag to be true")
+	}
+}
+
+func TestMockBroker_AssertNotPublished(t *testing.T) {
+	m := taverntest.NewMockBroker()
+
+	m.Publish("events", "hello")
+	m.AssertNotPublished(t, "other")
+}
+
+func TestMockBroker_Reset(t *testing.T) {
+	m := taverntest.NewMockBroker()
+
+	m.Publish("events", "hello")
+	m.AssertPublishedCount(t, "events", 1)
+
+	m.Reset()
+	m.AssertPublishedCount(t, "events", 0)
+	m.AssertNotPublished(t, "events")
+}
+
+func TestMockBroker_Calls(t *testing.T) {
+	m := taverntest.NewMockBroker()
+
+	m.Publish("a", "1")
+	m.Publish("b", "2")
+
+	calls := m.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", len(calls))
+	}
+	if calls[0].Topic != "a" || calls[0].Msg != "1" {
+		t.Errorf("unexpected call[0]: %+v", calls[0])
+	}
+	if calls[1].Topic != "b" || calls[1].Msg != "2" {
+		t.Errorf("unexpected call[1]: %+v", calls[1])
+	}
+
+	// Mutating returned slice should not affect mock
+	calls[0].Msg = "mutated"
+	fresh := m.Calls()
+	if fresh[0].Msg != "1" {
+		t.Error("Calls() should return a copy")
+	}
+}

--- a/taverntest/simulated_connection.go
+++ b/taverntest/simulated_connection.go
@@ -1,0 +1,183 @@
+package taverntest
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/catgoose/tavern"
+)
+
+// SimulatedConnection models a client that can disconnect and reconnect to a
+// broker, collecting messages across connection cycles. This is useful for
+// testing Last-Event-ID resumption, reconnect behavior, and message
+// continuity across disconnects.
+type SimulatedConnection struct {
+	broker *tavern.SSEBroker
+	topic  string
+
+	mu              sync.Mutex
+	msgs            []string
+	reconnectMsgs   []string // messages received after the most recent reconnect
+	unsub           func()
+	done            chan struct{}
+	connected       bool
+}
+
+// NewSimulatedConnection subscribes to the given topic and starts collecting
+// messages. Call [SimulatedConnection.Close] when done.
+func NewSimulatedConnection(broker *tavern.SSEBroker, topic string) *SimulatedConnection {
+	sc := &SimulatedConnection{
+		broker: broker,
+		topic:  topic,
+	}
+	sc.connect("")
+	return sc
+}
+
+func (sc *SimulatedConnection) connect(lastEventID string) {
+	var ch <-chan string
+	var unsub func()
+	if lastEventID != "" {
+		ch, unsub = sc.broker.SubscribeFromID(sc.topic, lastEventID)
+	} else {
+		ch, unsub = sc.broker.Subscribe(sc.topic)
+	}
+	done := make(chan struct{})
+	sc.mu.Lock()
+	sc.unsub = unsub
+	sc.done = done
+	sc.connected = true
+	sc.reconnectMsgs = nil
+	sc.mu.Unlock()
+
+	go func() {
+		defer close(done)
+		for msg := range ch {
+			sc.mu.Lock()
+			sc.msgs = append(sc.msgs, msg)
+			sc.reconnectMsgs = append(sc.reconnectMsgs, msg)
+			sc.mu.Unlock()
+		}
+	}()
+}
+
+// Disconnect unsubscribes from the broker, simulating a client disconnect.
+func (sc *SimulatedConnection) Disconnect() {
+	sc.mu.Lock()
+	if !sc.connected {
+		sc.mu.Unlock()
+		return
+	}
+	sc.connected = false
+	unsub := sc.unsub
+	done := sc.done
+	sc.mu.Unlock()
+	unsub()
+	<-done
+}
+
+// Reconnect re-subscribes to the topic with the given lastEventID, simulating
+// a client reconnect with Last-Event-ID resumption. Pass an empty string to
+// reconnect without resumption.
+func (sc *SimulatedConnection) Reconnect(lastEventID string) {
+	sc.Disconnect()
+	sc.connect(lastEventID)
+}
+
+// Close disconnects and releases resources. Safe to call multiple times.
+func (sc *SimulatedConnection) Close() {
+	sc.Disconnect()
+}
+
+// Messages returns a copy of all messages received across all connection
+// cycles.
+func (sc *SimulatedConnection) Messages() []string {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	cp := make([]string, len(sc.msgs))
+	copy(cp, sc.msgs)
+	return cp
+}
+
+// ReconnectMessages returns a copy of messages received since the most
+// recent connect or reconnect.
+func (sc *SimulatedConnection) ReconnectMessages() []string {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	cp := make([]string, len(sc.reconnectMsgs))
+	copy(cp, sc.reconnectMsgs)
+	return cp
+}
+
+// Connected reports whether the simulated connection is currently active.
+func (sc *SimulatedConnection) Connected() bool {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	return sc.connected
+}
+
+// WaitFor blocks until at least n total messages have been received or the
+// timeout elapses. Returns true if n messages were collected, false on timeout.
+func (sc *SimulatedConnection) WaitFor(n int, timeout time.Duration) bool {
+	deadline := time.After(timeout)
+	for {
+		sc.mu.Lock()
+		count := len(sc.msgs)
+		sc.mu.Unlock()
+		if count >= n {
+			return true
+		}
+		select {
+		case <-deadline:
+			return false
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+// WaitForReconnect blocks until at least n messages have been received since
+// the most recent reconnect, or the timeout elapses.
+func (sc *SimulatedConnection) WaitForReconnect(n int, timeout time.Duration) bool {
+	deadline := time.After(timeout)
+	for {
+		sc.mu.Lock()
+		count := len(sc.reconnectMsgs)
+		sc.mu.Unlock()
+		if count >= n {
+			return true
+		}
+		select {
+		case <-deadline:
+			return false
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+// AssertReceivedAfterReconnect fails the test if the messages received since
+// the most recent reconnect do not contain all of the expected messages (in
+// any order). It waits up to 1 second for messages to arrive.
+func (sc *SimulatedConnection) AssertReceivedAfterReconnect(t testing.TB, expected ...string) {
+	t.Helper()
+	if !sc.WaitForReconnect(len(expected), time.Second) {
+		sc.mu.Lock()
+		got := len(sc.reconnectMsgs)
+		sc.mu.Unlock()
+		t.Fatalf("timed out waiting for %d reconnect messages, got %d", len(expected), got)
+	}
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	for _, exp := range expected {
+		found := false
+		for _, msg := range sc.reconnectMsgs {
+			if msg == exp {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected message %q not found in reconnect messages", exp)
+		}
+	}
+}

--- a/taverntest/simulated_connection_test.go
+++ b/taverntest/simulated_connection_test.go
@@ -1,0 +1,149 @@
+package taverntest_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/catgoose/tavern"
+	"github.com/catgoose/tavern/taverntest"
+)
+
+func TestSimulatedConnection_BasicMessages(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	conn := taverntest.NewSimulatedConnection(b, "events")
+	defer conn.Close()
+
+	b.Publish("events", "hello")
+	b.Publish("events", "world")
+
+	if !conn.WaitFor(2, time.Second) {
+		t.Fatal("timed out waiting for messages")
+	}
+
+	msgs := conn.Messages()
+	if len(msgs) != 2 || msgs[0] != "hello" || msgs[1] != "world" {
+		t.Errorf("unexpected messages: %v", msgs)
+	}
+}
+
+func TestSimulatedConnection_DisconnectReconnect(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	conn := taverntest.NewSimulatedConnection(b, "events")
+	defer conn.Close()
+
+	b.Publish("events", "before-disconnect")
+	if !conn.WaitFor(1, time.Second) {
+		t.Fatal("timed out waiting for first message")
+	}
+
+	conn.Disconnect()
+
+	if conn.Connected() {
+		t.Error("expected disconnected")
+	}
+
+	// Publish while disconnected — should not be received
+	b.Publish("events", "while-disconnected")
+
+	conn.Reconnect("")
+
+	if !conn.Connected() {
+		t.Error("expected connected after reconnect")
+	}
+
+	b.Publish("events", "after-reconnect")
+
+	conn.AssertReceivedAfterReconnect(t, "after-reconnect")
+
+	// Total messages should include before-disconnect and after-reconnect
+	msgs := conn.Messages()
+	if len(msgs) != 2 {
+		t.Errorf("expected 2 total messages, got %d: %v", len(msgs), msgs)
+	}
+}
+
+func TestSimulatedConnection_ReconnectWithLastEventID(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+
+	conn := taverntest.NewSimulatedConnection(b, "events")
+	defer conn.Close()
+
+	b.PublishWithID("events", "1", "msg-1")
+	b.PublishWithID("events", "2", "msg-2")
+	b.PublishWithID("events", "3", "msg-3")
+
+	if !conn.WaitFor(3, time.Second) {
+		t.Fatal("timed out waiting for messages")
+	}
+
+	conn.Disconnect()
+
+	// Reconnect from ID "1" — should replay "msg-2" and "msg-3"
+	conn.Reconnect("1")
+
+	conn.AssertReceivedAfterReconnect(t, "msg-2", "msg-3")
+}
+
+func TestSimulatedConnection_ReconnectMessages(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	conn := taverntest.NewSimulatedConnection(b, "events")
+	defer conn.Close()
+
+	b.Publish("events", "first-session")
+	if !conn.WaitFor(1, time.Second) {
+		t.Fatal("timed out")
+	}
+
+	conn.Reconnect("")
+
+	b.Publish("events", "second-session")
+	if !conn.WaitForReconnect(1, time.Second) {
+		t.Fatal("timed out waiting for reconnect message")
+	}
+
+	reconnMsgs := conn.ReconnectMessages()
+	if len(reconnMsgs) != 1 || reconnMsgs[0] != "second-session" {
+		t.Errorf("unexpected reconnect messages: %v", reconnMsgs)
+	}
+}
+
+func TestSimulatedConnection_Close_Idempotent(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	conn := taverntest.NewSimulatedConnection(b, "events")
+	conn.Close()
+	conn.Close() // should not panic
+}
+
+func TestSimulatedConnection_Connected(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	conn := taverntest.NewSimulatedConnection(b, "events")
+
+	if !conn.Connected() {
+		t.Error("expected connected after creation")
+	}
+
+	conn.Disconnect()
+	if conn.Connected() {
+		t.Error("expected disconnected")
+	}
+
+	conn.Reconnect("")
+	if !conn.Connected() {
+		t.Error("expected connected after reconnect")
+	}
+
+	conn.Close()
+}

--- a/taverntest/slow_subscriber.go
+++ b/taverntest/slow_subscriber.go
@@ -1,0 +1,104 @@
+package taverntest
+
+import (
+	"sync"
+	"time"
+
+	"github.com/catgoose/tavern"
+)
+
+// SlowSubscriberConfig configures the simulated slow subscriber.
+type SlowSubscriberConfig struct {
+	// ReadDelay is the time to wait before reading each message from the
+	// subscriber channel. This simulates a client that processes messages
+	// slowly, causing backpressure.
+	ReadDelay time.Duration
+}
+
+// SlowSubscriber simulates a subscriber that reads messages slowly, useful
+// for testing backpressure, drop-oldest behavior, and slow subscriber
+// eviction scenarios.
+type SlowSubscriber struct {
+	msgs   []string
+	mu     sync.Mutex
+	unsub  func()
+	done   chan struct{}
+	closed bool
+}
+
+// NewSlowSubscriber subscribes to the given topic and reads messages with a
+// configurable delay between each read. Call [SlowSubscriber.Close] when done.
+func NewSlowSubscriber(broker *tavern.SSEBroker, topic string, cfg SlowSubscriberConfig) *SlowSubscriber {
+	ch, unsub := broker.Subscribe(topic)
+	s := &SlowSubscriber{
+		unsub: unsub,
+		done:  make(chan struct{}),
+	}
+	go func() {
+		defer close(s.done)
+		for msg := range ch {
+			if cfg.ReadDelay > 0 {
+				time.Sleep(cfg.ReadDelay)
+			}
+			s.mu.Lock()
+			s.msgs = append(s.msgs, msg)
+			s.mu.Unlock()
+		}
+	}()
+	return s
+}
+
+// Close stops reading and unsubscribes. Safe to call multiple times.
+func (s *SlowSubscriber) Close() {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	s.closed = true
+	s.mu.Unlock()
+	s.unsub()
+	<-s.done
+}
+
+// Messages returns a copy of all messages that have been read so far.
+func (s *SlowSubscriber) Messages() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make([]string, len(s.msgs))
+	copy(cp, s.msgs)
+	return cp
+}
+
+// Len returns the number of messages read so far.
+func (s *SlowSubscriber) Len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.msgs)
+}
+
+// WaitFor blocks until at least n messages have been read or the timeout
+// elapses. Returns true if n messages were read, false on timeout.
+func (s *SlowSubscriber) WaitFor(n int, timeout time.Duration) bool {
+	deadline := time.After(timeout)
+	for {
+		s.mu.Lock()
+		count := len(s.msgs)
+		s.mu.Unlock()
+		if count >= n {
+			return true
+		}
+		select {
+		case <-deadline:
+			return false
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+// Done returns a channel that is closed when the subscriber's collection
+// goroutine exits (e.g., because the broker closed the channel or the
+// subscriber was evicted).
+func (s *SlowSubscriber) Done() <-chan struct{} {
+	return s.done
+}

--- a/taverntest/slow_subscriber_test.go
+++ b/taverntest/slow_subscriber_test.go
@@ -1,0 +1,111 @@
+package taverntest_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/catgoose/tavern"
+	"github.com/catgoose/tavern/taverntest"
+)
+
+func TestSlowSubscriber_ReadsWithDelay(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	slow := taverntest.NewSlowSubscriber(b, "events", taverntest.SlowSubscriberConfig{
+		ReadDelay: 20 * time.Millisecond,
+	})
+	defer slow.Close()
+
+	b.Publish("events", "msg1")
+	b.Publish("events", "msg2")
+
+	// Should eventually read both messages
+	if !slow.WaitFor(2, 2*time.Second) {
+		t.Fatal("timed out waiting for slow subscriber to read messages")
+	}
+
+	msgs := slow.Messages()
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+	if msgs[0] != "msg1" || msgs[1] != "msg2" {
+		t.Errorf("unexpected messages: %v", msgs)
+	}
+}
+
+func TestSlowSubscriber_CausesDrops(t *testing.T) {
+	b := tavern.NewSSEBroker(tavern.WithBufferSize(2))
+	defer b.Close()
+
+	slow := taverntest.NewSlowSubscriber(b, "events", taverntest.SlowSubscriberConfig{
+		ReadDelay: 100 * time.Millisecond,
+	})
+	defer slow.Close()
+
+	// Publish more messages than the buffer can hold
+	for i := range 10 {
+		b.Publish("events", time.Duration(i).String())
+	}
+
+	// Some messages should be dropped
+	time.Sleep(200 * time.Millisecond)
+	drops := b.PublishDrops()
+	if drops == 0 {
+		t.Log("no drops detected; buffer was large enough (may vary by timing)")
+	}
+}
+
+func TestSlowSubscriber_Eviction(t *testing.T) {
+	b := tavern.NewSSEBroker(
+		tavern.WithBufferSize(1),
+		tavern.WithSlowSubscriberEviction(3),
+	)
+	defer b.Close()
+
+	slow := taverntest.NewSlowSubscriber(b, "events", taverntest.SlowSubscriberConfig{
+		ReadDelay: 500 * time.Millisecond,
+	})
+
+	// Flood the subscriber to trigger eviction
+	for range 20 {
+		b.Publish("events", "flood")
+	}
+
+	// Subscriber should be evicted — its done channel should close
+	select {
+	case <-slow.Done():
+		// evicted as expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected slow subscriber to be evicted")
+		slow.Close()
+	}
+}
+
+func TestSlowSubscriber_Close_Idempotent(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	slow := taverntest.NewSlowSubscriber(b, "events", taverntest.SlowSubscriberConfig{})
+	slow.Close()
+	slow.Close() // should not panic
+}
+
+func TestSlowSubscriber_Len(t *testing.T) {
+	b := tavern.NewSSEBroker()
+	defer b.Close()
+
+	slow := taverntest.NewSlowSubscriber(b, "events", taverntest.SlowSubscriberConfig{})
+	defer slow.Close()
+
+	if slow.Len() != 0 {
+		t.Fatal("expected 0 messages initially")
+	}
+
+	b.Publish("events", "msg")
+	slow.WaitFor(1, time.Second)
+
+	if slow.Len() != 1 {
+		t.Fatal("expected 1 message")
+	}
+}

--- a/taverntest/sse_recorder.go
+++ b/taverntest/sse_recorder.go
@@ -1,0 +1,211 @@
+package taverntest
+
+import (
+	"bufio"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// SSEEvent represents a parsed Server-Sent Event from the SSE stream.
+type SSEEvent struct {
+	// Event is the event type (from the "event:" field). Empty if not set.
+	Event string
+	// Data is the event payload (concatenated "data:" fields, joined by newlines).
+	Data string
+	// ID is the event identifier (from the "id:" field). Empty if not set.
+	ID string
+	// Retry is the raw retry value (from the "retry:" field). Empty if not set.
+	Retry string
+}
+
+// SSERecorder is an [http.ResponseWriter] and [http.Flusher] that captures
+// SSE-formatted output written by handlers. It parses the SSE wire format
+// into structured [SSEEvent] values for easy assertion.
+//
+// Use it like [net/http/httptest.ResponseRecorder] but with SSE-aware
+// assertion methods.
+type SSERecorder struct {
+	mu      sync.Mutex
+	header  http.Header
+	body    strings.Builder
+	code    int
+	flushed int
+}
+
+// NewSSERecorder creates a ready-to-use SSERecorder.
+func NewSSERecorder() *SSERecorder {
+	return &SSERecorder{
+		header: make(http.Header),
+		code:   http.StatusOK,
+	}
+}
+
+// Header returns the response headers.
+func (r *SSERecorder) Header() http.Header {
+	return r.header
+}
+
+// Write writes data to the response body.
+func (r *SSERecorder) Write(b []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.body.Write(b)
+}
+
+// WriteHeader records the HTTP status code.
+func (r *SSERecorder) WriteHeader(code int) {
+	r.mu.Lock()
+	r.code = code
+	r.mu.Unlock()
+}
+
+// Flush records that a flush occurred.
+func (r *SSERecorder) Flush() {
+	r.mu.Lock()
+	r.flushed++
+	r.mu.Unlock()
+}
+
+// Code returns the recorded HTTP status code.
+func (r *SSERecorder) Code() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.code
+}
+
+// Body returns the raw response body as a string.
+func (r *SSERecorder) Body() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.body.String()
+}
+
+// FlushCount returns how many times Flush was called.
+func (r *SSERecorder) FlushCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.flushed
+}
+
+// Events parses the recorded body as an SSE stream and returns the events.
+// Each event is delimited by a blank line (double newline) per the SSE spec.
+// Comment lines (starting with ":") are ignored.
+func (r *SSERecorder) Events() []SSEEvent {
+	r.mu.Lock()
+	raw := r.body.String()
+	r.mu.Unlock()
+	return parseSSEStream(raw)
+}
+
+// parseSSEStream parses an SSE wire-format string into events.
+func parseSSEStream(raw string) []SSEEvent {
+	var events []SSEEvent
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+
+	var current SSEEvent
+	var dataLines []string
+	hasFields := false
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Blank line = event boundary
+		if line == "" {
+			if hasFields {
+				current.Data = strings.Join(dataLines, "\n")
+				events = append(events, current)
+			}
+			current = SSEEvent{}
+			dataLines = nil
+			hasFields = false
+			continue
+		}
+
+		// Comment lines
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+
+		// Parse field: value
+		field, value, _ := strings.Cut(line, ":")
+		value = strings.TrimPrefix(value, " ")
+
+		switch field {
+		case "event":
+			current.Event = value
+			hasFields = true
+		case "data":
+			dataLines = append(dataLines, value)
+			hasFields = true
+		case "id":
+			current.ID = value
+			hasFields = true
+		case "retry":
+			current.Retry = value
+			hasFields = true
+		}
+	}
+
+	// Handle trailing event without final blank line
+	if hasFields {
+		current.Data = strings.Join(dataLines, "\n")
+		events = append(events, current)
+	}
+
+	return events
+}
+
+// AssertEvent fails the test if no recorded event matches the given event
+// name and data.
+func (r *SSERecorder) AssertEvent(t testing.TB, eventName, data string) {
+	t.Helper()
+	events := r.Events()
+	for _, e := range events {
+		if e.Event == eventName && e.Data == data {
+			return
+		}
+	}
+	t.Errorf("expected SSE event(event=%q, data=%q) not found in %d events", eventName, data, len(events))
+}
+
+// AssertEventCount fails the test if the number of recorded events does not
+// equal n.
+func (r *SSERecorder) AssertEventCount(t testing.TB, n int) {
+	t.Helper()
+	events := r.Events()
+	if len(events) != n {
+		t.Errorf("expected %d SSE events, got %d", n, len(events))
+	}
+}
+
+// AssertHasID fails the test if no recorded event has the given ID.
+func (r *SSERecorder) AssertHasID(t testing.TB, id string) {
+	t.Helper()
+	events := r.Events()
+	for _, e := range events {
+		if e.ID == id {
+			return
+		}
+	}
+	t.Errorf("expected SSE event with id=%q not found in %d events", id, len(events))
+}
+
+// AssertContentType fails the test if the Content-Type header is not
+// "text/event-stream".
+func (r *SSERecorder) AssertContentType(t testing.TB) {
+	t.Helper()
+	ct := r.header.Get("Content-Type")
+	if ct != "text/event-stream" {
+		t.Errorf("expected Content-Type %q, got %q", "text/event-stream", ct)
+	}
+}
+
+// AssertFlushed fails the test if Flush was never called.
+func (r *SSERecorder) AssertFlushed(t testing.TB) {
+	t.Helper()
+	if r.FlushCount() == 0 {
+		t.Error("expected at least one Flush call")
+	}
+}

--- a/taverntest/sse_recorder_test.go
+++ b/taverntest/sse_recorder_test.go
@@ -1,0 +1,222 @@
+package taverntest_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/catgoose/tavern/taverntest"
+)
+
+func TestSSERecorder_ImplementsInterfaces(t *testing.T) {
+	rec := taverntest.NewSSERecorder()
+
+	// Verify it satisfies http.ResponseWriter and http.Flusher
+	var _ http.ResponseWriter = rec
+	var _ http.Flusher = rec
+}
+
+func TestSSERecorder_WriteAndBody(t *testing.T) {
+	rec := taverntest.NewSSERecorder()
+
+	n, err := rec.Write([]byte("hello "))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 6 {
+		t.Errorf("expected 6 bytes written, got %d", n)
+	}
+
+	_, _ = rec.Write([]byte("world"))
+
+	if rec.Body() != "hello world" {
+		t.Errorf("unexpected body: %q", rec.Body())
+	}
+}
+
+func TestSSERecorder_WriteHeader(t *testing.T) {
+	rec := taverntest.NewSSERecorder()
+
+	if rec.Code() != http.StatusOK {
+		t.Errorf("expected default status 200, got %d", rec.Code())
+	}
+
+	rec.WriteHeader(http.StatusNotFound)
+	if rec.Code() != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code())
+	}
+}
+
+func TestSSERecorder_Header(t *testing.T) {
+	rec := taverntest.NewSSERecorder()
+
+	rec.Header().Set("Content-Type", "text/event-stream")
+	if rec.Header().Get("Content-Type") != "text/event-stream" {
+		t.Error("expected Content-Type header to be set")
+	}
+}
+
+func TestSSERecorder_Flush(t *testing.T) {
+	rec := taverntest.NewSSERecorder()
+
+	if rec.FlushCount() != 0 {
+		t.Error("expected 0 flushes initially")
+	}
+
+	rec.Flush()
+	rec.Flush()
+
+	if rec.FlushCount() != 2 {
+		t.Errorf("expected 2 flushes, got %d", rec.FlushCount())
+	}
+}
+
+func TestSSERecorder_ParsesEvents(t *testing.T) {
+	rec := taverntest.NewSSERecorder()
+
+	// Write two SSE events
+	fmt.Fprint(rec, "event: message\ndata: hello\n\n")
+	fmt.Fprint(rec, "event: update\ndata: world\nid: 42\n\n")
+
+	events := rec.Events()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+
+	if events[0].Event != "message" {
+		t.Errorf("event[0].Event: expected %q, got %q", "message", events[0].Event)
+	}
+	if events[0].Data != "hello" {
+		t.Errorf("event[0].Data: expected %q, got %q", "hello", events[0].Data)
+	}
+
+	if events[1].Event != "update" {
+		t.Errorf("event[1].Event: expected %q, got %q", "update", events[1].Event)
+	}
+	if events[1].Data != "world" {
+		t.Errorf("event[1].Data: expected %q, got %q", "world", events[1].Data)
+	}
+	if events[1].ID != "42" {
+		t.Errorf("event[1].ID: expected %q, got %q", "42", events[1].ID)
+	}
+}
+
+func TestSSERecorder_ParsesMultilineData(t *testing.T) {
+	rec := taverntest.NewSSERecorder()
+
+	fmt.Fprint(rec, "event: msg\ndata: line1\ndata: line2\ndata: line3\n\n")
+
+	events := rec.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Data != "line1\nline2\nline3" {
+		t.Errorf("expected multiline data, got %q", events[0].Data)
+	}
+}
+
+func TestSSERecorder_IgnoresComments(t *testing.T) {
+	rec := taverntest.NewSSERecorder()
+
+	fmt.Fprint(rec, ": keepalive\nevent: msg\ndata: hello\n\n")
+
+	events := rec.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Data != "hello" {
+		t.Errorf("expected %q, got %q", "hello", events[0].Data)
+	}
+}
+
+func TestSSERecorder_ParsesRetry(t *testing.T) {
+	rec := taverntest.NewSSERecorder()
+
+	fmt.Fprint(rec, "event: msg\ndata: hello\nretry: 3000\n\n")
+
+	events := rec.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Retry != "3000" {
+		t.Errorf("expected retry %q, got %q", "3000", events[0].Retry)
+	}
+}
+
+func TestSSERecorder_AssertEvent(t *testing.T) {
+	rec := taverntest.NewSSERecorder()
+
+	fmt.Fprint(rec, "event: greeting\ndata: hello\n\n")
+	fmt.Fprint(rec, "event: farewell\ndata: bye\n\n")
+
+	rec.AssertEvent(t, "greeting", "hello")
+	rec.AssertEvent(t, "farewell", "bye")
+}
+
+func TestSSERecorder_AssertEventCount(t *testing.T) {
+	rec := taverntest.NewSSERecorder()
+
+	fmt.Fprint(rec, "event: a\ndata: 1\n\n")
+	fmt.Fprint(rec, "event: b\ndata: 2\n\n")
+	fmt.Fprint(rec, "event: c\ndata: 3\n\n")
+
+	rec.AssertEventCount(t, 3)
+}
+
+func TestSSERecorder_AssertHasID(t *testing.T) {
+	rec := taverntest.NewSSERecorder()
+
+	fmt.Fprint(rec, "event: msg\ndata: hello\nid: evt-123\n\n")
+
+	rec.AssertHasID(t, "evt-123")
+}
+
+func TestSSERecorder_AssertContentType(t *testing.T) {
+	rec := taverntest.NewSSERecorder()
+
+	rec.Header().Set("Content-Type", "text/event-stream")
+	rec.AssertContentType(t)
+}
+
+func TestSSERecorder_AssertFlushed(t *testing.T) {
+	rec := taverntest.NewSSERecorder()
+
+	rec.Flush()
+	rec.AssertFlushed(t)
+}
+
+func TestSSERecorder_TrailingEventWithoutBlankLine(t *testing.T) {
+	rec := taverntest.NewSSERecorder()
+
+	// Event without trailing blank line (edge case)
+	fmt.Fprint(rec, "event: msg\ndata: trailing")
+
+	events := rec.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Data != "trailing" {
+		t.Errorf("expected %q, got %q", "trailing", events[0].Data)
+	}
+}
+
+func TestSSERecorder_EmptyBody(t *testing.T) {
+	rec := taverntest.NewSSERecorder()
+
+	events := rec.Events()
+	if len(events) != 0 {
+		t.Errorf("expected 0 events from empty body, got %d", len(events))
+	}
+}
+
+func TestSSERecorder_WithSSEMessage(t *testing.T) {
+	// Test that SSERecorder can parse output from tavern.SSEMessage.String()
+	rec := taverntest.NewSSERecorder()
+
+	// This matches the format from tavern.NewSSEMessage("update", "data").WithID("5").String()
+	fmt.Fprint(rec, "event: update\ndata: hello world\nid: 5\n\n")
+
+	rec.AssertEvent(t, "update", "hello world")
+	rec.AssertHasID(t, "5")
+	rec.AssertEventCount(t, 1)
+}


### PR DESCRIPTION
## Summary

- Adds **MockBroker** to record publishes for assertion without a real broker, supporting `Publish`, `PublishTo`, `PublishOOB`, and `PublishOOBTo` with assertion helpers
- Adds **Capture** to subscribe to a real broker and collect messages with declarative `AssertReceived`, `AssertReceivedWithin`, and `AssertReceivedExactly` methods
- Adds **SlowSubscriber** to simulate backpressure scenarios with configurable `ReadDelay`, useful for testing drop-oldest and slow subscriber eviction
- Adds **SimulatedConnection** to model disconnect/reconnect lifecycle with `Last-Event-ID` resumption support and `AssertReceivedAfterReconnect`
- Adds **SSERecorder** implementing `http.ResponseWriter` + `http.Flusher` that parses SSE wire format into structured events with `AssertEvent`, `AssertEventCount`, and `AssertHasID`

All utilities include comprehensive tests. Closes #90.

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [ ] Verify MockBroker records all publish variants correctly
- [ ] Verify Capture collects messages from real broker with order-independent and exact assertions
- [ ] Verify SlowSubscriber triggers drops and eviction under backpressure
- [ ] Verify SimulatedConnection handles disconnect/reconnect with Last-Event-ID replay
- [ ] Verify SSERecorder parses multiline data, comments, retry fields, and trailing events