### PR TITLE
feat: structured error handling and circuit breaker

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -58,6 +58,7 @@ type SSEBroker struct {
 	dynGroupsMu       sync.RWMutex                   // protects dynGroups
 	middlewares       []Middleware                    // global publish middleware
 	topicMiddlewares  []topicMiddleware               // topic-scoped publish middleware
+	onRenderError     func(*RenderError)             // nil = no callback
 }
 
 // Topic name constants are conventions for common real-time use cases.
@@ -366,6 +367,28 @@ func (b *SSEBroker) OnLastUnsubscribe(topic string, fn func(topic string)) {
 		return
 	}
 	b.onLast[topic] = append(b.onLast[topic], fn)
+}
+
+// OnRenderError registers a callback that fires when a render function fails.
+// This applies to lazy OOB renders and scheduled section renders. Only one
+// callback is supported; subsequent calls replace the previous callback.
+// The callback receives a [*RenderError] with structured information about
+// the failure. The callback runs synchronously in the goroutine where the
+// error occurred — avoid blocking operations.
+func (b *SSEBroker) OnRenderError(fn func(*RenderError)) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.onRenderError = fn
+}
+
+// fireRenderError invokes the registered render error callback, if any.
+func (b *SSEBroker) fireRenderError(re *RenderError) {
+	b.mu.RLock()
+	fn := b.onRenderError
+	b.mu.RUnlock()
+	if fn != nil {
+		fn(re)
+	}
 }
 
 // HasSubscribers reports whether the given topic has at least one active

--- a/circuit.go
+++ b/circuit.go
@@ -1,0 +1,134 @@
+package tavern
+
+import (
+	"sync"
+	"time"
+)
+
+// circuitState represents the current state of a circuit breaker.
+type circuitState int
+
+const (
+	circuitClosed   circuitState = iota // normal operation
+	circuitOpen                         // failures exceeded threshold, not calling render
+	circuitHalfOpen                     // recovery attempt in progress
+)
+
+// CircuitBreakerConfig configures a circuit breaker for a scheduled section.
+type CircuitBreakerConfig struct {
+	// FailureThreshold is the number of consecutive failures before the
+	// circuit opens. Must be at least 1.
+	FailureThreshold int
+
+	// RecoveryInterval is how long the circuit stays open before trying a
+	// half-open probe. Must be positive.
+	RecoveryInterval time.Duration
+
+	// FallbackRender is called when the circuit is open. If nil, the section
+	// is skipped while the circuit is open.
+	FallbackRender func() string
+}
+
+// RenderError contains structured information about a render failure.
+type RenderError struct {
+	// Topic is the broker topic or scheduled publisher event associated with the error.
+	Topic string
+
+	// Section is the section name within a ScheduledPublisher (empty for broker-level errors).
+	Section string
+
+	// Err is the underlying error returned by the render function.
+	Err error
+
+	// Timestamp is when the error occurred.
+	Timestamp time.Time
+
+	// Count is the current consecutive failure count.
+	Count int
+}
+
+// Error implements the error interface.
+func (e *RenderError) Error() string {
+	return e.Err.Error()
+}
+
+// Unwrap returns the underlying error.
+func (e *RenderError) Unwrap() error {
+	return e.Err
+}
+
+// circuitBreaker tracks the state machine for a single section.
+type circuitBreaker struct {
+	mu           sync.Mutex
+	config       CircuitBreakerConfig
+	state        circuitState
+	failures     int
+	lastFailure  time.Time
+	nowFunc      func() time.Time // for testing; defaults to time.Now
+}
+
+// newCircuitBreaker creates a circuit breaker with the given config.
+func newCircuitBreaker(cfg CircuitBreakerConfig) *circuitBreaker {
+	return &circuitBreaker{
+		config:  cfg,
+		state:   circuitClosed,
+		nowFunc: time.Now,
+	}
+}
+
+// allow reports whether the render function should be called. It also
+// transitions from open to half-open when the recovery interval has elapsed.
+func (cb *circuitBreaker) allow() bool {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	switch cb.state {
+	case circuitClosed:
+		return true
+	case circuitOpen:
+		if cb.nowFunc().Sub(cb.lastFailure) >= cb.config.RecoveryInterval {
+			cb.state = circuitHalfOpen
+			return true
+		}
+		return false
+	case circuitHalfOpen:
+		// Already probing — allow the single probe call.
+		return true
+	}
+	return false
+}
+
+// recordSuccess resets the failure counter and closes the circuit.
+func (cb *circuitBreaker) recordSuccess() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	cb.failures = 0
+	cb.state = circuitClosed
+}
+
+// recordFailure increments the failure counter and may open the circuit.
+// Returns the current consecutive failure count.
+func (cb *circuitBreaker) recordFailure() int {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	cb.failures++
+	cb.lastFailure = cb.nowFunc()
+	if cb.failures >= cb.config.FailureThreshold {
+		cb.state = circuitOpen
+	}
+	return cb.failures
+}
+
+// currentState returns the current circuit state (for testing/observability).
+func (cb *circuitBreaker) currentState() circuitState {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	return cb.state
+}
+
+// consecutiveFailures returns the current failure count (for testing/observability).
+func (cb *circuitBreaker) consecutiveFailures() int {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	return cb.failures
+}

--- a/circuit_test.go
+++ b/circuit_test.go
@@ -1,0 +1,515 @@
+package tavern
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- circuitBreaker unit tests ---
+
+func TestCircuitBreaker_StartsInClosed(t *testing.T) {
+	cb := newCircuitBreaker(CircuitBreakerConfig{
+		FailureThreshold: 3,
+		RecoveryInterval: time.Second,
+	})
+	assert.Equal(t, circuitClosed, cb.currentState())
+	assert.True(t, cb.allow())
+}
+
+func TestCircuitBreaker_OpensAfterThreshold(t *testing.T) {
+	cb := newCircuitBreaker(CircuitBreakerConfig{
+		FailureThreshold: 3,
+		RecoveryInterval: time.Second,
+	})
+
+	cb.recordFailure()
+	assert.Equal(t, circuitClosed, cb.currentState())
+	assert.True(t, cb.allow())
+
+	cb.recordFailure()
+	assert.Equal(t, circuitClosed, cb.currentState())
+
+	cb.recordFailure()
+	assert.Equal(t, circuitOpen, cb.currentState())
+	assert.False(t, cb.allow())
+}
+
+func TestCircuitBreaker_SuccessResets(t *testing.T) {
+	cb := newCircuitBreaker(CircuitBreakerConfig{
+		FailureThreshold: 3,
+		RecoveryInterval: time.Second,
+	})
+
+	cb.recordFailure()
+	cb.recordFailure()
+	assert.Equal(t, 2, cb.consecutiveFailures())
+
+	cb.recordSuccess()
+	assert.Equal(t, 0, cb.consecutiveFailures())
+	assert.Equal(t, circuitClosed, cb.currentState())
+}
+
+func TestCircuitBreaker_HalfOpenAfterRecoveryInterval(t *testing.T) {
+	now := time.Now()
+	cb := newCircuitBreaker(CircuitBreakerConfig{
+		FailureThreshold: 2,
+		RecoveryInterval: 100 * time.Millisecond,
+	})
+	cb.nowFunc = func() time.Time { return now }
+
+	cb.recordFailure()
+	cb.recordFailure()
+	assert.Equal(t, circuitOpen, cb.currentState())
+	assert.False(t, cb.allow())
+
+	// Advance time past recovery interval.
+	now = now.Add(150 * time.Millisecond)
+	assert.True(t, cb.allow())
+	assert.Equal(t, circuitHalfOpen, cb.currentState())
+}
+
+func TestCircuitBreaker_HalfOpenSuccessCloses(t *testing.T) {
+	now := time.Now()
+	cb := newCircuitBreaker(CircuitBreakerConfig{
+		FailureThreshold: 1,
+		RecoveryInterval: 50 * time.Millisecond,
+	})
+	cb.nowFunc = func() time.Time { return now }
+
+	cb.recordFailure()
+	assert.Equal(t, circuitOpen, cb.currentState())
+
+	now = now.Add(60 * time.Millisecond)
+	assert.True(t, cb.allow()) // transitions to half-open
+	assert.Equal(t, circuitHalfOpen, cb.currentState())
+
+	cb.recordSuccess()
+	assert.Equal(t, circuitClosed, cb.currentState())
+	assert.Equal(t, 0, cb.consecutiveFailures())
+}
+
+func TestCircuitBreaker_HalfOpenFailureReopens(t *testing.T) {
+	now := time.Now()
+	cb := newCircuitBreaker(CircuitBreakerConfig{
+		FailureThreshold: 1,
+		RecoveryInterval: 50 * time.Millisecond,
+	})
+	cb.nowFunc = func() time.Time { return now }
+
+	cb.recordFailure()
+	assert.Equal(t, circuitOpen, cb.currentState())
+
+	now = now.Add(60 * time.Millisecond)
+	assert.True(t, cb.allow()) // half-open
+
+	cb.recordFailure()
+	assert.Equal(t, circuitOpen, cb.currentState())
+}
+
+func TestCircuitBreaker_RecordFailureReturnsCount(t *testing.T) {
+	cb := newCircuitBreaker(CircuitBreakerConfig{
+		FailureThreshold: 5,
+		RecoveryInterval: time.Second,
+	})
+
+	assert.Equal(t, 1, cb.recordFailure())
+	assert.Equal(t, 2, cb.recordFailure())
+	assert.Equal(t, 3, cb.recordFailure())
+}
+
+// --- OnRenderError callback tests ---
+
+func TestOnRenderError_FiredOnScheduledSectionError(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	var captured *RenderError
+	var mu sync.Mutex
+	b.OnRenderError(func(re *RenderError) {
+		mu.Lock()
+		captured = re
+		mu.Unlock()
+	})
+
+	pub := b.NewScheduledPublisher("onerr", WithBaseTick(10*time.Millisecond))
+	pub.Register("bad-section", 10*time.Millisecond, func(_ context.Context, buf *bytes.Buffer) error {
+		return errors.New("db connection lost")
+	})
+
+	ch, unsub := b.Subscribe("onerr")
+	defer unsub()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go pub.Start(ctx)
+
+	// Wait for at least one tick.
+	time.Sleep(60 * time.Millisecond)
+
+	// Drain channel — no messages should arrive since the section errors.
+	select {
+	case <-ch:
+		// might receive empty messages if other sections exist
+	default:
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotNil(t, captured, "OnRenderError callback should have fired")
+	assert.Equal(t, "onerr", captured.Topic)
+	assert.Equal(t, "bad-section", captured.Section)
+	assert.Equal(t, "db connection lost", captured.Err.Error())
+	assert.Greater(t, captured.Count, 0)
+}
+
+func TestOnRenderError_NotFiredOnSuccess(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	var called atomic.Int64
+	b.OnRenderError(func(_ *RenderError) {
+		called.Add(1)
+	})
+
+	pub := b.NewScheduledPublisher("ok", WithBaseTick(10*time.Millisecond))
+	pub.Register("good", 10*time.Millisecond, func(_ context.Context, buf *bytes.Buffer) error {
+		buf.WriteString("fine")
+		return nil
+	})
+
+	ch, unsub := b.Subscribe("ok")
+	defer unsub()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go pub.Start(ctx)
+
+	select {
+	case <-ch:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for message")
+	}
+
+	assert.Equal(t, int64(0), called.Load())
+}
+
+func TestOnRenderError_NilCallbackSafe(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	// No callback registered — should not panic.
+	b.fireRenderError(&RenderError{
+		Topic: "test",
+		Err:   errors.New("oops"),
+	})
+}
+
+// --- Circuit breaker integration with ScheduledPublisher ---
+
+func TestScheduledPublisher_CircuitBreaker_OpensAfterFailures(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	var renderCalls atomic.Int64
+	pub := b.NewScheduledPublisher("cb-open", WithBaseTick(10*time.Millisecond))
+	pub.Register("flaky", 10*time.Millisecond, func(_ context.Context, buf *bytes.Buffer) error {
+		renderCalls.Add(1)
+		return errors.New("fail")
+	}, SectionOptions{
+		CircuitBreaker: &CircuitBreakerConfig{
+			FailureThreshold: 3,
+			RecoveryInterval: 5 * time.Second, // long enough that it won't recover during test
+		},
+	})
+
+	_, unsub := b.Subscribe("cb-open")
+	defer unsub()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go pub.Start(ctx)
+
+	// Wait enough ticks for 3+ failures then circuit opens.
+	time.Sleep(150 * time.Millisecond)
+
+	calls := renderCalls.Load()
+	// After 3 failures the circuit opens, so calls should stop growing.
+	// Wait a bit more and confirm no new calls.
+	time.Sleep(100 * time.Millisecond)
+	callsAfter := renderCalls.Load()
+
+	// The render should have been called at least 3 times (to trip the breaker)
+	// but not much more after that.
+	assert.GreaterOrEqual(t, calls, int64(3))
+	assert.LessOrEqual(t, callsAfter-calls, int64(1), "render should stop being called after circuit opens")
+}
+
+func TestScheduledPublisher_CircuitBreaker_FallbackWhenOpen(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	pub := b.NewScheduledPublisher("cb-fallback", WithBaseTick(10*time.Millisecond))
+	pub.Register("flaky", 10*time.Millisecond, func(_ context.Context, buf *bytes.Buffer) error {
+		return errors.New("fail")
+	}, SectionOptions{
+		CircuitBreaker: &CircuitBreakerConfig{
+			FailureThreshold: 1,
+			RecoveryInterval: 5 * time.Second,
+			FallbackRender:   func() string { return "<div>fallback</div>" },
+		},
+	})
+
+	ch, unsub := b.Subscribe("cb-fallback")
+	defer unsub()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go pub.Start(ctx)
+
+	// First tick: render fails, circuit opens, fallback rendered.
+	// Second tick: circuit open, fallback rendered.
+	var gotFallback bool
+	deadline := time.After(500 * time.Millisecond)
+outer:
+	for i := 0; i < 5; i++ {
+		select {
+		case msg := <-ch:
+			if msg == "<div>fallback</div>" {
+				gotFallback = true
+				break outer
+			}
+		case <-deadline:
+			break outer
+		}
+	}
+	assert.True(t, gotFallback, "should receive fallback content when circuit is open")
+}
+
+func TestScheduledPublisher_CircuitBreaker_Recovery(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	var shouldFail atomic.Bool
+	shouldFail.Store(true)
+
+	pub := b.NewScheduledPublisher("cb-recover", WithBaseTick(10*time.Millisecond))
+	pub.Register("recovering", 10*time.Millisecond, func(_ context.Context, buf *bytes.Buffer) error {
+		if shouldFail.Load() {
+			return errors.New("fail")
+		}
+		buf.WriteString("recovered")
+		return nil
+	}, SectionOptions{
+		CircuitBreaker: &CircuitBreakerConfig{
+			FailureThreshold: 2,
+			RecoveryInterval: 80 * time.Millisecond,
+		},
+	})
+
+	ch, unsub := b.Subscribe("cb-recover")
+	defer unsub()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go pub.Start(ctx)
+
+	// Let it fail and open the circuit.
+	time.Sleep(100 * time.Millisecond)
+
+	// Now fix the render function.
+	shouldFail.Store(false)
+
+	// Wait for recovery interval + a few ticks.
+	var gotRecovered bool
+	deadline := time.After(500 * time.Millisecond)
+loop:
+	for {
+		select {
+		case msg := <-ch:
+			if msg == "recovered" {
+				gotRecovered = true
+				break loop
+			}
+		case <-deadline:
+			break loop
+		}
+	}
+	assert.True(t, gotRecovered, "should recover after recovery interval when render succeeds")
+}
+
+func TestScheduledPublisher_CircuitBreaker_NoFallbackSkipsWhenOpen(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	pub := b.NewScheduledPublisher("cb-skip", WithBaseTick(10*time.Millisecond))
+
+	var renderCalls atomic.Int64
+	pub.Register("no-fallback", 10*time.Millisecond, func(_ context.Context, buf *bytes.Buffer) error {
+		renderCalls.Add(1)
+		return errors.New("fail")
+	}, SectionOptions{
+		CircuitBreaker: &CircuitBreakerConfig{
+			FailureThreshold: 1,
+			RecoveryInterval: 5 * time.Second,
+			// No FallbackRender
+		},
+	})
+
+	// Also add a healthy section to confirm messages still flow.
+	pub.Register("healthy", 10*time.Millisecond, func(_ context.Context, buf *bytes.Buffer) error {
+		buf.WriteString("ok")
+		return nil
+	})
+
+	ch, unsub := b.Subscribe("cb-skip")
+	defer unsub()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go pub.Start(ctx)
+
+	// Should still receive messages from the healthy section.
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "ok", msg)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for healthy section message")
+	}
+}
+
+func TestScheduledPublisher_CircuitBreaker_ErrorCallbackWithCount(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	var errors_ []*RenderError
+	var mu sync.Mutex
+	b.OnRenderError(func(re *RenderError) {
+		mu.Lock()
+		errors_ = append(errors_, re)
+		mu.Unlock()
+	})
+
+	pub := b.NewScheduledPublisher("cb-count", WithBaseTick(10*time.Millisecond))
+	pub.Register("counting", 10*time.Millisecond, func(_ context.Context, buf *bytes.Buffer) error {
+		return fmt.Errorf("err")
+	}, SectionOptions{
+		CircuitBreaker: &CircuitBreakerConfig{
+			FailureThreshold: 3,
+			RecoveryInterval: 5 * time.Second,
+		},
+	})
+
+	_, unsub := b.Subscribe("cb-count")
+	defer unsub()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go pub.Start(ctx)
+
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.GreaterOrEqual(t, len(errors_), 3, "should have at least 3 error callbacks")
+
+	// Verify counts increment.
+	assert.Equal(t, 1, errors_[0].Count)
+	assert.Equal(t, 2, errors_[1].Count)
+	assert.Equal(t, 3, errors_[2].Count)
+}
+
+func TestScheduledPublisher_CircuitBreaker_WithRegularSection(t *testing.T) {
+	// Ensure that sections without circuit breaker still work fine alongside ones with.
+	b := NewSSEBroker()
+	defer b.Close()
+
+	pub := b.NewScheduledPublisher("mixed", WithBaseTick(10*time.Millisecond))
+	pub.Register("with-cb", 10*time.Millisecond, func(_ context.Context, buf *bytes.Buffer) error {
+		buf.WriteString("[cb]")
+		return nil
+	}, SectionOptions{
+		CircuitBreaker: &CircuitBreakerConfig{
+			FailureThreshold: 5,
+			RecoveryInterval: time.Second,
+		},
+	})
+	pub.Register("without-cb", 10*time.Millisecond, func(_ context.Context, buf *bytes.Buffer) error {
+		buf.WriteString("[plain]")
+		return nil
+	})
+
+	ch, unsub := b.Subscribe("mixed")
+	defer unsub()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go pub.Start(ctx)
+
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "[cb]")
+		assert.Contains(t, msg, "[plain]")
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out")
+	}
+}
+
+// --- RenderError struct tests ---
+
+func TestRenderError_ErrorInterface(t *testing.T) {
+	underlying := errors.New("something broke")
+	re := &RenderError{
+		Topic: "test",
+		Err:   underlying,
+	}
+	assert.Equal(t, "something broke", re.Error())
+	assert.ErrorIs(t, re, underlying)
+}
+
+func TestRenderError_Unwrap(t *testing.T) {
+	sentinel := errors.New("sentinel")
+	wrapped := fmt.Errorf("wrapped: %w", sentinel)
+	re := &RenderError{
+		Err: wrapped,
+	}
+	assert.ErrorIs(t, re, sentinel)
+}
+
+// --- RenderComponentErr tests ---
+
+type okComponent struct{}
+
+func (c okComponent) Render(_ context.Context, w io.Writer) error {
+	_, err := w.Write([]byte("<p>ok</p>"))
+	return err
+}
+
+type errComponent struct{}
+
+func (c errComponent) Render(_ context.Context, _ io.Writer) error {
+	return errors.New("component failed")
+}
+
+func TestRenderComponentErr_Success(t *testing.T) {
+	html, err := RenderComponentErr(okComponent{})
+	require.NoError(t, err)
+	assert.Equal(t, "<p>ok</p>", html)
+}
+
+func TestRenderComponentErr_Error(t *testing.T) {
+	html, err := RenderComponentErr(errComponent{})
+	require.Error(t, err)
+	assert.Equal(t, "", html)
+	assert.Equal(t, "component failed", err.Error())
+}

--- a/oob.go
+++ b/oob.go
@@ -122,6 +122,18 @@ func (b *SSEBroker) PublishIfChangedOOBTo(topic, scope string, fragments ...Frag
 	return b.PublishIfChangedTo(topic, scope, msg)
 }
 
+// RenderComponentErr renders a Component to a string, returning the error
+// separately instead of embedding it in an HTML comment. This is useful when
+// you want to handle render errors explicitly rather than silently embedding
+// them in the output.
+func RenderComponentErr(cmp Component) (string, error) {
+	var buf bytes.Buffer
+	if err := cmp.Render(context.Background(), &buf); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
 // PublishLazyOOB calls renderFn only if the topic has subscribers, then
 // publishes the rendered fragments. This avoids expensive rendering (DB
 // queries, template execution) when nobody is listening. If renderFn returns

--- a/scheduled.go
+++ b/scheduled.go
@@ -25,10 +25,18 @@ type ScheduledPublisher struct {
 	logger   *slog.Logger
 }
 
+// SectionOptions configures optional behavior for a registered section.
+type SectionOptions struct {
+	// CircuitBreaker enables circuit breaker protection for the section.
+	// When nil, the section renders normally without circuit breaker logic.
+	CircuitBreaker *CircuitBreakerConfig
+}
+
 type section struct {
 	name     string
 	interval time.Duration
 	render   RenderFunc
+	cb       *circuitBreaker // nil when no circuit breaker configured
 }
 
 // ScheduledPublisherOption configures the scheduled publisher.
@@ -58,13 +66,17 @@ func (b *SSEBroker) NewScheduledPublisher(event string, opts ...ScheduledPublish
 
 // Register adds a named section with an interval and render function.
 // Sections are rendered in registration order.
-func (p *ScheduledPublisher) Register(name string, interval time.Duration, fn RenderFunc) {
-	p.mu.Lock()
-	p.sections = append(p.sections, section{
+func (p *ScheduledPublisher) Register(name string, interval time.Duration, fn RenderFunc, opts ...SectionOptions) {
+	s := section{
 		name:     name,
 		interval: interval,
 		render:   fn,
-	})
+	}
+	if len(opts) > 0 && opts[0].CircuitBreaker != nil {
+		s.cb = newCircuitBreaker(*opts[0].CircuitBreaker)
+	}
+	p.mu.Lock()
+	p.sections = append(p.sections, s)
 	p.mu.Unlock()
 }
 
@@ -114,16 +126,7 @@ func (p *ScheduledPublisher) Start(ctx context.Context) {
 				if now.Sub(lastSent[s.name]) < s.interval {
 					continue
 				}
-				if err := p.renderSection(ctx, s, buf); err != nil {
-					if p.logger != nil {
-						p.logger.Error("section render error",
-							"section", s.name,
-							"event", p.event,
-							"error", err,
-						)
-					}
-					continue
-				}
+				p.tickSection(ctx, s, buf, now)
 				lastSent[s.name] = now
 			}
 			p.mu.RUnlock()
@@ -133,6 +136,56 @@ func (p *ScheduledPublisher) Start(ctx context.Context) {
 			}
 		}
 	}
+}
+
+// tickSection handles a single section render with circuit breaker and error callback support.
+func (p *ScheduledPublisher) tickSection(ctx context.Context, s *section, buf *bytes.Buffer, now time.Time) {
+	// No circuit breaker — render directly.
+	if s.cb == nil {
+		if err := p.renderSection(ctx, s, buf); err != nil {
+			p.handleSectionError(s, err, now, 1)
+		}
+		return
+	}
+
+	// Circuit breaker is configured.
+	if !s.cb.allow() {
+		// Circuit is open — use fallback if available.
+		if s.cb.config.FallbackRender != nil {
+			buf.WriteString(s.cb.config.FallbackRender())
+		}
+		return
+	}
+
+	if err := p.renderSection(ctx, s, buf); err != nil {
+		count := s.cb.recordFailure()
+		p.handleSectionError(s, err, now, count)
+		// If circuit just opened and fallback exists, render fallback.
+		if s.cb.currentState() == circuitOpen && s.cb.config.FallbackRender != nil {
+			buf.WriteString(s.cb.config.FallbackRender())
+		}
+		return
+	}
+
+	s.cb.recordSuccess()
+}
+
+// handleSectionError logs the error and fires the broker's render error callback.
+func (p *ScheduledPublisher) handleSectionError(s *section, err error, now time.Time, count int) {
+	if p.logger != nil {
+		p.logger.Error("section render error",
+			"section", s.name,
+			"event", p.event,
+			"error", err,
+		)
+	}
+	p.broker.fireRenderError(&RenderError{
+		Topic:     p.event,
+		Section:   s.name,
+		Err:       err,
+		Timestamp: now,
+		Count:     count,
+	})
 }
 
 // renderSection calls the render func with panic recovery.


### PR DESCRIPTION
## Summary

- Add `OnRenderError` callback on `SSEBroker` that fires when render functions fail, providing structured `RenderError` with topic, section, error, timestamp, and consecutive failure count
- Add `CircuitBreakerConfig` for `ScheduledPublisher` sections with closed/open/half-open state machine, configurable failure threshold, recovery interval, and optional fallback rendering
- Add `RenderComponentErr` helper that returns errors explicitly instead of embedding them in HTML comments

## Test plan

- [ ] `go test ./...` passes (all new and existing tests)
- [ ] `golangci-lint run ./...` passes with zero issues
- [ ] Verify `OnRenderError` fires on scheduled section render errors
- [ ] Verify circuit breaker state transitions: closed → open after N failures, open → half-open after recovery interval, half-open → closed on success, half-open → open on failure
- [ ] Verify fallback rendering when circuit is open
- [ ] Verify sections without circuit breaker continue working alongside circuit-breaker-enabled ones

Closes #93