### PR TITLE
feat: TTL support for published messages

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -62,6 +62,8 @@ type SSEBroker struct {
 	afterHooks        map[string][]func()              // topic → After hook callbacks
 	mutateHooks       map[string][]func(MutationEvent) // resource → OnMutate handlers
 	activeChains      sync.Map                         // goroutine ID → *afterChain for cycle detection
+	ttlSweeperOnce    sync.Once                      // ensures TTL sweeper starts at most once
+	msgTTLSweep       time.Duration                  // override for TTL sweep interval (0 = default 1s)
 }
 
 // Topic name constants are conventions for common real-time use cases.
@@ -144,6 +146,16 @@ func WithSlowSubscriberEviction(threshold int) BrokerOption {
 func WithSlowSubscriberCallback(fn func(topic string)) BrokerOption {
 	return func(b *SSEBroker) {
 		b.evictCallback = fn
+	}
+}
+
+// WithMessageTTLSweep sets the interval at which the background goroutine
+// checks for expired TTL entries in the replay cache. Default is 1 second.
+// A shorter interval provides faster expiry at the cost of more frequent
+// lock acquisitions. This option only takes effect when TTL publishes are used.
+func WithMessageTTLSweep(interval time.Duration) BrokerOption {
+	return func(b *SSEBroker) {
+		b.msgTTLSweep = interval
 	}
 }
 

--- a/resume.go
+++ b/resume.go
@@ -6,9 +6,13 @@ import (
 )
 
 // ReplayEntry pairs a message with its event ID for resumption support.
+// When ExpiresAt is non-zero, the entry will be removed from the replay
+// cache after that time (see [SSEBroker.PublishWithTTL]).
 type ReplayEntry struct {
-	ID  string
-	Msg string
+	ID           string
+	Msg          string
+	ExpiresAt    time.Time // zero means no expiry
+	AutoRemoveID string    // element ID for OOB delete on expiry (empty = none)
 }
 
 // PublishWithID publishes msg to the topic with an associated event ID.
@@ -88,20 +92,34 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 		}
 	}
 
-	// Find messages after lastEventID.
+	// Find messages after lastEventID, skipping expired TTL entries.
+	now := time.Now()
 	var replayMsgs []string
 	var gapDetected bool
 	if lastEventID == "" {
 		// No Last-Event-ID: replay all cached (same as regular Subscribe).
-		replayMsgs = append([]string(nil), b.replayCache[topic]...)
+		// Filter out expired entries from the replay log if present.
+		if log := b.replayLog[topic]; len(log) > 0 {
+			for _, e := range log {
+				if !e.ExpiresAt.IsZero() && now.After(e.ExpiresAt) {
+					continue
+				}
+				replayMsgs = append(replayMsgs, e.Msg)
+			}
+		} else {
+			replayMsgs = append([]string(nil), b.replayCache[topic]...)
+		}
 	} else {
 		log := b.replayLog[topic]
 		found := false
 		for i, entry := range log {
 			if entry.ID == lastEventID {
 				found = true
-				// Replay everything after this entry.
+				// Replay everything after this entry, skipping expired.
 				for _, e := range log[i+1:] {
+					if !e.ExpiresAt.IsZero() && now.After(e.ExpiresAt) {
+						continue
+					}
 					replayMsgs = append(replayMsgs, e.Msg)
 				}
 				break

--- a/ttl.go
+++ b/ttl.go
@@ -1,0 +1,263 @@
+package tavern
+
+import "time"
+
+// TTLOption configures optional behavior for TTL-based publish methods.
+type TTLOption func(*ttlConfig)
+
+type ttlConfig struct {
+	autoRemoveID string // element ID to send OOB delete on expiry
+}
+
+// WithAutoRemove configures a TTL publish to automatically send an OOB delete
+// fragment for the given element ID when the message expires from the replay
+// cache. This removes the element from currently-connected clients' DOM.
+func WithAutoRemove(elementID string) TTLOption {
+	return func(c *ttlConfig) {
+		c.autoRemoveID = elementID
+	}
+}
+
+// PublishWithTTL behaves like [SSEBroker.PublishWithReplay] but marks the
+// replay cache entry with a time-to-live. After the TTL expires, the entry is
+// removed from the replay cache so new subscribers do not see stale messages.
+// The message is delivered immediately to all current subscribers regardless of
+// the TTL.
+func (b *SSEBroker) PublishWithTTL(topic, msg string, ttl time.Duration, opts ...TTLOption) {
+	cfg := parseTTLOpts(opts)
+	now := time.Now()
+
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return
+	}
+	b.storeReplayWithTTL(topic, msg, now, ttl, cfg)
+
+	subscribers := b.topics[topic]
+	channels := make([]chan string, 0, len(subscribers))
+	for ch := range subscribers {
+		channels = append(channels, ch)
+	}
+	b.mu.Unlock()
+
+	b.ensureTTLSweeper()
+
+	sent, dropped := b.publishToChannels(topic, channels, msg)
+	if b.metrics != nil {
+		tc := b.metrics.counter(topic)
+		tc.published.Add(int64(sent))
+		tc.dropped.Add(int64(dropped))
+	}
+}
+
+// PublishOOBWithTTL renders the given fragments and publishes them with a TTL
+// on the replay cache entry. See [SSEBroker.PublishWithTTL] for TTL semantics.
+func (b *SSEBroker) PublishOOBWithTTL(topic string, ttl time.Duration, fragments ...Fragment) {
+	b.PublishWithTTL(topic, RenderFragments(fragments...), ttl)
+}
+
+// PublishToWithTTL publishes msg to scoped subscribers with a TTL on the
+// replay cache entry. See [SSEBroker.PublishWithTTL] for TTL semantics.
+func (b *SSEBroker) PublishToWithTTL(topic, scope, msg string, ttl time.Duration, opts ...TTLOption) {
+	cfg := parseTTLOpts(opts)
+	now := time.Now()
+
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return
+	}
+	b.storeReplayWithTTL(topic, msg, now, ttl, cfg)
+
+	scopedSubs, exists := b.scopedTopics[topic]
+	var channels []chan string
+	if exists {
+		channels = make([]chan string, 0, len(scopedSubs))
+		for ch, sub := range scopedSubs {
+			if sub.scope == scope {
+				channels = append(channels, ch)
+			}
+		}
+	}
+	b.mu.Unlock()
+
+	b.ensureTTLSweeper()
+
+	sent, dropped := b.publishToChannels(topic, channels, msg)
+	if b.metrics != nil {
+		tc := b.metrics.counter(topic)
+		tc.published.Add(int64(sent))
+		tc.dropped.Add(int64(dropped))
+	}
+}
+
+// PublishIfChangedWithTTL combines deduplication with TTL. The message is
+// published only if it differs from the last PublishIfChanged value for the
+// topic, and the replay cache entry expires after the given TTL. Returns true
+// if published (content changed), false if skipped.
+func (b *SSEBroker) PublishIfChangedWithTTL(topic, msg string, ttl time.Duration, opts ...TTLOption) bool {
+	cfg := parseTTLOpts(opts)
+	h := hashMsg(msg)
+	now := time.Now()
+
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return false
+	}
+	if prev, ok := b.lastHash[topic]; ok && prev == h {
+		b.mu.Unlock()
+		return false
+	}
+	b.lastHash[topic] = h
+	b.storeReplayWithTTL(topic, msg, now, ttl, cfg)
+
+	subscribers := b.topics[topic]
+	channels := make([]chan string, 0, len(subscribers))
+	for ch := range subscribers {
+		channels = append(channels, ch)
+	}
+	b.mu.Unlock()
+
+	b.ensureTTLSweeper()
+
+	sent, dropped := b.publishToChannels(topic, channels, msg)
+	if b.metrics != nil {
+		tc := b.metrics.counter(topic)
+		tc.published.Add(int64(sent))
+		tc.dropped.Add(int64(dropped))
+	}
+	return true
+}
+
+// storeReplayWithTTL adds a message to both the replay cache and replay log
+// with TTL metadata. Must be called with b.mu held.
+func (b *SSEBroker) storeReplayWithTTL(topic, msg string, now time.Time, ttl time.Duration, cfg ttlConfig) {
+	maxSize := 1
+	if n, ok := b.replaySize[topic]; ok {
+		maxSize = n
+	}
+
+	// Update replay cache.
+	msgs := b.replayCache[topic]
+	msgs = append(msgs, msg)
+	if len(msgs) > maxSize {
+		msgs = msgs[len(msgs)-maxSize:]
+	}
+	b.replayCache[topic] = msgs
+
+	// Update replay log with TTL metadata.
+	entry := ReplayEntry{
+		Msg:       msg,
+		ExpiresAt: now.Add(ttl),
+	}
+	if cfg.autoRemoveID != "" {
+		entry.AutoRemoveID = cfg.autoRemoveID
+	}
+	log := b.replayLog[topic]
+	log = append(log, entry)
+	if len(log) > maxSize {
+		log = log[len(log)-maxSize:]
+	}
+	b.replayLog[topic] = log
+}
+
+// ensureTTLSweeper starts the background TTL sweeper goroutine if it has not
+// been started yet. It is safe to call from multiple goroutines.
+func (b *SSEBroker) ensureTTLSweeper() {
+	b.ttlSweeperOnce.Do(func() {
+		go b.ttlSweepLoop()
+	})
+}
+
+// ttlSweepLoop periodically removes expired entries from the replay cache and
+// replay log. When an expired entry has an AutoRemoveID, an OOB delete
+// fragment is published to connected subscribers.
+func (b *SSEBroker) ttlSweepLoop() {
+	ticker := time.NewTicker(b.ttlSweepInterval())
+	defer ticker.Stop()
+	for {
+		select {
+		case <-b.done:
+			return
+		case now := <-ticker.C:
+			b.sweepExpiredEntries(now)
+		}
+	}
+}
+
+// ttlSweepInterval returns the sweep interval. Defaults to 1 second.
+func (b *SSEBroker) ttlSweepInterval() time.Duration {
+	if b.msgTTLSweep > 0 {
+		return b.msgTTLSweep
+	}
+	return time.Second
+}
+
+// sweepExpiredEntries removes expired TTL entries and publishes auto-remove
+// fragments for entries that have an AutoRemoveID.
+func (b *SSEBroker) sweepExpiredEntries(now time.Time) {
+	type autoRemoval struct {
+		topic     string
+		elementID string
+	}
+	var removals []autoRemoval
+
+	b.mu.Lock()
+	for topic, log := range b.replayLog {
+		var kept []ReplayEntry
+		var keptMsgs []string
+		cache := b.replayCache[topic]
+
+		// Build a set of messages to remove based on expired log entries.
+		expiredMsgs := make(map[string]struct{})
+		for _, entry := range log {
+			if !entry.ExpiresAt.IsZero() && now.After(entry.ExpiresAt) {
+				expiredMsgs[entry.Msg] = struct{}{}
+				if entry.AutoRemoveID != "" {
+					removals = append(removals, autoRemoval{
+						topic:     topic,
+						elementID: entry.AutoRemoveID,
+					})
+				}
+			} else {
+				kept = append(kept, entry)
+			}
+		}
+
+		if len(expiredMsgs) > 0 {
+			// Filter replay cache to remove expired messages.
+			for _, msg := range cache {
+				if _, expired := expiredMsgs[msg]; !expired {
+					keptMsgs = append(keptMsgs, msg)
+				}
+			}
+			if len(keptMsgs) == 0 {
+				delete(b.replayCache, topic)
+			} else {
+				b.replayCache[topic] = keptMsgs
+			}
+		}
+
+		if len(kept) == 0 {
+			delete(b.replayLog, topic)
+		} else {
+			b.replayLog[topic] = kept
+		}
+	}
+	b.mu.Unlock()
+
+	// Publish auto-remove fragments outside the lock.
+	for _, r := range removals {
+		b.PublishOOB(r.topic, Delete(r.elementID))
+	}
+}
+
+func parseTTLOpts(opts []TTLOption) ttlConfig {
+	var cfg ttlConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}

--- a/ttl_test.go
+++ b/ttl_test.go
@@ -1,0 +1,394 @@
+package tavern
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishWithTTL_ImmediateDelivery(t *testing.T) {
+	b := NewSSEBroker(WithMessageTTLSweep(10 * time.Millisecond))
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("toasts")
+	defer unsub()
+
+	b.PublishWithTTL("toasts", "hello", 5*time.Second)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "hello", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+}
+
+func TestPublishWithTTL_ReplayBeforeExpiry(t *testing.T) {
+	b := NewSSEBroker(WithMessageTTLSweep(10 * time.Millisecond))
+	defer b.Close()
+
+	b.SetReplayPolicy("toasts", 10)
+	b.PublishWithTTL("toasts", "toast-msg", 5*time.Second)
+
+	// Subscribe immediately — should get the replay.
+	ch, unsub := b.Subscribe("toasts")
+	defer unsub()
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "toast-msg", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for replay")
+	}
+}
+
+func TestPublishWithTTL_ExpiresFromReplay(t *testing.T) {
+	b := NewSSEBroker(WithMessageTTLSweep(10 * time.Millisecond))
+	defer b.Close()
+
+	b.SetReplayPolicy("toasts", 10)
+	b.PublishWithTTL("toasts", "ephemeral", 50*time.Millisecond)
+
+	// Wait for the TTL to expire and the sweeper to run.
+	time.Sleep(150 * time.Millisecond)
+
+	// New subscriber should NOT get the expired message.
+	ch, unsub := b.Subscribe("toasts")
+	defer unsub()
+
+	select {
+	case msg := <-ch:
+		t.Fatalf("expected no replay, got: %s", msg)
+	case <-time.After(100 * time.Millisecond):
+		// Good — no replay.
+	}
+}
+
+func TestPublishWithTTL_NonTTLEntriesSurviveSweep(t *testing.T) {
+	b := NewSSEBroker(WithMessageTTLSweep(10 * time.Millisecond))
+	defer b.Close()
+
+	b.SetReplayPolicy("mixed", 10)
+
+	// Publish a TTL message and a regular replay message.
+	b.PublishWithTTL("mixed", "ephemeral", 50*time.Millisecond)
+	b.PublishWithReplay("mixed", "persistent")
+
+	// Wait for TTL to expire.
+	time.Sleep(150 * time.Millisecond)
+
+	ch, unsub := b.Subscribe("mixed")
+	defer unsub()
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "persistent", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for persistent replay")
+	}
+
+	// Should have no more messages.
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected extra message: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestPublishWithTTL_AutoRemove(t *testing.T) {
+	b := NewSSEBroker(WithMessageTTLSweep(10 * time.Millisecond))
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("toasts")
+	defer unsub()
+
+	b.PublishWithTTL("toasts", "<div id=\"toast-1\">Saved!</div>", 50*time.Millisecond,
+		WithAutoRemove("toast-1"),
+	)
+
+	// Receive the original message.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "Saved!")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+
+	// Wait for expiry — should receive an OOB delete fragment.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, `hx-swap-oob="delete"`)
+		assert.Contains(t, msg, `id="toast-1"`)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for auto-remove message")
+	}
+}
+
+func TestPublishToWithTTL_ScopedDelivery(t *testing.T) {
+	b := NewSSEBroker(WithMessageTTLSweep(10 * time.Millisecond))
+	defer b.Close()
+
+	ch1, unsub1 := b.SubscribeScoped("notif", "user:1")
+	defer unsub1()
+	ch2, unsub2 := b.SubscribeScoped("notif", "user:2")
+	defer unsub2()
+
+	b.PublishToWithTTL("notif", "user:1", "for-user-1", 5*time.Second)
+
+	// user:1 should receive.
+	select {
+	case msg := <-ch1:
+		assert.Equal(t, "for-user-1", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for scoped message")
+	}
+
+	// user:2 should NOT receive.
+	select {
+	case msg := <-ch2:
+		t.Fatalf("user:2 should not receive scoped message, got: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestPublishToWithTTL_ExpiresFromReplay(t *testing.T) {
+	b := NewSSEBroker(WithMessageTTLSweep(10 * time.Millisecond))
+	defer b.Close()
+
+	b.SetReplayPolicy("notif", 10)
+	b.PublishToWithTTL("notif", "user:1", "ephemeral-scoped", 50*time.Millisecond)
+
+	time.Sleep(150 * time.Millisecond)
+
+	ch, unsub := b.Subscribe("notif")
+	defer unsub()
+
+	select {
+	case msg := <-ch:
+		t.Fatalf("expected no replay, got: %s", msg)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestPublishOOBWithTTL(t *testing.T) {
+	b := NewSSEBroker(WithMessageTTLSweep(10 * time.Millisecond))
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("oob-topic")
+	defer unsub()
+
+	b.PublishOOBWithTTL("oob-topic", 5*time.Second, Replace("area", "<p>Updated</p>"))
+
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, `hx-swap-oob="outerHTML"`)
+		assert.Contains(t, msg, "Updated")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for OOB message")
+	}
+}
+
+func TestPublishIfChangedWithTTL_Dedup(t *testing.T) {
+	b := NewSSEBroker(WithMessageTTLSweep(10 * time.Millisecond))
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("dedup")
+	defer unsub()
+
+	ok1 := b.PublishIfChangedWithTTL("dedup", "same", 5*time.Second)
+	assert.True(t, ok1, "first publish should succeed")
+
+	ok2 := b.PublishIfChangedWithTTL("dedup", "same", 5*time.Second)
+	assert.False(t, ok2, "duplicate should be skipped")
+
+	ok3 := b.PublishIfChangedWithTTL("dedup", "different", 5*time.Second)
+	assert.True(t, ok3, "changed content should publish")
+
+	// Drain messages.
+	var got []string
+	for range 2 {
+		select {
+		case msg := <-ch:
+			got = append(got, msg)
+		case <-time.After(time.Second):
+			t.Fatal("timed out")
+		}
+	}
+	assert.Equal(t, []string{"same", "different"}, got)
+}
+
+func TestPublishIfChangedWithTTL_ExpiresFromReplay(t *testing.T) {
+	b := NewSSEBroker(WithMessageTTLSweep(10 * time.Millisecond))
+	defer b.Close()
+
+	b.SetReplayPolicy("dedup-ttl", 10)
+	b.PublishIfChangedWithTTL("dedup-ttl", "temp", 50*time.Millisecond)
+
+	time.Sleep(150 * time.Millisecond)
+
+	ch, unsub := b.Subscribe("dedup-ttl")
+	defer unsub()
+
+	select {
+	case msg := <-ch:
+		t.Fatalf("expected no replay, got: %s", msg)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestPublishWithTTL_AfterClose(t *testing.T) {
+	b := NewSSEBroker()
+	b.Close()
+
+	require.NotPanics(t, func() {
+		b.PublishWithTTL("topic", "msg", time.Second)
+	})
+}
+
+func TestPublishToWithTTL_AfterClose(t *testing.T) {
+	b := NewSSEBroker()
+	b.Close()
+
+	require.NotPanics(t, func() {
+		b.PublishToWithTTL("topic", "scope", "msg", time.Second)
+	})
+}
+
+func TestPublishIfChangedWithTTL_AfterClose(t *testing.T) {
+	b := NewSSEBroker()
+	b.Close()
+
+	require.NotPanics(t, func() {
+		ok := b.PublishIfChangedWithTTL("topic", "msg", time.Second)
+		assert.False(t, ok)
+	})
+}
+
+func TestPublishWithTTL_SubscribeFromID_FiltersExpired(t *testing.T) {
+	b := NewSSEBroker(WithMessageTTLSweep(10 * time.Millisecond))
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+
+	// Publish some entries via PublishWithID, then a TTL entry via replay log.
+	b.PublishWithID("events", "1", "msg-1")
+	b.PublishWithID("events", "2", "msg-2")
+
+	// Manually add a TTL entry to the replay log.
+	b.mu.Lock()
+	log := b.replayLog["events"]
+	log = append(log, ReplayEntry{
+		ID:        "3",
+		Msg:       "ttl-msg",
+		ExpiresAt: time.Now().Add(-time.Second), // already expired
+	})
+	b.replayLog["events"] = log
+	b.mu.Unlock()
+
+	// SubscribeFromID from "1" should skip the expired entry.
+	ch, unsub := b.SubscribeFromID("events", "1")
+	defer unsub()
+
+	var got []string
+	for range 1 {
+		select {
+		case msg := <-ch:
+			got = append(got, msg)
+		case <-time.After(time.Second):
+			t.Fatal("timed out")
+		}
+	}
+	assert.Equal(t, []string{"msg-2"}, got)
+
+	// No more messages.
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestPublishWithTTL_SubscribeFromID_EmptyID_FiltersExpired(t *testing.T) {
+	b := NewSSEBroker(WithMessageTTLSweep(10 * time.Millisecond))
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+
+	// Add entries to the replay log with mixed expiry.
+	b.mu.Lock()
+	b.replayLog["events"] = []ReplayEntry{
+		{ID: "1", Msg: "alive"},
+		{ID: "2", Msg: "expired", ExpiresAt: time.Now().Add(-time.Second)},
+		{ID: "3", Msg: "also-alive"},
+	}
+	b.replayCache["events"] = []string{"alive", "expired", "also-alive"}
+	b.mu.Unlock()
+
+	ch, unsub := b.SubscribeFromID("events", "")
+	defer unsub()
+
+	var got []string
+	for range 2 {
+		select {
+		case msg := <-ch:
+			got = append(got, msg)
+		case <-time.After(time.Second):
+			t.Fatal("timed out")
+		}
+	}
+	assert.Equal(t, []string{"alive", "also-alive"}, got)
+}
+
+func TestPublishWithTTL_MultipleAutoRemove(t *testing.T) {
+	b := NewSSEBroker(WithMessageTTLSweep(10 * time.Millisecond))
+	defer b.Close()
+
+	b.SetReplayPolicy("toasts", 10)
+
+	ch, unsub := b.Subscribe("toasts")
+	defer unsub()
+
+	b.PublishWithTTL("toasts", "toast-a", 50*time.Millisecond, WithAutoRemove("el-a"))
+	b.PublishWithTTL("toasts", "toast-b", 50*time.Millisecond, WithAutoRemove("el-b"))
+
+	// Drain the two original messages.
+	for range 2 {
+		select {
+		case <-ch:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for original message")
+		}
+	}
+
+	// Wait for expiry — should get two delete fragments.
+	var deleteMsgs []string
+	timeout := time.After(time.Second)
+	for range 2 {
+		select {
+		case msg := <-ch:
+			deleteMsgs = append(deleteMsgs, msg)
+		case <-timeout:
+			t.Fatalf("timed out waiting for auto-remove, got %d", len(deleteMsgs))
+		}
+	}
+
+	combined := strings.Join(deleteMsgs, " ")
+	assert.Contains(t, combined, "el-a")
+	assert.Contains(t, combined, "el-b")
+}
+
+func TestWithAutoRemove(t *testing.T) {
+	opt := WithAutoRemove("my-element")
+	var cfg ttlConfig
+	opt(&cfg)
+	assert.Equal(t, "my-element", cfg.autoRemoveID)
+}
+
+func TestWithMessageTTLSweep(t *testing.T) {
+	b := NewSSEBroker(WithMessageTTLSweep(500 * time.Millisecond))
+	defer b.Close()
+	assert.Equal(t, 500*time.Millisecond, b.msgTTLSweep)
+}


### PR DESCRIPTION
## Summary

- Add `PublishWithTTL`, `PublishOOBWithTTL`, `PublishToWithTTL`, and `PublishIfChangedWithTTL` methods for ephemeral state (toasts, typing indicators) that auto-expires from the replay cache
- Background sweeper goroutine periodically removes expired entries; `WithAutoRemove` option sends OOB delete fragment on expiry so connected clients also clear the element
- `ReplayEntry` extended with `ExpiresAt` and `AutoRemoveID` fields; `SubscribeFromID` filters expired entries during replay

Closes #82

## Test plan

- [x] `go test ./...` passes (17 new TTL tests covering immediate delivery, replay before/after expiry, auto-remove, scoped TTL, dedup+TTL, close safety, SubscribeFromID filtering)
- [x] `golangci-lint run ./...` passes with 0 issues