### PR TITLE
feat: per-subscriber rate limiting

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -64,6 +64,7 @@ type SSEBroker struct {
 	activeChains      sync.Map                         // goroutine ID → *afterChain for cycle detection
 	ttlSweeperOnce    sync.Once                      // ensures TTL sweeper starts at most once
 	msgTTLSweep       time.Duration                  // override for TTL sweep interval (0 = default 1s)
+	rateLimit         *rateLimiter                     // per-subscriber rate limiting
 }
 
 // Topic name constants are conventions for common real-time use cases.
@@ -197,6 +198,7 @@ func NewSSEBroker(opts ...BrokerOption) *SSEBroker {
 	initGroupFields(b)
 	b.debounce.timers = make(map[string]*debounceEntry)
 	b.throttle.state = make(map[string]*throttleEntry)
+	b.rateLimit = newRateLimiter()
 	if b.evictThreshold > 0 {
 		b.dropCounts = make(map[chan string]*atomic.Int64)
 	}
@@ -531,6 +533,11 @@ func (b *SSEBroker) publishToChannels(topic string, channels []chan string, msg 
 	for _, ch := range channels {
 		func() {
 			defer func() { _ = recover() }()
+			// Per-subscriber rate limiting: hold the message if within interval.
+			if b.rateLimit.hold(ch, msg) {
+				sent++ // held messages count as sent, not dropped
+				return
+			}
 			if b.send(ch, msg) {
 				sent++
 				if b.evictThreshold > 0 {
@@ -1004,6 +1011,7 @@ func (b *SSEBroker) Close() {
 		delete(b.throttle.state, topic)
 	}
 	b.throttle.mu.Unlock()
+	b.rateLimit.stop()
 }
 
 // startTopicSweep periodically removes topics that have had zero subscribers

--- a/rate.go
+++ b/rate.go
@@ -1,0 +1,237 @@
+package tavern
+
+import (
+	"sync"
+	"time"
+)
+
+// Rate configures per-subscriber rate limiting. If both MaxPerSecond and
+// MinInterval are set, MinInterval takes precedence.
+type Rate struct {
+	// MaxPerSecond is a convenience field: converted to MinInterval internally.
+	MaxPerSecond float64
+	// MinInterval is the minimum time between deliveries to this subscriber.
+	MinInterval time.Duration
+}
+
+// interval returns the effective minimum interval, converting MaxPerSecond
+// if MinInterval is not set.
+func (r Rate) interval() time.Duration {
+	if r.MinInterval > 0 {
+		return r.MinInterval
+	}
+	if r.MaxPerSecond > 0 {
+		return time.Duration(float64(time.Second) / r.MaxPerSecond)
+	}
+	return 0
+}
+
+// rateLimitedSub tracks state for a single rate-limited subscriber.
+type rateLimitedSub struct {
+	ch          chan string
+	topic       string
+	minInterval time.Duration
+	lastSent    time.Time
+	pending     *string // latest held message (nil = nothing pending)
+}
+
+// rateLimiter manages per-subscriber rate limiting with a single shared ticker.
+type rateLimiter struct {
+	mu      sync.Mutex
+	subs    map[chan string]*rateLimitedSub
+	ticker  *time.Ticker
+	done    chan struct{}
+	running bool
+}
+
+const rateTickInterval = 10 * time.Millisecond
+
+// newRateLimiter creates an idle rate limiter. The shared ticker is started
+// lazily when the first rate-limited subscriber is added.
+func newRateLimiter() *rateLimiter {
+	return &rateLimiter{
+		subs: make(map[chan string]*rateLimitedSub),
+		done: make(chan struct{}),
+	}
+}
+
+// add registers a rate-limited subscriber. Starts the shared ticker if this
+// is the first subscriber.
+func (rl *rateLimiter) add(ch chan string, topic string, interval time.Duration) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	rl.subs[ch] = &rateLimitedSub{
+		ch:          ch,
+		topic:       topic,
+		minInterval: interval,
+	}
+	if !rl.running {
+		rl.running = true
+		rl.ticker = time.NewTicker(rateTickInterval)
+		go rl.loop()
+	}
+}
+
+// remove unregisters a rate-limited subscriber. Stops the ticker if no
+// subscribers remain.
+func (rl *rateLimiter) remove(ch chan string) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	delete(rl.subs, ch)
+	if len(rl.subs) == 0 && rl.running {
+		rl.ticker.Stop()
+		rl.running = false
+	}
+}
+
+// hold stores a pending message for the subscriber. Returns true if the
+// subscriber is rate-limited and the message was held (caller should skip
+// the normal send). Returns false if the subscriber is not rate-limited or
+// enough time has elapsed for immediate delivery.
+func (rl *rateLimiter) hold(ch chan string, msg string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	sub, ok := rl.subs[ch]
+	if !ok {
+		return false
+	}
+	now := time.Now()
+	if now.Sub(sub.lastSent) >= sub.minInterval {
+		// Enough time passed — allow immediate send and update timestamp.
+		sub.lastSent = now
+		return false
+	}
+	// Within interval — hold latest message.
+	sub.pending = &msg
+	return true
+}
+
+// loop is the shared ticker goroutine. It checks all rate-limited subscribers
+// and flushes pending messages whose interval has elapsed.
+func (rl *rateLimiter) loop() {
+	for {
+		select {
+		case <-rl.done:
+			return
+		case now := <-rl.ticker.C:
+			rl.flush(now)
+		}
+	}
+}
+
+// flush sends any pending messages whose interval has elapsed.
+func (rl *rateLimiter) flush(now time.Time) {
+	rl.mu.Lock()
+	// Collect channels that need flushing while holding the lock.
+	type pending struct {
+		ch  chan string
+		msg string
+	}
+	var toSend []pending
+	for _, sub := range rl.subs {
+		if sub.pending == nil {
+			continue
+		}
+		if now.Sub(sub.lastSent) >= sub.minInterval {
+			toSend = append(toSend, pending{ch: sub.ch, msg: *sub.pending})
+			sub.pending = nil
+			sub.lastSent = now
+		}
+	}
+	rl.mu.Unlock()
+
+	// Send outside the lock to avoid blocking.
+	for _, p := range toSend {
+		func() {
+			defer func() { _ = recover() }()
+			select {
+			case p.ch <- p.msg:
+			default:
+			}
+		}()
+	}
+}
+
+// stop shuts down the shared ticker goroutine and clears all state.
+func (rl *rateLimiter) stop() {
+	close(rl.done)
+	rl.mu.Lock()
+	if rl.running {
+		rl.ticker.Stop()
+		rl.running = false
+	}
+	rl.subs = nil
+	rl.mu.Unlock()
+}
+
+// SubscribeWithRate registers a subscriber with per-subscriber rate limiting.
+// Messages published faster than the configured rate are held, and the most
+// recent held message is delivered when the interval elapses (latest-wins).
+// Rate limiting is per-subscriber and does not affect the publisher or other
+// subscribers.
+func (b *SSEBroker) SubscribeWithRate(topic string, rate Rate) (msgs <-chan string, unsubscribe func()) {
+	ch, unsub := b.Subscribe(topic)
+	interval := rate.interval()
+	if interval <= 0 {
+		return ch, unsub
+	}
+
+	// The bidirectional channel is stored in topics[topic]; we need it to
+	// register with the rate limiter. Recover it via the read-only channel.
+	biCh := b.findBiChan(topic, ch)
+	if biCh == nil {
+		return ch, unsub
+	}
+
+	b.rateLimit.add(biCh, topic, interval)
+	return ch, func() {
+		b.rateLimit.remove(biCh)
+		unsub()
+	}
+}
+
+// SubscribeScopedWithRate registers a scoped subscriber with per-subscriber
+// rate limiting. See [SSEBroker.SubscribeWithRate] for rate-limiting semantics.
+func (b *SSEBroker) SubscribeScopedWithRate(topic, scope string, rate Rate) (msgs <-chan string, unsubscribe func()) {
+	ch, unsub := b.SubscribeScoped(topic, scope)
+	interval := rate.interval()
+	if interval <= 0 {
+		return ch, unsub
+	}
+
+	biCh := b.findBiScopedChan(topic, ch)
+	if biCh == nil {
+		return ch, unsub
+	}
+
+	b.rateLimit.add(biCh, topic, interval)
+	return ch, func() {
+		b.rateLimit.remove(biCh)
+		unsub()
+	}
+}
+
+// findBiChan recovers the bidirectional channel from the topics map by
+// comparing it to the read-only channel returned by Subscribe.
+func (b *SSEBroker) findBiChan(topic string, readOnly <-chan string) chan string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for c := range b.topics[topic] {
+		if (<-chan string)(c) == readOnly { //nolint:gocritic // parens required for channel type conversion
+			return c
+		}
+	}
+	return nil
+}
+
+// findBiScopedChan recovers the bidirectional channel from the scopedTopics map.
+func (b *SSEBroker) findBiScopedChan(topic string, readOnly <-chan string) chan string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for c := range b.scopedTopics[topic] {
+		if (<-chan string)(c) == readOnly { //nolint:gocritic // parens required for channel type conversion
+			return c
+		}
+	}
+	return nil
+}

--- a/rate_test.go
+++ b/rate_test.go
@@ -1,0 +1,314 @@
+package tavern
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRate_Interval(t *testing.T) {
+	t.Run("MinInterval takes precedence", func(t *testing.T) {
+		r := Rate{MaxPerSecond: 10, MinInterval: 200 * time.Millisecond}
+		assert.Equal(t, 200*time.Millisecond, r.interval())
+	})
+
+	t.Run("MaxPerSecond converts", func(t *testing.T) {
+		r := Rate{MaxPerSecond: 2}
+		assert.Equal(t, 500*time.Millisecond, r.interval())
+	})
+
+	t.Run("zero rate returns zero", func(t *testing.T) {
+		r := Rate{}
+		assert.Equal(t, time.Duration(0), r.interval())
+	})
+}
+
+func TestSubscribeWithRate_BasicRateLimiting(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeWithRate("metrics", Rate{MinInterval: 100 * time.Millisecond})
+	defer unsub()
+
+	// First message should be immediate (no previous send).
+	b.Publish("metrics", "msg-1")
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "msg-1", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out on first message")
+	}
+
+	// Rapid publishes within the interval — should be held.
+	b.Publish("metrics", "msg-2")
+	b.Publish("metrics", "msg-3")
+
+	// Nothing should arrive immediately.
+	select {
+	case <-ch:
+		t.Fatal("message should be held during rate limit interval")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// After the interval the latest held message should arrive.
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "msg-3", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for rate-limited message")
+	}
+}
+
+func TestSubscribeWithRate_LatestWins(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeWithRate("topic", Rate{MinInterval: 100 * time.Millisecond})
+	defer unsub()
+
+	// Consume first message immediately.
+	b.Publish("topic", "first")
+	<-ch
+
+	// Rapid publishes — only the latest should be delivered.
+	b.Publish("topic", "second")
+	b.Publish("topic", "third")
+	b.Publish("topic", "fourth")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "fourth", msg, "latest held message should win")
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+
+	// No extra messages.
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected extra message: %s", msg)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func TestSubscribeWithRate_RateRecovery(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeWithRate("topic", Rate{MinInterval: 50 * time.Millisecond})
+	defer unsub()
+
+	// First message immediate.
+	b.Publish("topic", "msg-1")
+	<-ch
+
+	// Wait for interval to pass.
+	time.Sleep(60 * time.Millisecond)
+
+	// Next message should also be immediate.
+	b.Publish("topic", "msg-2")
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "msg-2", msg)
+	case <-time.After(time.Second):
+		t.Fatal("message after rate recovery should be immediate")
+	}
+}
+
+func TestSubscribeWithRate_DoesNotAffectOtherSubscribers(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	// One rate-limited subscriber, one normal subscriber.
+	rateCh, rateUnsub := b.SubscribeWithRate("topic", Rate{MinInterval: 200 * time.Millisecond})
+	defer rateUnsub()
+
+	normalCh, normalUnsub := b.Subscribe("topic")
+	defer normalUnsub()
+
+	// First message goes to both.
+	b.Publish("topic", "msg-1")
+	<-rateCh
+	<-normalCh
+
+	// Rapid publish — normal subscriber gets it immediately, rate-limited is held.
+	b.Publish("topic", "msg-2")
+
+	select {
+	case msg := <-normalCh:
+		assert.Equal(t, "msg-2", msg)
+	case <-time.After(time.Second):
+		t.Fatal("normal subscriber should receive immediately")
+	}
+
+	// Rate-limited subscriber should not have it yet.
+	select {
+	case <-rateCh:
+		t.Fatal("rate-limited subscriber should not receive within interval")
+	case <-time.After(30 * time.Millisecond):
+	}
+
+	// Eventually the rate-limited subscriber gets the message.
+	select {
+	case msg := <-rateCh:
+		assert.Equal(t, "msg-2", msg)
+	case <-time.After(time.Second):
+		t.Fatal("rate-limited subscriber should eventually receive")
+	}
+}
+
+func TestSubscribeWithRate_DoesNotCountAsDropped(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeWithRate("topic", Rate{MinInterval: 100 * time.Millisecond})
+	defer unsub()
+
+	b.Publish("topic", "msg-1")
+	<-ch
+
+	// Rapid publishes — held, not dropped.
+	b.Publish("topic", "msg-2")
+	b.Publish("topic", "msg-3")
+
+	assert.Equal(t, int64(0), b.PublishDrops(), "rate-limited messages should not count as drops")
+}
+
+func TestSubscribeScopedWithRate(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeScopedWithRate("metrics", "user:123", Rate{MinInterval: 100 * time.Millisecond})
+	defer unsub()
+
+	// Scoped publish — first is immediate.
+	b.PublishTo("metrics", "user:123", "data-1")
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "data-1", msg)
+	case <-time.After(time.Second):
+		t.Fatal("first scoped message should be immediate")
+	}
+
+	// Rapid scoped publishes.
+	b.PublishTo("metrics", "user:123", "data-2")
+	b.PublishTo("metrics", "user:123", "data-3")
+
+	select {
+	case <-ch:
+		t.Fatal("should be held during interval")
+	case <-time.After(30 * time.Millisecond):
+	}
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "data-3", msg)
+	case <-time.After(time.Second):
+		t.Fatal("latest scoped message should arrive after interval")
+	}
+}
+
+func TestSubscribeWithRate_SharedTickerCleanup(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub1 := b.SubscribeWithRate("t1", Rate{MinInterval: 50 * time.Millisecond})
+	_, unsub2 := b.SubscribeWithRate("t2", Rate{MinInterval: 50 * time.Millisecond})
+
+	require.True(t, b.rateLimit.running, "ticker should be running with subscribers")
+
+	unsub1()
+	require.True(t, b.rateLimit.running, "ticker should still run with one subscriber")
+
+	unsub2()
+	// After both unsubscribe, ticker should stop.
+	b.rateLimit.mu.Lock()
+	running := b.rateLimit.running
+	subsLen := len(b.rateLimit.subs)
+	b.rateLimit.mu.Unlock()
+	assert.False(t, running, "ticker should stop when all rate-limited subscribers leave")
+	assert.Equal(t, 0, subsLen)
+}
+
+func TestSubscribeWithRate_CloseStopsTicker(t *testing.T) {
+	b := NewSSEBroker()
+
+	ch, _ := b.SubscribeWithRate("topic", Rate{MinInterval: 5 * time.Second})
+
+	// First message immediate.
+	b.Publish("topic", "first")
+	<-ch
+
+	// Hold a message.
+	b.Publish("topic", "should-not-arrive")
+
+	b.Close()
+
+	// Verify nothing arrives (channel is closed).
+	select {
+	case msg, ok := <-ch:
+		if ok {
+			t.Fatalf("unexpected message after close: %s", msg)
+		}
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestSubscribeWithRate_MaxPerSecond(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	// 2 per second = 500ms interval.
+	ch, unsub := b.SubscribeWithRate("topic", Rate{MaxPerSecond: 2})
+	defer unsub()
+
+	b.Publish("topic", "msg-1")
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "msg-1", msg)
+	case <-time.After(time.Second):
+		t.Fatal("first message should be immediate")
+	}
+
+	// Publish within interval — should be held.
+	b.Publish("topic", "msg-2")
+	select {
+	case <-ch:
+		t.Fatal("should be rate-limited at 2/sec")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Eventually arrives.
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "msg-2", msg)
+	case <-time.After(time.Second):
+		t.Fatal("held message should arrive after interval")
+	}
+}
+
+func TestSubscribeWithRate_ZeroRateNoOp(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	// Zero rate should behave like normal Subscribe.
+	ch, unsub := b.SubscribeWithRate("topic", Rate{})
+	defer unsub()
+
+	b.Publish("topic", "msg-1")
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "msg-1", msg)
+	case <-time.After(time.Second):
+		t.Fatal("zero rate should not limit")
+	}
+
+	b.Publish("topic", "msg-2")
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "msg-2", msg)
+	case <-time.After(time.Second):
+		t.Fatal("zero rate should not limit")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `SubscribeWithRate` and `SubscribeScopedWithRate` methods for per-subscriber rate limiting
- Messages within the rate interval are held (latest-wins, not dropped) and delivered when the interval elapses
- Uses a single shared ticker for all rate-limited subscribers instead of one timer per subscriber
- Rate-limited held messages do not count toward drop counts or trigger backpressure/eviction

## Test plan
- [x] Basic rate limiting: first message immediate, subsequent messages held
- [x] Latest-wins: only the most recent held message is delivered
- [x] Rate recovery: after interval passes, next message is immediate again
- [x] Does not affect other subscribers on the same topic
- [x] Held messages do not count as drops
- [x] Scoped + rate-limited subscription works correctly
- [x] Shared ticker starts/stops with subscriber lifecycle
- [x] Close stops the ticker and cleans up
- [x] MaxPerSecond convenience field converts correctly
- [x] Zero rate behaves like normal Subscribe
- [x] All tests pass: `go test ./...`
- [x] Linting passes: `golangci-lint run ./...`

Closes #94