### PR TITLE
feat: predicate-based subscriber filtering

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -47,7 +47,8 @@ type SSEBroker struct {
 	evictCallback     func(topic string)           // optional callback on eviction
 	dropCounts        map[chan string]*atomic.Int64 // per-channel consecutive drop counter
 	dropCountsMu      sync.RWMutex                 // separate lock for drop counts (avoid nesting with main mu)
-	subscriberMeta    map[chan string]*SubscriberInfo // channel → subscriber info
+	subscriberMeta    map[chan string]*SubscriberInfo  // channel → subscriber info
+	filterPredicates  map[chan string]FilterPredicate // channel → optional message filter
 	connEventsTopic   string                         // empty = connection events disabled
 	onReplayGap       map[string][]ReplayGapCallback  // topic → gap callbacks
 	replayGapStrategy map[string]GapStrategy          // topic → gap strategy
@@ -268,6 +269,7 @@ func (b *SSEBroker) Subscribe(topic string) (msgs <-chan string, unsubscribe fun
 		if _, ok := b.topics[topic][ch]; ok {
 			delete(b.topics[topic], ch)
 			delete(b.subscriberMeta, ch)
+			delete(b.filterPredicates, ch)
 			close(ch)
 			total := len(b.topics[topic]) + len(b.scopedTopics[topic])
 			if total == 0 {
@@ -340,6 +342,7 @@ func (b *SSEBroker) SubscribeScoped(topic, scope string) (msgs <-chan string, un
 		if _, ok := b.scopedTopics[topic][ch]; ok {
 			delete(b.scopedTopics[topic], ch)
 			delete(b.subscriberMeta, ch)
+			delete(b.filterPredicates, ch)
 			close(ch)
 			total := len(b.topics[topic]) + len(b.scopedTopics[topic])
 			if total == 0 {
@@ -498,6 +501,15 @@ func (b *SSEBroker) Stats() BrokerStats {
 // send attempts to send msg on ch. If the channel is full and dropOldest is
 // enabled, it drains the oldest message first and counts the drop. Returns
 // true if the new message was sent, false if it was dropped entirely.
+// filterPredicate returns the filter predicate for the given channel, or nil
+// if no filter is set. The caller must not hold b.mu.
+func (b *SSEBroker) filterPredicate(ch chan string) FilterPredicate {
+	b.mu.RLock()
+	pred := b.filterPredicates[ch]
+	b.mu.RUnlock()
+	return pred
+}
+
 func (b *SSEBroker) send(ch chan string, msg string) bool {
 	if b.dropOldest {
 		select {
@@ -536,6 +548,11 @@ func (b *SSEBroker) publishToChannels(topic string, channels []chan string, msg 
 			// Per-subscriber rate limiting: hold the message if within interval.
 			if b.rateLimit.hold(ch, msg) {
 				sent++ // held messages count as sent, not dropped
+				return
+			}
+			// Check filter predicate — non-matching messages are silently
+			// skipped without counting toward drops or backpressure.
+			if pred := b.filterPredicate(ch); pred != nil && !pred(msg) {
 				return
 			}
 			if b.send(ch, msg) {
@@ -581,6 +598,7 @@ func (b *SSEBroker) evictSubscriber(topic string, ch chan string) {
 	if _, ok := b.topics[topic][ch]; ok {
 		delete(b.topics[topic], ch)
 		delete(b.subscriberMeta, ch)
+		delete(b.filterPredicates, ch)
 		close(ch)
 		total := len(b.topics[topic]) + len(b.scopedTopics[topic])
 		var lastHooks []func(string)
@@ -595,6 +613,7 @@ func (b *SSEBroker) evictSubscriber(topic string, ch chan string) {
 	} else if _, ok := b.scopedTopics[topic][ch]; ok {
 		delete(b.scopedTopics[topic], ch)
 		delete(b.subscriberMeta, ch)
+		delete(b.filterPredicates, ch)
 		close(ch)
 		total := len(b.topics[topic]) + len(b.scopedTopics[topic])
 		var lastHooks []func(string)
@@ -972,6 +991,7 @@ func (b *SSEBroker) Close() {
 	b.replayLog = nil
 	b.lastHash = nil
 	b.subscriberMeta = nil
+	b.filterPredicates = nil
 	b.onReplayGap = nil
 	b.replayGapStrategy = nil
 	b.replayGapSnapshot = nil

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,182 @@
+package tavern
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// FilterPredicate is a function that returns true if the message should be
+// delivered to the subscriber. It runs in the publish path and must be fast.
+type FilterPredicate func(msg string) bool
+
+// SubscribeWithFilter registers a subscriber with a predicate filter for the
+// given topic. Only messages for which the predicate returns true are delivered
+// to the subscriber's channel. Non-matching messages are silently skipped and
+// do not count toward drop counts or backpressure.
+//
+// The predicate runs in the publish goroutine — keep it fast.
+func (b *SSEBroker) SubscribeWithFilter(topic string, predicate FilterPredicate) (msgs <-chan string, unsubscribe func()) {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		ch := make(chan string)
+		close(ch)
+		return ch, func() {}
+	}
+	ch := make(chan string, b.bufferSize)
+	if b.topics[topic] == nil {
+		b.topics[topic] = make(map[chan string]struct{})
+	}
+	b.topics[topic][ch] = struct{}{}
+	b.subscriberMeta[ch] = &SubscriberInfo{Topic: topic, ConnectedAt: time.Now()}
+	if b.filterPredicates == nil {
+		b.filterPredicates = make(map[chan string]FilterPredicate)
+	}
+	b.filterPredicates[ch] = predicate
+	total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+	var firstHooks []func(string)
+	if total == 1 {
+		firstHooks = b.onFirst[topic]
+	}
+	if b.metrics != nil {
+		if total > b.metrics.peakSubs[topic] {
+			b.metrics.peakSubs[topic] = total
+		}
+	}
+	if b.evictThreshold > 0 {
+		b.dropCountsMu.Lock()
+		b.dropCounts[ch] = &atomic.Int64{}
+		b.dropCountsMu.Unlock()
+	}
+	replayMsgs := append([]string(nil), b.replayCache[topic]...)
+	delete(b.topicEmpty, topic)
+	b.mu.Unlock()
+	for _, fn := range firstHooks {
+		go fn(topic)
+	}
+	b.publishConnectionEvent("subscribe", topic, total)
+	for _, msg := range replayMsgs {
+		if predicate != nil && !predicate(msg) {
+			continue
+		}
+		select {
+		case ch <- msg:
+		default:
+		}
+	}
+	return ch, b.makeUnsubscribe(topic, ch)
+}
+
+// SubscribeScopedWithFilter registers a scoped subscriber with a predicate
+// filter. Only messages published via [SSEBroker.PublishTo] with a matching
+// scope AND passing the predicate are delivered. Non-matching messages are
+// silently skipped.
+func (b *SSEBroker) SubscribeScopedWithFilter(topic, scope string, predicate FilterPredicate) (msgs <-chan string, unsubscribe func()) {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		ch := make(chan string)
+		close(ch)
+		return ch, func() {}
+	}
+	ch := make(chan string, b.bufferSize)
+	if b.scopedTopics[topic] == nil {
+		b.scopedTopics[topic] = make(map[chan string]scopedSub)
+	}
+	b.scopedTopics[topic][ch] = scopedSub{scope: scope}
+	b.subscriberMeta[ch] = &SubscriberInfo{Topic: topic, Scope: scope, ConnectedAt: time.Now()}
+	if b.filterPredicates == nil {
+		b.filterPredicates = make(map[chan string]FilterPredicate)
+	}
+	b.filterPredicates[ch] = predicate
+	total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+	var firstHooks []func(string)
+	if total == 1 {
+		firstHooks = b.onFirst[topic]
+	}
+	if b.metrics != nil {
+		if total > b.metrics.peakSubs[topic] {
+			b.metrics.peakSubs[topic] = total
+		}
+	}
+	if b.evictThreshold > 0 {
+		b.dropCountsMu.Lock()
+		b.dropCounts[ch] = &atomic.Int64{}
+		b.dropCountsMu.Unlock()
+	}
+	replayMsgs := append([]string(nil), b.replayCache[topic]...)
+	delete(b.topicEmpty, topic)
+	b.mu.Unlock()
+	for _, fn := range firstHooks {
+		go fn(topic)
+	}
+	b.publishConnectionEvent("subscribe", topic, total)
+	for _, msg := range replayMsgs {
+		if predicate != nil && !predicate(msg) {
+			continue
+		}
+		select {
+		case ch <- msg:
+		default:
+		}
+	}
+	return ch, b.makeScopedUnsubscribe(topic, ch)
+}
+
+// makeUnsubscribe returns an unsubscribe function for an unscoped subscriber.
+func (b *SSEBroker) makeUnsubscribe(topic string, ch chan string) func() {
+	return func() {
+		b.mu.Lock()
+		var lastHooks []func(string)
+		if _, ok := b.topics[topic][ch]; ok {
+			delete(b.topics[topic], ch)
+			delete(b.subscriberMeta, ch)
+			delete(b.filterPredicates, ch)
+			close(ch)
+			total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+			if total == 0 {
+				lastHooks = b.onLast[topic]
+				b.topicEmpty[topic] = time.Now()
+			}
+		}
+		b.mu.Unlock()
+		if b.evictThreshold > 0 {
+			b.dropCountsMu.Lock()
+			delete(b.dropCounts, ch)
+			b.dropCountsMu.Unlock()
+		}
+		for _, fn := range lastHooks {
+			go fn(topic)
+		}
+		b.publishConnectionEvent("unsubscribe", topic, -1)
+	}
+}
+
+// makeScopedUnsubscribe returns an unsubscribe function for a scoped subscriber.
+func (b *SSEBroker) makeScopedUnsubscribe(topic string, ch chan string) func() {
+	return func() {
+		b.mu.Lock()
+		var lastHooks []func(string)
+		if _, ok := b.scopedTopics[topic][ch]; ok {
+			delete(b.scopedTopics[topic], ch)
+			delete(b.subscriberMeta, ch)
+			delete(b.filterPredicates, ch)
+			close(ch)
+			total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+			if total == 0 {
+				lastHooks = b.onLast[topic]
+				b.topicEmpty[topic] = time.Now()
+			}
+		}
+		b.mu.Unlock()
+		if b.evictThreshold > 0 {
+			b.dropCountsMu.Lock()
+			delete(b.dropCounts, ch)
+			b.dropCountsMu.Unlock()
+		}
+		for _, fn := range lastHooks {
+			go fn(topic)
+		}
+		b.publishConnectionEvent("unsubscribe", topic, -1)
+	}
+}

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,337 @@
+package tavern
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSubscribeWithFilter_BasicFiltering(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	msgs, unsub := b.SubscribeWithFilter("news", func(msg string) bool {
+		return strings.Contains(msg, "engineering")
+	})
+	defer unsub()
+
+	b.Publish("news", "engineering: new release")
+	b.Publish("news", "marketing: campaign launch")
+	b.Publish("news", "engineering: bugfix deployed")
+
+	// Should receive only the two engineering messages.
+	got := drainN(t, msgs, 2, 500*time.Millisecond)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 messages, got %d: %v", len(got), got)
+	}
+	if got[0] != "engineering: new release" {
+		t.Errorf("msg[0] = %q, want %q", got[0], "engineering: new release")
+	}
+	if got[1] != "engineering: bugfix deployed" {
+		t.Errorf("msg[1] = %q, want %q", got[1], "engineering: bugfix deployed")
+	}
+}
+
+func TestSubscribeWithFilter_AllMatch(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	msgs, unsub := b.SubscribeWithFilter("t", func(msg string) bool {
+		return true
+	})
+	defer unsub()
+
+	b.Publish("t", "a")
+	b.Publish("t", "b")
+
+	got := drainN(t, msgs, 2, 500*time.Millisecond)
+	if len(got) != 2 {
+		t.Fatalf("expected 2, got %d", len(got))
+	}
+}
+
+func TestSubscribeWithFilter_NoneMatch(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	msgs, unsub := b.SubscribeWithFilter("t", func(msg string) bool {
+		return false
+	})
+	defer unsub()
+
+	b.Publish("t", "a")
+	b.Publish("t", "b")
+
+	got := drainN(t, msgs, 0, 100*time.Millisecond)
+	if len(got) != 0 {
+		t.Fatalf("expected 0 messages, got %d: %v", len(got), got)
+	}
+}
+
+func TestSubscribeScopedWithFilter(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	msgs, unsub := b.SubscribeScopedWithFilter("orders", "user-42", func(msg string) bool {
+		return strings.Contains(msg, "shipped")
+	})
+	defer unsub()
+
+	b.PublishTo("orders", "user-42", "order placed")
+	b.PublishTo("orders", "user-42", "order shipped")
+	b.PublishTo("orders", "user-99", "order shipped") // wrong scope
+	b.PublishTo("orders", "user-42", "order delivered")
+
+	got := drainN(t, msgs, 1, 500*time.Millisecond)
+	if len(got) != 1 {
+		t.Fatalf("expected 1, got %d: %v", len(got), got)
+	}
+	if got[0] != "order shipped" {
+		t.Errorf("msg = %q, want %q", got[0], "order shipped")
+	}
+}
+
+func TestSubscribeWithFilter_ReplayFiltered(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("feed", 10)
+	b.PublishWithReplay("feed", "alpha")
+	b.PublishWithReplay("feed", "beta-match")
+	b.PublishWithReplay("feed", "gamma")
+	b.PublishWithReplay("feed", "delta-match")
+
+	// Subscribe with filter after messages are in replay cache.
+	msgs, unsub := b.SubscribeWithFilter("feed", func(msg string) bool {
+		return strings.Contains(msg, "match")
+	})
+	defer unsub()
+
+	got := drainN(t, msgs, 2, 500*time.Millisecond)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 replay messages, got %d: %v", len(got), got)
+	}
+	if got[0] != "beta-match" {
+		t.Errorf("replay[0] = %q, want %q", got[0], "beta-match")
+	}
+	if got[1] != "delta-match" {
+		t.Errorf("replay[1] = %q, want %q", got[1], "delta-match")
+	}
+}
+
+func TestSubscribeWithFilter_NonMatchDoesNotCountAsDrop(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(1))
+	defer b.Close()
+
+	msgs, unsub := b.SubscribeWithFilter("t", func(msg string) bool {
+		return msg == "yes"
+	})
+	defer unsub()
+
+	// Publish many non-matching messages — none should count as drops.
+	for i := 0; i < 100; i++ {
+		b.Publish("t", "no")
+	}
+
+	drops := b.PublishDrops()
+	if drops != 0 {
+		t.Errorf("expected 0 drops for filtered messages, got %d", drops)
+	}
+
+	// Now publish a matching message — it should be delivered.
+	b.Publish("t", "yes")
+	got := drainN(t, msgs, 1, 500*time.Millisecond)
+	if len(got) != 1 || got[0] != "yes" {
+		t.Errorf("expected [yes], got %v", got)
+	}
+}
+
+func TestSubscribeWithFilter_WithEviction(t *testing.T) {
+	evicted := make(chan string, 1)
+	b := NewSSEBroker(
+		WithBufferSize(1),
+		WithSlowSubscriberEviction(3),
+		WithSlowSubscriberCallback(func(topic string) {
+			evicted <- topic
+		}),
+	)
+	defer b.Close()
+
+	// Filtered subscriber — non-matching messages should not trigger eviction.
+	_, unsub := b.SubscribeWithFilter("t", func(msg string) bool {
+		return msg == "match"
+	})
+	defer unsub()
+
+	// Flood with non-matching messages.
+	for i := 0; i < 20; i++ {
+		b.Publish("t", "nope")
+	}
+
+	select {
+	case <-evicted:
+		t.Fatal("subscriber was evicted, but filtered messages should not count toward drops")
+	case <-time.After(100 * time.Millisecond):
+		// Good — no eviction.
+	}
+}
+
+func TestSubscribeWithFilter_UnfilteredSubscriberUnaffected(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	// One filtered, one unfiltered.
+	filtered, unsub1 := b.SubscribeWithFilter("t", func(msg string) bool {
+		return msg == "yes"
+	})
+	defer unsub1()
+
+	unfiltered, unsub2 := b.Subscribe("t")
+	defer unsub2()
+
+	b.Publish("t", "no")
+	b.Publish("t", "yes")
+
+	// Unfiltered should get both.
+	gotUnfiltered := drainN(t, unfiltered, 2, 500*time.Millisecond)
+	if len(gotUnfiltered) != 2 {
+		t.Fatalf("unfiltered: expected 2, got %d: %v", len(gotUnfiltered), gotUnfiltered)
+	}
+
+	// Filtered should get only "yes".
+	gotFiltered := drainN(t, filtered, 1, 500*time.Millisecond)
+	if len(gotFiltered) != 1 || gotFiltered[0] != "yes" {
+		t.Errorf("filtered: expected [yes], got %v", gotFiltered)
+	}
+}
+
+func TestSubscribeWithFilter_PublishOOB(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	msgs, unsub := b.SubscribeWithFilter("oob", func(msg string) bool {
+		return strings.Contains(msg, "target-id")
+	})
+	defer unsub()
+
+	b.PublishOOB("oob", Replace("target-id", "<div>updated</div>"))
+	b.PublishOOB("oob", Replace("other-id", "<div>skip</div>"))
+
+	got := drainN(t, msgs, 1, 500*time.Millisecond)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 OOB message, got %d: %v", len(got), got)
+	}
+	if !strings.Contains(got[0], "target-id") {
+		t.Errorf("expected message containing target-id, got %q", got[0])
+	}
+}
+
+func TestSubscribeWithFilter_Unsubscribe(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	msgs, unsub := b.SubscribeWithFilter("t", func(msg string) bool {
+		return true
+	})
+
+	unsub()
+
+	// Channel should be closed after unsubscribe.
+	select {
+	case _, ok := <-msgs:
+		if ok {
+			t.Fatal("expected channel to be closed")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("channel not closed after unsubscribe")
+	}
+}
+
+func TestSubscribeScopedWithFilter_ReplayFiltered(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("feed", 10)
+	b.PublishWithReplay("feed", "alpha")
+	b.PublishWithReplay("feed", "beta-match")
+
+	// Scoped subscribers also receive replay from the topic-level cache.
+	msgs, unsub := b.SubscribeScopedWithFilter("feed", "s1", func(msg string) bool {
+		return strings.Contains(msg, "match")
+	})
+	defer unsub()
+
+	got := drainN(t, msgs, 1, 500*time.Millisecond)
+	if len(got) != 1 || got[0] != "beta-match" {
+		t.Errorf("expected [beta-match], got %v", got)
+	}
+}
+
+func TestSubscribeWithFilter_ClosedBroker(t *testing.T) {
+	b := NewSSEBroker()
+	b.Close()
+
+	msgs, unsub := b.SubscribeWithFilter("t", func(msg string) bool {
+		return true
+	})
+	defer unsub()
+
+	// Channel should be immediately closed.
+	select {
+	case _, ok := <-msgs:
+		if ok {
+			t.Fatal("expected closed channel from closed broker")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("channel not closed")
+	}
+}
+
+func TestSubscribeScopedWithFilter_ClosedBroker(t *testing.T) {
+	b := NewSSEBroker()
+	b.Close()
+
+	msgs, unsub := b.SubscribeScopedWithFilter("t", "s", func(msg string) bool {
+		return true
+	})
+	defer unsub()
+
+	select {
+	case _, ok := <-msgs:
+		if ok {
+			t.Fatal("expected closed channel from closed broker")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("channel not closed")
+	}
+}
+
+// drainN reads up to n messages from ch within the timeout.
+func drainN(t *testing.T, ch <-chan string, n int, timeout time.Duration) []string {
+	t.Helper()
+	var result []string
+	deadline := time.After(timeout)
+	for range n {
+		select {
+		case msg, ok := <-ch:
+			if !ok {
+				return result
+			}
+			result = append(result, msg)
+		case <-deadline:
+			return result
+		}
+	}
+	// Brief extra drain to catch unexpected messages.
+	for {
+		select {
+		case msg, ok := <-ch:
+			if !ok {
+				return result
+			}
+			result = append(result, msg)
+		case <-time.After(50 * time.Millisecond):
+			return result
+		}
+	}
+}

--- a/subscriber.go
+++ b/subscriber.go
@@ -99,6 +99,7 @@ func (b *SSEBroker) Disconnect(topic, subscriberID string) bool {
 		}
 		delete(b.topics[topic], ch)
 		delete(b.subscriberMeta, ch)
+		delete(b.filterPredicates, ch)
 		close(ch)
 		total := len(b.topics[topic]) + len(b.scopedTopics[topic])
 		var lastHooks []func(string)
@@ -126,6 +127,7 @@ func (b *SSEBroker) Disconnect(topic, subscriberID string) bool {
 		}
 		delete(b.scopedTopics[topic], ch)
 		delete(b.subscriberMeta, ch)
+		delete(b.filterPredicates, ch)
 		close(ch)
 		total := len(b.topics[topic]) + len(b.scopedTopics[topic])
 		var lastHooks []func(string)


### PR DESCRIPTION
## Summary
- Add `SubscribeWithFilter` and `SubscribeScopedWithFilter` methods that accept a `FilterPredicate` function evaluated before sending to the subscriber's channel
- Non-matching messages are silently skipped without counting toward drop counts or triggering slow subscriber eviction
- Filters apply to all publish variants (Publish, PublishTo, PublishOOB, replay, etc.)

## Implementation
- New `FilterPredicate` type (`func(msg string) bool`) stored per-channel in the broker's `filterPredicates` map
- `publishToChannels` checks the predicate before calling `send()` — filtered messages bypass drop counting entirely
- Replay messages at subscribe time are also filtered
- Filter predicates are cleaned up in all unsubscribe, disconnect, eviction, and close paths

## Test plan
- [x] Basic filtering: only matching messages delivered
- [x] All-match and none-match predicates
- [x] Scoped + filtered subscriptions
- [x] Replay messages filtered at subscribe time
- [x] Non-matching messages do not count as drops
- [x] Filtered messages do not trigger slow subscriber eviction
- [x] Unfiltered subscribers coexist with filtered ones
- [x] PublishOOB works with filters
- [x] Unsubscribe properly cleans up filter
- [x] Closed broker returns closed channel
- [x] All tests pass: `go test ./...`
- [x] Linting passes: `golangci-lint run ./...`

Closes #84