### PR TITLE
feat: enhanced observability metrics

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -69,6 +69,7 @@ type SSEBroker struct {
 	msgTTLSweep       time.Duration                  // override for TTL sweep interval (0 = default 1s)
 	rateLimit         *rateLimiter                     // per-subscriber rate limiting
 	adaptive          *adaptiveBackpressure          // nil = adaptive backpressure disabled
+	obs               *observabilityState              // nil when observability disabled
 }
 
 // Topic name constants are conventions for common real-time use cases.
@@ -271,6 +272,7 @@ func (b *SSEBroker) Subscribe(topic string) (msgs <-chan string, unsubscribe fun
 		default:
 		}
 	}
+	connectedAt := time.Now()
 	return ch, func() {
 		b.mu.Lock()
 		var lastHooks []func(string)
@@ -293,6 +295,9 @@ func (b *SSEBroker) Subscribe(topic string) (msgs <-chan string, unsubscribe fun
 		}
 		if b.adaptive != nil {
 			b.adaptive.removeState(ch)
+		}
+		if b.obs != nil {
+			b.obs.recordConnectionDuration(topic, time.Since(connectedAt))
 		}
 		for _, fn := range lastHooks {
 			go fn(topic)
@@ -350,6 +355,7 @@ func (b *SSEBroker) SubscribeScoped(topic, scope string) (msgs <-chan string, un
 		default:
 		}
 	}
+	scopedConnectedAt := time.Now()
 	return ch, func() {
 		b.mu.Lock()
 		var lastHooks []func(string)
@@ -372,6 +378,9 @@ func (b *SSEBroker) SubscribeScoped(topic, scope string) (msgs <-chan string, un
 		}
 		if b.adaptive != nil {
 			b.adaptive.removeState(ch)
+		}
+		if b.obs != nil {
+			b.obs.recordConnectionDuration(topic, time.Since(scopedConnectedAt))
 		}
 		for _, fn := range lastHooks {
 			go fn(topic)
@@ -715,6 +724,9 @@ func (b *SSEBroker) evictSubscriber(topic string, ch chan string) {
 	if b.adaptive != nil {
 		b.adaptive.removeState(ch)
 	}
+	if b.obs != nil {
+		b.obs.recordEviction(topic)
+	}
 	// Fire callback.
 	if b.evictCallback != nil {
 		go b.evictCallback(topic)
@@ -734,6 +746,10 @@ func (b *SSEBroker) Publish(topic, msg string) {
 // middleware.  It is the terminal function in the middleware chain for
 // [SSEBroker.Publish].
 func (b *SSEBroker) publishDirect(topic, msg string) {
+	var start time.Time
+	if b.obs != nil {
+		start = time.Now()
+	}
 	b.mu.RLock()
 	subscribers, exists := b.topics[topic]
 	if !exists || len(subscribers) == 0 {
@@ -752,6 +768,11 @@ func (b *SSEBroker) publishDirect(topic, msg string) {
 		tc.published.Add(int64(sent))
 		tc.dropped.Add(int64(dropped))
 	}
+	if b.obs != nil {
+		now := time.Now()
+		b.obs.recordPublishLatency(topic, now.Sub(start))
+		b.obs.recordThroughput(topic, now)
+	}
 	b.fireAfterHooks(topic)
 }
 
@@ -767,6 +788,10 @@ func (b *SSEBroker) PublishWithReplay(topic, msg string) {
 // publishWithReplayDirect caches msg for replay and fans it out to
 // unscoped subscribers without applying middleware.
 func (b *SSEBroker) publishWithReplayDirect(topic, msg string) {
+	var start time.Time
+	if b.obs != nil {
+		start = time.Now()
+	}
 	b.mu.Lock()
 	if b.closed {
 		b.mu.Unlock()
@@ -794,6 +819,11 @@ func (b *SSEBroker) publishWithReplayDirect(topic, msg string) {
 		tc := b.metrics.counter(topic)
 		tc.published.Add(int64(sent))
 		tc.dropped.Add(int64(dropped))
+	}
+	if b.obs != nil {
+		now := time.Now()
+		b.obs.recordPublishLatency(topic, now.Sub(start))
+		b.obs.recordThroughput(topic, now)
 	}
 	b.fireAfterHooks(topic)
 }
@@ -849,6 +879,10 @@ func (b *SSEBroker) PublishTo(topic, scope, msg string) {
 // publishToDirect fans out msg to scoped subscribers without applying
 // middleware.
 func (b *SSEBroker) publishToDirect(topic, scope, msg string) {
+	var start time.Time
+	if b.obs != nil {
+		start = time.Now()
+	}
 	b.mu.RLock()
 	scopedSubs, exists := b.scopedTopics[topic]
 	if !exists || len(scopedSubs) == 0 {
@@ -868,6 +902,11 @@ func (b *SSEBroker) publishToDirect(topic, scope, msg string) {
 		tc := b.metrics.counter(topic)
 		tc.published.Add(int64(sent))
 		tc.dropped.Add(int64(dropped))
+	}
+	if b.obs != nil {
+		now := time.Now()
+		b.obs.recordPublishLatency(topic, now.Sub(start))
+		b.obs.recordThroughput(topic, now)
 	}
 	b.fireAfterHooks(topic)
 }

--- a/observability.go
+++ b/observability.go
@@ -1,0 +1,471 @@
+package tavern
+
+import (
+	"math"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// defaultHistogramSize is the number of samples kept in a circular buffer.
+	defaultHistogramSize = 1024
+
+	// defaultThroughputWindow is the sliding window for throughput calculation.
+	defaultThroughputWindow = 10 * time.Second
+)
+
+// ObservabilityConfig controls which observability features are enabled.
+// By default all fields are false and observability has zero overhead.
+type ObservabilityConfig struct {
+	// PublishLatency enables per-topic publish latency histograms.
+	PublishLatency bool
+	// SubscriberLag enables per-subscriber buffer depth gauges.
+	SubscriberLag bool
+	// ConnectionDuration enables tracking of subscriber connection durations.
+	ConnectionDuration bool
+	// TopicThroughput enables per-topic message rate calculation.
+	TopicThroughput bool
+}
+
+// LatencyHistogram holds percentile latency data.
+type LatencyHistogram struct {
+	P50, P95, P99 time.Duration
+	Count         int64
+}
+
+// TopicObservability holds observability data for a single topic.
+type TopicObservability struct {
+	PublishLatency      LatencyHistogram
+	SubscriberLag       map[string]int // subscriberID -> buffer depth
+	ConnectionDurations []time.Duration
+	Throughput          float64 // msgs/sec over last window
+	EvictionCount       int64
+}
+
+// ObservabilitySnapshot is an export-friendly snapshot of all observability data.
+type ObservabilitySnapshot struct {
+	Topics map[string]TopicObservability
+}
+
+// observabilityState holds internal state for the observability subsystem.
+type observabilityState struct {
+	config ObservabilityConfig
+
+	// Per-topic latency circular buffers.
+	latencyMu      sync.RWMutex
+	latencyBuffers map[string]*circularDurations
+
+	// Per-topic throughput sliding window.
+	throughputMu   sync.RWMutex
+	throughputData map[string]*slidingWindow
+
+	// Per-topic connection durations (recorded on unsubscribe).
+	connDurMu   sync.RWMutex
+	connDurData map[string]*circularDurations
+
+	// Per-topic eviction counters.
+	evictionMu       sync.RWMutex
+	evictionCounters map[string]*atomic.Int64
+}
+
+// circularDurations is a fixed-size circular buffer for time.Duration values.
+type circularDurations struct {
+	mu    sync.Mutex
+	buf   []time.Duration
+	pos   int
+	count int64
+	full  bool
+}
+
+func newCircularDurations(size int) *circularDurations {
+	return &circularDurations{
+		buf: make([]time.Duration, size),
+	}
+}
+
+func (c *circularDurations) add(d time.Duration) {
+	c.mu.Lock()
+	c.buf[c.pos] = d
+	c.pos = (c.pos + 1) % len(c.buf)
+	c.count++
+	if !c.full && c.count >= int64(len(c.buf)) {
+		c.full = true
+	}
+	c.mu.Unlock()
+}
+
+// snapshot returns a copy of the stored durations (unordered).
+func (c *circularDurations) snapshot() (samples []time.Duration, total int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := int(c.count)
+	if c.full {
+		n = len(c.buf)
+	}
+	out := make([]time.Duration, n)
+	copy(out, c.buf[:n])
+	return out, c.count
+}
+
+// slidingWindow tracks timestamps of events for rate calculation.
+type slidingWindow struct {
+	mu     sync.Mutex
+	events []time.Time
+	window time.Duration
+}
+
+func newSlidingWindow(window time.Duration) *slidingWindow {
+	return &slidingWindow{
+		window: window,
+	}
+}
+
+func (sw *slidingWindow) record(now time.Time) {
+	sw.mu.Lock()
+	sw.events = append(sw.events, now)
+	sw.gc(now)
+	sw.mu.Unlock()
+}
+
+func (sw *slidingWindow) rate(now time.Time) float64 {
+	sw.mu.Lock()
+	sw.gc(now)
+	n := len(sw.events)
+	sw.mu.Unlock()
+	if n == 0 {
+		return 0
+	}
+	return float64(n) / sw.window.Seconds()
+}
+
+// gc removes events outside the window. Must be called with mu held.
+func (sw *slidingWindow) gc(now time.Time) {
+	cutoff := now.Add(-sw.window)
+	i := 0
+	for i < len(sw.events) && sw.events[i].Before(cutoff) {
+		i++
+	}
+	if i > 0 {
+		sw.events = sw.events[i:]
+	}
+}
+
+// WithObservability enables enhanced observability with the given configuration.
+// Disabled by default — zero overhead when not configured.
+func WithObservability(config ObservabilityConfig) BrokerOption {
+	return func(b *SSEBroker) {
+		b.obs = &observabilityState{
+			config:           config,
+			latencyBuffers:   make(map[string]*circularDurations),
+			throughputData:   make(map[string]*slidingWindow),
+			connDurData:      make(map[string]*circularDurations),
+			evictionCounters: make(map[string]*atomic.Int64),
+		}
+	}
+}
+
+// Observability returns the observability handle for the broker.
+// Returns nil if observability is not enabled.
+func (b *SSEBroker) Observability() *observabilityState {
+	return b.obs
+}
+
+// recordPublishLatency records a publish latency sample for a topic.
+func (o *observabilityState) recordPublishLatency(topic string, d time.Duration) {
+	if !o.config.PublishLatency {
+		return
+	}
+	buf := o.getOrCreateLatencyBuffer(topic)
+	buf.add(d)
+}
+
+func (o *observabilityState) getOrCreateLatencyBuffer(topic string) *circularDurations {
+	o.latencyMu.RLock()
+	buf, ok := o.latencyBuffers[topic]
+	o.latencyMu.RUnlock()
+	if ok {
+		return buf
+	}
+	o.latencyMu.Lock()
+	buf, ok = o.latencyBuffers[topic]
+	if !ok {
+		buf = newCircularDurations(defaultHistogramSize)
+		o.latencyBuffers[topic] = buf
+	}
+	o.latencyMu.Unlock()
+	return buf
+}
+
+// recordThroughput records a publish event for throughput calculation.
+func (o *observabilityState) recordThroughput(topic string, now time.Time) {
+	if !o.config.TopicThroughput {
+		return
+	}
+	sw := o.getOrCreateSlidingWindow(topic)
+	sw.record(now)
+}
+
+func (o *observabilityState) getOrCreateSlidingWindow(topic string) *slidingWindow {
+	o.throughputMu.RLock()
+	sw, ok := o.throughputData[topic]
+	o.throughputMu.RUnlock()
+	if ok {
+		return sw
+	}
+	o.throughputMu.Lock()
+	sw, ok = o.throughputData[topic]
+	if !ok {
+		sw = newSlidingWindow(defaultThroughputWindow)
+		o.throughputData[topic] = sw
+	}
+	o.throughputMu.Unlock()
+	return sw
+}
+
+// recordConnectionDuration records a connection duration when a subscriber disconnects.
+func (o *observabilityState) recordConnectionDuration(topic string, d time.Duration) {
+	if !o.config.ConnectionDuration {
+		return
+	}
+	buf := o.getOrCreateConnDurBuffer(topic)
+	buf.add(d)
+}
+
+func (o *observabilityState) getOrCreateConnDurBuffer(topic string) *circularDurations {
+	o.connDurMu.RLock()
+	buf, ok := o.connDurData[topic]
+	o.connDurMu.RUnlock()
+	if ok {
+		return buf
+	}
+	o.connDurMu.Lock()
+	buf, ok = o.connDurData[topic]
+	if !ok {
+		buf = newCircularDurations(defaultHistogramSize)
+		o.connDurData[topic] = buf
+	}
+	o.connDurMu.Unlock()
+	return buf
+}
+
+// recordEviction increments the eviction counter for a topic.
+func (o *observabilityState) recordEviction(topic string) {
+	o.evictionMu.RLock()
+	counter, ok := o.evictionCounters[topic]
+	o.evictionMu.RUnlock()
+	if ok {
+		counter.Add(1)
+		return
+	}
+	o.evictionMu.Lock()
+	counter, ok = o.evictionCounters[topic]
+	if !ok {
+		counter = &atomic.Int64{}
+		o.evictionCounters[topic] = counter
+	}
+	o.evictionMu.Unlock()
+	counter.Add(1)
+}
+
+// PublishLatencyP99 returns the p99 publish latency for the given topic.
+func (o *observabilityState) PublishLatencyP99(topic string) time.Duration {
+	if !o.config.PublishLatency {
+		return 0
+	}
+	o.latencyMu.RLock()
+	buf, ok := o.latencyBuffers[topic]
+	o.latencyMu.RUnlock()
+	if !ok {
+		return 0
+	}
+	samples, _ := buf.snapshot()
+	return percentile(samples, 0.99)
+}
+
+// SubscriberLag returns the buffer depth for each subscriber on the given topic.
+// The broker reference is needed to inspect subscriber channels.
+func (o *observabilityState) SubscriberLag(topic string, b *SSEBroker) map[string]int {
+	if !o.config.SubscriberLag {
+		return nil
+	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	result := make(map[string]int)
+	for ch := range b.topics[topic] {
+		info, ok := b.subscriberMeta[ch]
+		if !ok {
+			continue
+		}
+		id := info.ID
+		if id == "" {
+			id = info.ConnectedAt.Format(time.RFC3339Nano)
+		}
+		result[id] = len(ch)
+	}
+	for ch := range b.scopedTopics[topic] {
+		info, ok := b.subscriberMeta[ch]
+		if !ok {
+			continue
+		}
+		id := info.ID
+		if id == "" {
+			id = info.ConnectedAt.Format(time.RFC3339Nano)
+		}
+		result[id] = len(ch)
+	}
+	return result
+}
+
+// ConnectionDurations returns recorded connection durations for the given topic.
+func (o *observabilityState) ConnectionDurations(topic string) []time.Duration {
+	if !o.config.ConnectionDuration {
+		return nil
+	}
+	o.connDurMu.RLock()
+	buf, ok := o.connDurData[topic]
+	o.connDurMu.RUnlock()
+	if !ok {
+		return nil
+	}
+	durations, _ := buf.snapshot()
+	return durations
+}
+
+// TopicThroughput returns the message rate (msgs/sec) for the given topic.
+func (o *observabilityState) TopicThroughput(topic string) float64 {
+	if !o.config.TopicThroughput {
+		return 0
+	}
+	o.throughputMu.RLock()
+	sw, ok := o.throughputData[topic]
+	o.throughputMu.RUnlock()
+	if !ok {
+		return 0
+	}
+	return sw.rate(time.Now())
+}
+
+// EvictionCount returns the number of subscriber evictions for the given topic.
+func (o *observabilityState) EvictionCount(topic string) int64 {
+	o.evictionMu.RLock()
+	counter, ok := o.evictionCounters[topic]
+	o.evictionMu.RUnlock()
+	if !ok {
+		return 0
+	}
+	return counter.Load()
+}
+
+// Snapshot returns a point-in-time snapshot of all observability data.
+func (o *observabilityState) Snapshot(b *SSEBroker) ObservabilitySnapshot {
+	snap := ObservabilitySnapshot{
+		Topics: make(map[string]TopicObservability),
+	}
+	now := time.Now()
+
+	// Collect all known topics across all data sources.
+	seen := make(map[string]struct{})
+	if o.config.PublishLatency {
+		o.latencyMu.RLock()
+		for t := range o.latencyBuffers {
+			seen[t] = struct{}{}
+		}
+		o.latencyMu.RUnlock()
+	}
+	if o.config.TopicThroughput {
+		o.throughputMu.RLock()
+		for t := range o.throughputData {
+			seen[t] = struct{}{}
+		}
+		o.throughputMu.RUnlock()
+	}
+	if o.config.ConnectionDuration {
+		o.connDurMu.RLock()
+		for t := range o.connDurData {
+			seen[t] = struct{}{}
+		}
+		o.connDurMu.RUnlock()
+	}
+	o.evictionMu.RLock()
+	for t := range o.evictionCounters {
+		seen[t] = struct{}{}
+	}
+	o.evictionMu.RUnlock()
+
+	// Also include topics with active subscribers.
+	if o.config.SubscriberLag {
+		b.mu.RLock()
+		for t := range b.topics {
+			seen[t] = struct{}{}
+		}
+		for t := range b.scopedTopics {
+			seen[t] = struct{}{}
+		}
+		b.mu.RUnlock()
+	}
+
+	for topic := range seen {
+		to := TopicObservability{}
+
+		if o.config.PublishLatency {
+			o.latencyMu.RLock()
+			buf, ok := o.latencyBuffers[topic]
+			o.latencyMu.RUnlock()
+			if ok {
+				samples, count := buf.snapshot()
+				to.PublishLatency = LatencyHistogram{
+					P50:   percentile(samples, 0.50),
+					P95:   percentile(samples, 0.95),
+					P99:   percentile(samples, 0.99),
+					Count: count,
+				}
+			}
+		}
+
+		if o.config.SubscriberLag {
+			to.SubscriberLag = o.SubscriberLag(topic, b)
+		}
+
+		if o.config.ConnectionDuration {
+			to.ConnectionDurations = o.ConnectionDurations(topic)
+		}
+
+		if o.config.TopicThroughput {
+			o.throughputMu.RLock()
+			sw, ok := o.throughputData[topic]
+			o.throughputMu.RUnlock()
+			if ok {
+				to.Throughput = sw.rate(now)
+			}
+		}
+
+		o.evictionMu.RLock()
+		counter, ok := o.evictionCounters[topic]
+		o.evictionMu.RUnlock()
+		if ok {
+			to.EvictionCount = counter.Load()
+		}
+
+		snap.Topics[topic] = to
+	}
+	return snap
+}
+
+// percentile computes the given percentile (0..1) from a slice of durations.
+// Returns 0 if the slice is empty.
+func percentile(samples []time.Duration, p float64) time.Duration {
+	if len(samples) == 0 {
+		return 0
+	}
+	slices.Sort(samples)
+	idx := int(math.Ceil(p*float64(len(samples)))) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(samples) {
+		idx = len(samples) - 1
+	}
+	return samples[idx]
+}

--- a/observability_test.go
+++ b/observability_test.go
@@ -1,0 +1,428 @@
+package tavern
+
+import (
+	"testing"
+	"time"
+)
+
+func TestObservability_DisabledByDefault(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	if b.Observability() != nil {
+		t.Fatal("expected Observability() to return nil when not configured")
+	}
+}
+
+func TestObservability_ZeroOverheadWhenDisabled(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("events")
+	defer unsub()
+
+	// These should not panic even without observability.
+	b.Publish("events", "msg1")
+	b.PublishWithReplay("events", "msg2")
+	b.PublishIfChanged("events", "msg3")
+	b.PublishTo("events", "scope", "msg4")
+
+	timeout := time.After(100 * time.Millisecond)
+	for {
+		select {
+		case <-ch:
+		case <-timeout:
+			return
+		}
+	}
+}
+
+func TestObservability_PublishLatency(t *testing.T) {
+	b := NewSSEBroker(WithObservability(ObservabilityConfig{
+		PublishLatency: true,
+	}))
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("events")
+	defer unsub()
+
+	for i := 0; i < 10; i++ {
+		b.Publish("events", "msg")
+	}
+	for i := 0; i < 10; i++ {
+		<-ch
+	}
+
+	obs := b.Observability()
+	p99 := obs.PublishLatencyP99("events")
+	if p99 <= 0 {
+		t.Fatal("expected positive p99 latency")
+	}
+}
+
+func TestObservability_PublishLatency_NoDataReturnsZero(t *testing.T) {
+	b := NewSSEBroker(WithObservability(ObservabilityConfig{
+		PublishLatency: true,
+	}))
+	defer b.Close()
+
+	obs := b.Observability()
+	if p99 := obs.PublishLatencyP99("nonexistent"); p99 != 0 {
+		t.Fatalf("expected 0 for nonexistent topic, got %v", p99)
+	}
+}
+
+func TestObservability_PublishLatency_DisabledReturnsZero(t *testing.T) {
+	b := NewSSEBroker(WithObservability(ObservabilityConfig{
+		PublishLatency: false,
+	}))
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("events")
+	defer unsub()
+	b.Publish("events", "msg")
+	<-ch
+
+	obs := b.Observability()
+	if p99 := obs.PublishLatencyP99("events"); p99 != 0 {
+		t.Fatalf("expected 0 when PublishLatency disabled, got %v", p99)
+	}
+}
+
+func TestObservability_SubscriberLag(t *testing.T) {
+	b := NewSSEBroker(WithObservability(ObservabilityConfig{
+		SubscriberLag: true,
+	}), WithBufferSize(10))
+	defer b.Close()
+
+	_, unsub := b.SubscribeWithMeta("events", SubscribeMeta{ID: "sub-1"})
+	defer unsub()
+
+	// Publish 5 messages without draining.
+	for i := 0; i < 5; i++ {
+		b.Publish("events", "msg")
+	}
+
+	obs := b.Observability()
+	lag := obs.SubscriberLag("events", b)
+	if lag == nil {
+		t.Fatal("expected non-nil lag map")
+	}
+	depth, ok := lag["sub-1"]
+	if !ok {
+		t.Fatal("expected sub-1 in lag map")
+	}
+	if depth != 5 {
+		t.Fatalf("expected lag=5, got %d", depth)
+	}
+}
+
+func TestObservability_SubscriberLag_DisabledReturnsNil(t *testing.T) {
+	b := NewSSEBroker(WithObservability(ObservabilityConfig{
+		SubscriberLag: false,
+	}))
+	defer b.Close()
+
+	obs := b.Observability()
+	if lag := obs.SubscriberLag("events", b); lag != nil {
+		t.Fatal("expected nil when SubscriberLag disabled")
+	}
+}
+
+func TestObservability_ConnectionDuration(t *testing.T) {
+	b := NewSSEBroker(WithObservability(ObservabilityConfig{
+		ConnectionDuration: true,
+	}))
+	defer b.Close()
+
+	_, unsub := b.Subscribe("events")
+	time.Sleep(10 * time.Millisecond)
+	unsub()
+
+	obs := b.Observability()
+	durations := obs.ConnectionDurations("events")
+	if len(durations) != 1 {
+		t.Fatalf("expected 1 duration, got %d", len(durations))
+	}
+	if durations[0] < 10*time.Millisecond {
+		t.Fatalf("expected duration >= 10ms, got %v", durations[0])
+	}
+}
+
+func TestObservability_ConnectionDuration_ScopedSubscriber(t *testing.T) {
+	b := NewSSEBroker(WithObservability(ObservabilityConfig{
+		ConnectionDuration: true,
+	}))
+	defer b.Close()
+
+	_, unsub := b.SubscribeScoped("events", "scope-1")
+	time.Sleep(10 * time.Millisecond)
+	unsub()
+
+	obs := b.Observability()
+	durations := obs.ConnectionDurations("events")
+	if len(durations) != 1 {
+		t.Fatalf("expected 1 duration, got %d", len(durations))
+	}
+	if durations[0] < 10*time.Millisecond {
+		t.Fatalf("expected duration >= 10ms, got %v", durations[0])
+	}
+}
+
+func TestObservability_ConnectionDuration_DisabledReturnsNil(t *testing.T) {
+	b := NewSSEBroker(WithObservability(ObservabilityConfig{
+		ConnectionDuration: false,
+	}))
+	defer b.Close()
+
+	_, unsub := b.Subscribe("events")
+	unsub()
+
+	obs := b.Observability()
+	if d := obs.ConnectionDurations("events"); d != nil {
+		t.Fatal("expected nil when ConnectionDuration disabled")
+	}
+}
+
+func TestObservability_TopicThroughput(t *testing.T) {
+	b := NewSSEBroker(WithObservability(ObservabilityConfig{
+		TopicThroughput: true,
+	}), WithBufferSize(100))
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("events")
+	defer unsub()
+
+	for i := 0; i < 50; i++ {
+		b.Publish("events", "msg")
+	}
+	for i := 0; i < 50; i++ {
+		<-ch
+	}
+
+	obs := b.Observability()
+	rate := obs.TopicThroughput("events")
+	if rate <= 0 {
+		t.Fatal("expected positive throughput")
+	}
+}
+
+func TestObservability_TopicThroughput_DisabledReturnsZero(t *testing.T) {
+	b := NewSSEBroker(WithObservability(ObservabilityConfig{
+		TopicThroughput: false,
+	}))
+	defer b.Close()
+
+	obs := b.Observability()
+	if rate := obs.TopicThroughput("events"); rate != 0 {
+		t.Fatalf("expected 0 when TopicThroughput disabled, got %v", rate)
+	}
+}
+
+func TestObservability_EvictionCount(t *testing.T) {
+	b := NewSSEBroker(
+		WithObservability(ObservabilityConfig{}),
+		WithBufferSize(1),
+		WithSlowSubscriberEviction(2),
+	)
+	defer b.Close()
+
+	_, unsub := b.Subscribe("events")
+	defer unsub()
+
+	// Fill buffer and cause drops that trigger eviction.
+	for i := 0; i < 10; i++ {
+		b.Publish("events", "msg")
+	}
+
+	// Allow eviction to complete.
+	time.Sleep(50 * time.Millisecond)
+
+	obs := b.Observability()
+	count := obs.EvictionCount("events")
+	if count < 1 {
+		t.Fatalf("expected at least 1 eviction, got %d", count)
+	}
+}
+
+func TestObservability_Snapshot(t *testing.T) {
+	b := NewSSEBroker(WithObservability(ObservabilityConfig{
+		PublishLatency:     true,
+		SubscriberLag:      true,
+		ConnectionDuration: true,
+		TopicThroughput:    true,
+	}))
+	defer b.Close()
+
+	// Create subscriber, publish, then disconnect to populate all metrics.
+	ch, unsub := b.SubscribeWithMeta("events", SubscribeMeta{ID: "snap-sub"})
+	for i := 0; i < 5; i++ {
+		b.Publish("events", "msg")
+	}
+	for i := 0; i < 5; i++ {
+		<-ch
+	}
+	unsub()
+
+	obs := b.Observability()
+	snap := obs.Snapshot(b)
+
+	if snap.Topics == nil {
+		t.Fatal("expected non-nil Topics in snapshot")
+	}
+	to, ok := snap.Topics["events"]
+	if !ok {
+		t.Fatal("expected 'events' topic in snapshot")
+	}
+	if to.PublishLatency.Count != 5 {
+		t.Fatalf("expected latency count=5, got %d", to.PublishLatency.Count)
+	}
+	if to.PublishLatency.P50 <= 0 || to.PublishLatency.P95 <= 0 || to.PublishLatency.P99 <= 0 {
+		t.Fatal("expected positive latency percentiles")
+	}
+	if to.Throughput <= 0 {
+		t.Fatal("expected positive throughput in snapshot")
+	}
+	if len(to.ConnectionDurations) != 1 {
+		t.Fatalf("expected 1 connection duration, got %d", len(to.ConnectionDurations))
+	}
+}
+
+func TestObservability_Snapshot_EmptyWhenDisabled(t *testing.T) {
+	b := NewSSEBroker(WithObservability(ObservabilityConfig{}))
+	defer b.Close()
+
+	obs := b.Observability()
+	snap := obs.Snapshot(b)
+	if len(snap.Topics) != 0 {
+		t.Fatalf("expected empty snapshot, got %d topics", len(snap.Topics))
+	}
+}
+
+func TestObservability_PublishWithReplay_RecordsLatency(t *testing.T) {
+	b := NewSSEBroker(WithObservability(ObservabilityConfig{
+		PublishLatency:  true,
+		TopicThroughput: true,
+	}))
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("events")
+	defer unsub()
+
+	b.PublishWithReplay("events", "msg")
+	<-ch
+
+	obs := b.Observability()
+	if p99 := obs.PublishLatencyP99("events"); p99 <= 0 {
+		t.Fatal("expected positive p99 from PublishWithReplay")
+	}
+	if rate := obs.TopicThroughput("events"); rate <= 0 {
+		t.Fatal("expected positive throughput from PublishWithReplay")
+	}
+}
+
+func TestObservability_PublishTo_RecordsLatency(t *testing.T) {
+	b := NewSSEBroker(WithObservability(ObservabilityConfig{
+		PublishLatency:  true,
+		TopicThroughput: true,
+	}))
+	defer b.Close()
+
+	ch, unsub := b.SubscribeScoped("events", "scope-1")
+	defer unsub()
+
+	b.PublishTo("events", "scope-1", "msg")
+	<-ch
+
+	obs := b.Observability()
+	if p99 := obs.PublishLatencyP99("events"); p99 <= 0 {
+		t.Fatal("expected positive p99 from PublishTo")
+	}
+}
+
+func TestObservability_SubscriberLag_FallbackID(t *testing.T) {
+	b := NewSSEBroker(WithObservability(ObservabilityConfig{
+		SubscriberLag: true,
+	}), WithBufferSize(10))
+	defer b.Close()
+
+	// Subscribe without meta — should use ConnectedAt as fallback ID.
+	_, unsub := b.Subscribe("events")
+	defer unsub()
+
+	b.Publish("events", "msg")
+
+	obs := b.Observability()
+	lag := obs.SubscriberLag("events", b)
+	if len(lag) != 1 {
+		t.Fatalf("expected 1 entry in lag map, got %d", len(lag))
+	}
+	for _, depth := range lag {
+		if depth != 1 {
+			t.Fatalf("expected lag=1, got %d", depth)
+		}
+	}
+}
+
+func TestPercentile_EmptySlice(t *testing.T) {
+	if d := percentile(nil, 0.99); d != 0 {
+		t.Fatalf("expected 0 for empty slice, got %v", d)
+	}
+}
+
+func TestPercentile_SingleElement(t *testing.T) {
+	samples := []time.Duration{5 * time.Millisecond}
+	if d := percentile(samples, 0.50); d != 5*time.Millisecond {
+		t.Fatalf("expected 5ms, got %v", d)
+	}
+	if d := percentile(samples, 0.99); d != 5*time.Millisecond {
+		t.Fatalf("expected 5ms, got %v", d)
+	}
+}
+
+func TestPercentile_MultipleElements(t *testing.T) {
+	samples := make([]time.Duration, 100)
+	for i := range samples {
+		samples[i] = time.Duration(i+1) * time.Millisecond
+	}
+	p50 := percentile(samples, 0.50)
+	p99 := percentile(samples, 0.99)
+	if p50 != 50*time.Millisecond {
+		t.Fatalf("expected p50=50ms, got %v", p50)
+	}
+	if p99 != 99*time.Millisecond {
+		t.Fatalf("expected p99=99ms, got %v", p99)
+	}
+}
+
+func TestCircularDurations_Wraps(t *testing.T) {
+	c := newCircularDurations(4)
+	for i := 0; i < 10; i++ {
+		c.add(time.Duration(i) * time.Millisecond)
+	}
+	snap, count := c.snapshot()
+	if count != 10 {
+		t.Fatalf("expected count=10, got %d", count)
+	}
+	if len(snap) != 4 {
+		t.Fatalf("expected 4 samples after wrap, got %d", len(snap))
+	}
+}
+
+func TestSlidingWindow_ExpiresOldEvents(t *testing.T) {
+	sw := newSlidingWindow(100 * time.Millisecond)
+	now := time.Now()
+	// Add events in the past.
+	sw.record(now.Add(-200 * time.Millisecond))
+	sw.record(now.Add(-150 * time.Millisecond))
+	// Add current events.
+	sw.record(now)
+	sw.record(now)
+
+	rate := sw.rate(now)
+	// Only 2 events should be in the window.
+	expected := 2.0 / 0.1 // 20 msgs/sec
+	if rate != expected {
+		t.Fatalf("expected rate=%.1f, got %.1f", expected, rate)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `WithObservability(ObservabilityConfig{...})` broker option for rich per-topic metrics
- Implements publish latency histograms (p50/p95/p99), subscriber buffer depth gauges, connection duration tracking, topic throughput (msgs/sec), and per-topic eviction counters
- All features disabled by default with zero overhead when not configured; hooks into publish, subscribe/unsubscribe, and eviction paths only when enabled

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Linting passes (`golangci-lint run ./...`)
- [x] New tests cover: latency recording, lag calculation, connection duration (unscoped + scoped), throughput, eviction count, snapshot, disabled-by-default behavior, percentile edge cases, circular buffer wrapping, sliding window expiry

Closes #95