### PR TITLE
feat: dynamic topic add/remove for existing subscribers

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -70,6 +70,7 @@ type SSEBroker struct {
 	rateLimit         *rateLimiter                     // per-subscriber rate limiting
 	adaptive          *adaptiveBackpressure          // nil = adaptive backpressure disabled
 	obs               *observabilityState              // nil when observability disabled
+	multiSubs         map[string]*multiSub             // subscriberID → managed multi-subscription
 }
 
 // Topic name constants are conventions for common real-time use cases.
@@ -1116,6 +1117,7 @@ func (b *SSEBroker) Close() {
 	b.lastHash = nil
 	b.subscriberMeta = nil
 	b.filterPredicates = nil
+	b.multiSubs = nil
 	b.onReplayGap = nil
 	b.replayGapStrategy = nil
 	b.replayGapSnapshot = nil

--- a/subscription_changes.go
+++ b/subscription_changes.go
@@ -1,0 +1,349 @@
+package tavern
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+)
+
+// topicsChangedEvent is the SSE event name sent to clients when their
+// subscription set changes via [SSEBroker.AddTopic] or [SSEBroker.RemoveTopic].
+const topicsChangedEvent = "tavern-topics-changed"
+
+// multiSub tracks a multiplexed subscriber that was created via
+// [SSEBroker.SubscribeMulti] or upgraded from a single-topic subscriber
+// via [SSEBroker.AddTopic].
+type multiSub struct {
+	id     string
+	out    chan TopicMessage
+	done   chan struct{}
+	wg     sync.WaitGroup
+	mu     sync.Mutex
+	topics map[string]chan string // topic → internal channel
+	unsubs map[string]func()     // topic → unsubscribe function
+}
+
+// AddTopic adds a topic to an existing subscriber identified by subscriberID.
+// The subscriber starts receiving messages from the new topic without
+// reconnecting. If the subscriber is already subscribed to the topic, this is
+// a no-op and returns false. Returns true if the topic was successfully added.
+//
+// If sendControl is true, a control event with type "tavern-topics-changed" is
+// sent on the subscriber's channel so the client can react (e.g., set up new
+// SSE-swap targets).
+func (b *SSEBroker) AddTopic(subscriberID, topic string, sendControl bool) bool {
+	b.mu.RLock()
+	ms := b.findMultiSub(subscriberID)
+	b.mu.RUnlock()
+
+	if ms == nil {
+		return false
+	}
+
+	ms.mu.Lock()
+	if _, already := ms.topics[topic]; already {
+		ms.mu.Unlock()
+		return false
+	}
+	ms.mu.Unlock()
+
+	ch, unsub := b.Subscribe(topic)
+
+	// Attach subscriber metadata (ID) to the new channel.
+	b.mu.Lock()
+	bidir := b.findBidirChan(topic, ch)
+	if bidir != nil {
+		if info, ok := b.subscriberMeta[bidir]; ok {
+			info.ID = subscriberID
+		}
+	}
+	b.mu.Unlock()
+
+	ms.mu.Lock()
+	// Double-check after re-acquiring lock.
+	if _, already := ms.topics[topic]; already {
+		ms.mu.Unlock()
+		unsub()
+		return false
+	}
+	ms.topics[topic] = b.readToBidir(topic, ch)
+	ms.unsubs[topic] = unsub
+	ms.mu.Unlock()
+
+	// Start fan-in goroutine for the new topic.
+	ms.wg.Add(1)
+	go func() {
+		defer ms.wg.Done()
+		for {
+			select {
+			case msg, ok := <-ch:
+				if !ok {
+					return
+				}
+				select {
+				case ms.out <- TopicMessage{Topic: topic, Data: msg}:
+				case <-ms.done:
+					return
+				}
+			case <-ms.done:
+				return
+			}
+		}
+	}()
+
+	if sendControl {
+		b.sendTopicsChangedEvent(ms, "added", topic)
+	}
+
+	return true
+}
+
+// RemoveTopic removes a topic from an existing subscriber identified by
+// subscriberID. The subscriber stops receiving messages from the topic.
+// Returns true if the topic was found and removed. Lifecycle hooks
+// (OnLastUnsubscribe) fire if this was the last subscriber on the topic.
+//
+// If sendControl is true, a control event with type "tavern-topics-changed" is
+// sent on the subscriber's channel.
+func (b *SSEBroker) RemoveTopic(subscriberID, topic string, sendControl bool) bool {
+	b.mu.RLock()
+	ms := b.findMultiSub(subscriberID)
+	b.mu.RUnlock()
+
+	if ms == nil {
+		return false
+	}
+
+	ms.mu.Lock()
+	unsub, ok := ms.unsubs[topic]
+	if !ok {
+		ms.mu.Unlock()
+		return false
+	}
+	delete(ms.topics, topic)
+	delete(ms.unsubs, topic)
+	ms.mu.Unlock()
+
+	unsub()
+
+	if sendControl {
+		b.sendTopicsChangedEvent(ms, "removed", topic)
+	}
+
+	return true
+}
+
+// AddTopicForScope adds a topic to all subscribers with the matching scope.
+// Returns the number of subscribers that had the topic added.
+func (b *SSEBroker) AddTopicForScope(scope, topic string, sendControl bool) int {
+	subs := b.findMultiSubsByScope(scope)
+	count := 0
+	for _, ms := range subs {
+		if b.AddTopic(ms.id, topic, sendControl) {
+			count++
+		}
+	}
+	return count
+}
+
+// RemoveTopicForScope removes a topic from all subscribers with the matching
+// scope. Returns the number of subscribers that had the topic removed.
+func (b *SSEBroker) RemoveTopicForScope(scope, topic string, sendControl bool) int {
+	subs := b.findMultiSubsByScope(scope)
+	count := 0
+	for _, ms := range subs {
+		if b.RemoveTopic(ms.id, topic, sendControl) {
+			count++
+		}
+	}
+	return count
+}
+
+// SubscribeMultiWithMeta subscribes to multiple topics with metadata and
+// returns a managed multi-subscription that supports dynamic topic changes
+// via [SSEBroker.AddTopic] and [SSEBroker.RemoveTopic].
+func (b *SSEBroker) SubscribeMultiWithMeta(meta SubscribeMeta, topics ...string) (msgs <-chan TopicMessage, unsubscribe func()) {
+	out := make(chan TopicMessage, b.bufferSize)
+	done := make(chan struct{})
+
+	ms := &multiSub{
+		id:     meta.ID,
+		out:    out,
+		done:   done,
+		topics: make(map[string]chan string, len(topics)),
+		unsubs: make(map[string]func(), len(topics)),
+	}
+
+	for _, topic := range topics {
+		ch, unsub := b.Subscribe(topic)
+		bidir := b.readToBidir(topic, ch)
+
+		// Attach subscriber metadata.
+		b.mu.Lock()
+		if bidir != nil {
+			if info, ok := b.subscriberMeta[bidir]; ok {
+				info.ID = meta.ID
+				info.Meta = meta.Meta
+			}
+		}
+		b.mu.Unlock()
+
+		ms.topics[topic] = bidir
+		ms.unsubs[topic] = unsub
+
+		t := topic
+		ms.wg.Add(1)
+		go func() {
+			defer ms.wg.Done()
+			for {
+				select {
+				case msg, ok := <-ch:
+					if !ok {
+						return
+					}
+					select {
+					case out <- TopicMessage{Topic: t, Data: msg}:
+					case <-done:
+						return
+					}
+				case <-done:
+					return
+				}
+			}
+		}()
+	}
+
+	// Register the multi-sub for lookup.
+	b.mu.Lock()
+	if b.multiSubs == nil {
+		b.multiSubs = make(map[string]*multiSub)
+	}
+	b.multiSubs[meta.ID] = ms
+	b.mu.Unlock()
+
+	var closeOnce sync.Once
+	closeOut := func() {
+		closeOnce.Do(func() { close(out) })
+	}
+
+	var unsubOnce sync.Once
+	doUnsub := func() {
+		unsubOnce.Do(func() {
+			close(done)
+			ms.mu.Lock()
+			for _, unsub := range ms.unsubs {
+				unsub()
+			}
+			ms.mu.Unlock()
+
+			// Deregister the multi-sub.
+			b.mu.Lock()
+			delete(b.multiSubs, meta.ID)
+			b.mu.Unlock()
+		})
+	}
+
+	// Close out when all fan-in goroutines exit.
+	go func() {
+		ms.wg.Wait()
+		closeOut()
+	}()
+
+	return out, func() {
+		doUnsub()
+		ms.wg.Wait()
+		closeOut()
+	}
+}
+
+// findMultiSub returns the multiSub for the given subscriber ID.
+// Caller must hold b.mu (read or write).
+func (b *SSEBroker) findMultiSub(subscriberID string) *multiSub {
+	return b.multiSubs[subscriberID]
+}
+
+// findMultiSubsByScope returns all multiSubs whose ID matches any subscriber
+// with the given scope.
+func (b *SSEBroker) findMultiSubsByScope(scope string) []*multiSub {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	// Collect subscriber IDs that match the scope.
+	ids := make(map[string]struct{})
+	for _, info := range b.subscriberMeta {
+		if info != nil && info.Scope == scope && info.ID != "" {
+			ids[info.ID] = struct{}{}
+		}
+	}
+
+	// Also check multiSubs whose underlying channels have matching scope.
+	// For multiSubs, we check if any of their topics have scoped subscriptions.
+	var result []*multiSub
+	for id, ms := range b.multiSubs {
+		if _, ok := ids[id]; ok {
+			result = append(result, ms)
+			continue
+		}
+		// Check if any of the subscriber's metadata has matching scope.
+		ms.mu.Lock()
+		for _, ch := range ms.topics {
+			if info, ok := b.subscriberMeta[ch]; ok && info.Scope == scope {
+				result = append(result, ms)
+				break
+			}
+		}
+		ms.mu.Unlock()
+	}
+
+	return result
+}
+
+// readToBidir finds the bidirectional channel in the broker's topic map that
+// corresponds to the read-only channel. Returns nil if not found.
+func (b *SSEBroker) readToBidir(topic string, readCh <-chan string) chan string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.findBidirChan(topic, readCh)
+}
+
+// findBidirChan searches the topic map for a bidirectional channel matching
+// the read-only channel. Caller must hold b.mu.
+func (b *SSEBroker) findBidirChan(topic string, readCh <-chan string) chan string {
+	for ch := range b.topics[topic] {
+		readOnly := (<-chan string)(ch) //nolint:gocritic // parens required for channel type conversion
+		if readOnly == readCh {
+			return ch
+		}
+	}
+	for ch := range b.scopedTopics[topic] {
+		readOnly := (<-chan string)(ch) //nolint:gocritic // parens required for channel type conversion
+		if readOnly == readCh {
+			return ch
+		}
+	}
+	return nil
+}
+
+// sendTopicsChangedEvent sends a control event to the subscriber's output
+// channel with the current topic list.
+func (b *SSEBroker) sendTopicsChangedEvent(ms *multiSub, action, topic string) {
+	ms.mu.Lock()
+	topics := make([]string, 0, len(ms.topics))
+	for t := range ms.topics {
+		topics = append(topics, t)
+	}
+	ms.mu.Unlock()
+
+	payload, _ := json.Marshal(map[string]any{
+		"action": action,
+		"topic":  topic,
+		"topics": topics,
+	})
+
+	msg := fmt.Sprintf("event: %s\ndata: %s\n\n", topicsChangedEvent, string(payload))
+
+	select {
+	case ms.out <- TopicMessage{Topic: topicsChangedEvent, Data: msg}:
+	default:
+	}
+}

--- a/subscription_changes_test.go
+++ b/subscription_changes_test.go
@@ -1,0 +1,530 @@
+package tavern
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubscribeMultiWithMeta_ReceivesFromAllTopics(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a", "b")
+	defer unsub()
+
+	b.Publish("a", "from-a")
+	b.Publish("b", "from-b")
+
+	received := make(map[string]string)
+	for range 2 {
+		select {
+		case msg := <-ch:
+			received[msg.Topic] = msg.Data
+		case <-time.After(time.Second):
+			t.Fatalf("timed out, got %d/2", len(received))
+		}
+	}
+
+	assert.Equal(t, "from-a", received["a"])
+	assert.Equal(t, "from-b", received["b"])
+}
+
+func TestSubscribeMultiWithMeta_Unsubscribe(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a", "b")
+	unsub()
+
+	_, ok := <-ch
+	assert.False(t, ok, "channel should be closed after unsubscribe")
+}
+
+func TestSubscribeMultiWithMeta_DoubleUnsub(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a")
+	unsub()
+	assert.NotPanics(t, func() { unsub() })
+}
+
+func TestAddTopic_Basic(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a")
+	defer unsub()
+
+	ok := b.AddTopic("sub1", "b", false)
+	assert.True(t, ok)
+
+	b.Publish("a", "from-a")
+	b.Publish("b", "from-b")
+
+	received := make(map[string]string)
+	for range 2 {
+		select {
+		case msg := <-ch:
+			received[msg.Topic] = msg.Data
+		case <-time.After(time.Second):
+			t.Fatalf("timed out, got %d/2", len(received))
+		}
+	}
+
+	assert.Equal(t, "from-a", received["a"])
+	assert.Equal(t, "from-b", received["b"])
+}
+
+func TestAddTopic_DuplicateIsNoop(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a")
+	defer unsub()
+
+	ok := b.AddTopic("sub1", "a", false)
+	assert.False(t, ok, "adding duplicate topic should return false")
+}
+
+func TestAddTopic_UnknownSubscriber(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ok := b.AddTopic("nonexistent", "a", false)
+	assert.False(t, ok)
+}
+
+func TestRemoveTopic_Basic(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a", "b")
+	defer unsub()
+
+	// Drain any initial messages
+	ok := b.RemoveTopic("sub1", "b", false)
+	assert.True(t, ok)
+
+	b.Publish("a", "from-a")
+	b.Publish("b", "from-b-should-not-arrive")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "a", msg.Topic)
+		assert.Equal(t, "from-a", msg.Data)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for message from topic a")
+	}
+
+	// Ensure no message from b arrives
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected message: %+v", msg)
+	case <-time.After(100 * time.Millisecond):
+		// Expected: no message from removed topic
+	}
+}
+
+func TestRemoveTopic_UnknownTopic(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a")
+	defer unsub()
+
+	ok := b.RemoveTopic("sub1", "nonexistent", false)
+	assert.False(t, ok)
+}
+
+func TestRemoveTopic_UnknownSubscriber(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ok := b.RemoveTopic("nonexistent", "a", false)
+	assert.False(t, ok)
+}
+
+func TestAddTopic_FiresOnFirstSubscriber(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	fired := make(chan string, 1)
+	b.OnFirstSubscriber("new-topic", func(topic string) {
+		fired <- topic
+	})
+
+	_, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a")
+	defer unsub()
+
+	b.AddTopic("sub1", "new-topic", false)
+
+	select {
+	case topic := <-fired:
+		assert.Equal(t, "new-topic", topic)
+	case <-time.After(time.Second):
+		t.Fatal("OnFirstSubscriber did not fire")
+	}
+}
+
+func TestRemoveTopic_FiresOnLastUnsubscribe(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	fired := make(chan string, 1)
+	b.OnLastUnsubscribe("b", func(topic string) {
+		fired <- topic
+	})
+
+	_, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a", "b")
+	defer unsub()
+
+	b.RemoveTopic("sub1", "b", false)
+
+	select {
+	case topic := <-fired:
+		assert.Equal(t, "b", topic)
+	case <-time.After(time.Second):
+		t.Fatal("OnLastUnsubscribe did not fire")
+	}
+}
+
+func TestAddTopic_ControlEvent(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a")
+	defer unsub()
+
+	b.AddTopic("sub1", "b", true)
+
+	// Should receive a control event
+	select {
+	case msg := <-ch:
+		assert.Equal(t, topicsChangedEvent, msg.Topic)
+		assert.True(t, strings.Contains(msg.Data, "tavern-topics-changed"))
+		assert.True(t, strings.Contains(msg.Data, `"action":"added"`))
+		assert.True(t, strings.Contains(msg.Data, `"topic":"b"`))
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for control event")
+	}
+}
+
+func TestRemoveTopic_ControlEvent(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a", "b")
+	defer unsub()
+
+	b.RemoveTopic("sub1", "b", true)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, topicsChangedEvent, msg.Topic)
+		assert.True(t, strings.Contains(msg.Data, "tavern-topics-changed"))
+		assert.True(t, strings.Contains(msg.Data, `"action":"removed"`))
+		assert.True(t, strings.Contains(msg.Data, `"topic":"b"`))
+
+		// Parse the JSON data portion to verify topics list
+		dataIdx := strings.Index(msg.Data, "data: ")
+		require.NotEqual(t, -1, dataIdx)
+		dataStr := strings.TrimSpace(msg.Data[dataIdx+6:])
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal([]byte(dataStr), &payload))
+		topics := payload["topics"].([]any)
+		assert.Len(t, topics, 1)
+		assert.Equal(t, "a", topics[0].(string))
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for control event")
+	}
+}
+
+func TestAddTopicForScope(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	// Create subscriber with a scoped subscription so scope metadata is set.
+	ch1, unsub1 := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a")
+	defer unsub1()
+
+	// Manually set scope on the subscriber's metadata for the scope lookup.
+	b.mu.Lock()
+	for _, info := range b.subscriberMeta {
+		if info.ID == "sub1" {
+			info.Scope = "user:123"
+		}
+	}
+	b.mu.Unlock()
+
+	count := b.AddTopicForScope("user:123", "admin:panel", false)
+	assert.Equal(t, 1, count)
+
+	b.Publish("admin:panel", "admin-msg")
+
+	select {
+	case msg := <-ch1:
+		assert.Equal(t, "admin:panel", msg.Topic)
+		assert.Equal(t, "admin-msg", msg.Data)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for message on added topic")
+	}
+}
+
+func TestRemoveTopicForScope(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a", "b")
+	defer unsub()
+
+	// Set scope on subscriber metadata.
+	b.mu.Lock()
+	for _, info := range b.subscriberMeta {
+		if info.ID == "sub1" {
+			info.Scope = "user:123"
+		}
+	}
+	b.mu.Unlock()
+
+	count := b.RemoveTopicForScope("user:123", "b", false)
+	assert.Equal(t, 1, count)
+
+	b.Publish("a", "from-a")
+	b.Publish("b", "should-not-arrive")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "a", msg.Topic)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected message from removed topic: %+v", msg)
+	case <-time.After(100 * time.Millisecond):
+		// Expected
+	}
+}
+
+func TestAddTopic_ThreadSafety(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "base")
+	defer unsub()
+
+	var wg sync.WaitGroup
+	var addCount atomic.Int32
+
+	// Concurrently add topics and publish messages
+	for i := range 20 {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			topic := "topic-" + strings.Repeat("x", idx)
+			if b.AddTopic("sub1", topic, false) {
+				addCount.Add(1)
+			}
+		}(i)
+	}
+
+	// Concurrently publish to base topic
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			b.Publish("base", "concurrent-msg")
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, int32(20), addCount.Load(), "all 20 topics should have been added")
+
+	// Drain messages
+	drained := 0
+	for {
+		select {
+		case <-ch:
+			drained++
+		case <-time.After(200 * time.Millisecond):
+			goto done
+		}
+	}
+done:
+	// We should have received at least some messages
+	assert.Greater(t, drained, 0)
+}
+
+func TestRemoveTopic_ThreadSafety(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	topics := make([]string, 20)
+	for i := range topics {
+		topics[i] = "topic-" + strings.Repeat("x", i)
+	}
+
+	_, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, topics...)
+	defer unsub()
+
+	var wg sync.WaitGroup
+	var removeCount atomic.Int32
+
+	for _, topic := range topics {
+		wg.Add(1)
+		go func(t string) {
+			defer wg.Done()
+			if b.RemoveTopic("sub1", t, false) {
+				removeCount.Add(1)
+			}
+		}(topic)
+	}
+
+	wg.Wait()
+	assert.Equal(t, int32(20), removeCount.Load())
+}
+
+func TestAddAndRemoveTopic_Concurrent(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "base")
+	defer unsub()
+
+	var wg sync.WaitGroup
+
+	// Concurrently add and remove topics
+	for i := range 50 {
+		wg.Add(2)
+		topic := "dynamic-" + strings.Repeat("x", i%10)
+		go func() {
+			defer wg.Done()
+			b.AddTopic("sub1", topic, false)
+		}()
+		go func() {
+			defer wg.Done()
+			b.RemoveTopic("sub1", topic, false)
+		}()
+	}
+
+	wg.Wait()
+	// Test passes if no panics or deadlocks
+}
+
+func TestSubscribeMultiWithMeta_DeregistersOnUnsub(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a")
+	unsub()
+
+	// After unsubscribe, AddTopic should fail
+	ok := b.AddTopic("sub1", "b", false)
+	assert.False(t, ok, "should not be able to add topic after unsubscribe")
+}
+
+func TestAddTopic_MessagesDeliveredCorrectly(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a")
+	defer unsub()
+
+	// Add two more topics
+	b.AddTopic("sub1", "b", false)
+	b.AddTopic("sub1", "c", false)
+
+	// Publish to all three
+	b.Publish("a", "msg-a")
+	b.Publish("b", "msg-b")
+	b.Publish("c", "msg-c")
+
+	received := make(map[string]string)
+	for range 3 {
+		select {
+		case msg := <-ch:
+			received[msg.Topic] = msg.Data
+		case <-time.After(time.Second):
+			t.Fatalf("timed out, got %d/3 messages", len(received))
+		}
+	}
+
+	assert.Equal(t, "msg-a", received["a"])
+	assert.Equal(t, "msg-b", received["b"])
+	assert.Equal(t, "msg-c", received["c"])
+}
+
+func TestAddTopic_NoControlEventWhenDisabled(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a")
+	defer unsub()
+
+	b.AddTopic("sub1", "b", false)
+	b.Publish("b", "real-msg")
+
+	select {
+	case msg := <-ch:
+		// Should be the real message, not a control event
+		assert.Equal(t, "b", msg.Topic)
+		assert.Equal(t, "real-msg", msg.Data)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestMultipleSubscribers_IndependentTopicChanges(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch1, unsub1 := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "shared")
+	defer unsub1()
+
+	ch2, unsub2 := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub2"}, "shared")
+	defer unsub2()
+
+	// Add topic only to sub1
+	b.AddTopic("sub1", "exclusive", false)
+
+	b.Publish("exclusive", "exclusive-msg")
+
+	select {
+	case msg := <-ch1:
+		assert.Equal(t, "exclusive", msg.Topic)
+		assert.Equal(t, "exclusive-msg", msg.Data)
+	case <-time.After(time.Second):
+		t.Fatal("sub1 did not receive exclusive message")
+	}
+
+	// sub2 should NOT receive the exclusive message
+	select {
+	case msg := <-ch2:
+		t.Fatalf("sub2 should not receive exclusive message, got: %+v", msg)
+	case <-time.After(100 * time.Millisecond):
+		// Expected
+	}
+}
+
+func TestSubscribeMultiWithMeta_BrokerClose(t *testing.T) {
+	b := NewSSEBroker()
+
+	ch, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a", "b")
+	defer unsub()
+
+	b.Close()
+
+	// Drain; channel should eventually close
+	for range ch {
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `AddTopic`/`RemoveTopic` methods to modify a subscriber's topic set by subscriber ID without requiring reconnection
- Adds `AddTopicForScope`/`RemoveTopicForScope` to apply topic changes to all subscribers matching a scope
- Introduces `SubscribeMultiWithMeta` which creates a managed multi-subscription tracked by subscriber ID, enabling dynamic topic changes
- Lifecycle hooks (`OnFirstSubscriber`/`OnLastUnsubscribe`) fire correctly when topics are added/removed
- Optional `tavern-topics-changed` control event notifies clients of subscription changes

## Test plan

- [x] Basic add/remove topic operations
- [x] Duplicate add is a no-op
- [x] Unknown subscriber/topic returns false
- [x] Lifecycle hooks fire on add (OnFirstSubscriber) and remove (OnLastUnsubscribe)
- [x] Control event content and format validated
- [x] Scope-based add/remove variants
- [x] Thread safety: concurrent add/remove/publish
- [x] Multiple independent subscribers with separate topic sets
- [x] Deregistration on unsubscribe
- [x] Broker close with active managed subscriptions
- [x] All existing tests pass
- [x] golangci-lint clean

Closes #91