### PR TITLE
feat: hierarchical topic names with glob/wildcard subscriptions

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -71,6 +71,8 @@ type SSEBroker struct {
 	adaptive          *adaptiveBackpressure          // nil = adaptive backpressure disabled
 	obs               *observabilityState              // nil when observability disabled
 	multiSubs         map[string]*multiSub             // subscriberID → managed multi-subscription
+	globSubs          []*globSub                       // glob/wildcard subscriptions
+	globMu            sync.RWMutex                     // protects globSubs
 }
 
 // Topic name constants are conventions for common real-time use cases.
@@ -752,23 +754,22 @@ func (b *SSEBroker) publishDirect(topic, msg string) {
 		start = time.Now()
 	}
 	b.mu.RLock()
-	subscribers, exists := b.topics[topic]
-	if !exists || len(subscribers) == 0 {
-		b.mu.RUnlock()
-		return
-	}
+	subscribers := b.topics[topic]
 	channels := make([]chan string, 0, len(subscribers))
 	for ch := range subscribers {
 		channels = append(channels, ch)
 	}
 	b.mu.RUnlock()
 
-	sent, dropped := b.publishToChannels(topic, channels, msg)
-	if b.metrics != nil {
-		tc := b.metrics.counter(topic)
-		tc.published.Add(int64(sent))
-		tc.dropped.Add(int64(dropped))
+	if len(channels) > 0 {
+		sent, dropped := b.publishToChannels(topic, channels, msg)
+		if b.metrics != nil {
+			tc := b.metrics.counter(topic)
+			tc.published.Add(int64(sent))
+			tc.dropped.Add(int64(dropped))
+		}
 	}
+	b.dispatchToGlobSubscribers(topic, "", msg)
 	if b.obs != nil {
 		now := time.Now()
 		b.obs.recordPublishLatency(topic, now.Sub(start))
@@ -815,12 +816,15 @@ func (b *SSEBroker) publishWithReplayDirect(topic, msg string) {
 	}
 	b.mu.Unlock()
 
-	sent, dropped := b.publishToChannels(topic, channels, msg)
-	if b.metrics != nil {
-		tc := b.metrics.counter(topic)
-		tc.published.Add(int64(sent))
-		tc.dropped.Add(int64(dropped))
+	if len(channels) > 0 {
+		sent, dropped := b.publishToChannels(topic, channels, msg)
+		if b.metrics != nil {
+			tc := b.metrics.counter(topic)
+			tc.published.Add(int64(sent))
+			tc.dropped.Add(int64(dropped))
+		}
 	}
+	b.dispatchToGlobSubscribers(topic, "", msg)
 	if b.obs != nil {
 		now := time.Now()
 		b.obs.recordPublishLatency(topic, now.Sub(start))
@@ -885,11 +889,7 @@ func (b *SSEBroker) publishToDirect(topic, scope, msg string) {
 		start = time.Now()
 	}
 	b.mu.RLock()
-	scopedSubs, exists := b.scopedTopics[topic]
-	if !exists || len(scopedSubs) == 0 {
-		b.mu.RUnlock()
-		return
-	}
+	scopedSubs := b.scopedTopics[topic]
 	channels := make([]chan string, 0, len(scopedSubs))
 	for ch, sub := range scopedSubs {
 		if sub.scope == scope {
@@ -898,12 +898,15 @@ func (b *SSEBroker) publishToDirect(topic, scope, msg string) {
 	}
 	b.mu.RUnlock()
 
-	sent, dropped := b.publishToChannels(topic, channels, msg)
-	if b.metrics != nil {
-		tc := b.metrics.counter(topic)
-		tc.published.Add(int64(sent))
-		tc.dropped.Add(int64(dropped))
+	if len(channels) > 0 {
+		sent, dropped := b.publishToChannels(topic, channels, msg)
+		if b.metrics != nil {
+			tc := b.metrics.counter(topic)
+			tc.published.Add(int64(sent))
+			tc.dropped.Add(int64(dropped))
+		}
 	}
+	b.dispatchToGlobSubscribers(topic, scope, msg)
 	if b.obs != nil {
 		now := time.Now()
 		b.obs.recordPublishLatency(topic, now.Sub(start))
@@ -1148,6 +1151,12 @@ func (b *SSEBroker) Close() {
 		delete(b.scopedTopics, topic)
 	}
 	b.mu.Unlock()
+	b.globMu.Lock()
+	for _, gs := range b.globSubs {
+		close(gs.ch)
+	}
+	b.globSubs = nil
+	b.globMu.Unlock()
 	b.debounce.mu.Lock()
 	for topic, entry := range b.debounce.timers {
 		entry.timer.Stop()

--- a/glob.go
+++ b/glob.go
@@ -1,0 +1,163 @@
+package tavern
+
+import (
+	"strings"
+	"sync"
+)
+
+// globSub pairs a glob pattern with a subscriber channel and optional scope.
+type globSub struct {
+	pattern  string
+	ch       chan TopicMessage
+	scope    string // empty = unscoped
+	segments []string
+}
+
+// SubscribeGlob registers a subscriber for all topics matching the given glob
+// pattern and returns a channel that receives [TopicMessage] values tagged with
+// the actual publish topic. The pattern uses "/" as the topic separator:
+//   - "*" matches exactly one segment
+//   - "**" matches zero or more segments (any depth)
+//
+// The returned unsubscribe function removes the glob subscriber and closes the
+// channel. It is safe to call more than once.
+func (b *SSEBroker) SubscribeGlob(pattern string) (msgs <-chan TopicMessage, unsubscribe func()) {
+	return b.subscribeGlob(pattern, "")
+}
+
+// SubscribeGlobScoped registers a scoped glob subscriber. Only messages
+// published via [SSEBroker.PublishTo] with a matching scope will be delivered.
+func (b *SSEBroker) SubscribeGlobScoped(pattern, scope string) (msgs <-chan TopicMessage, unsubscribe func()) {
+	return b.subscribeGlob(pattern, scope)
+}
+
+func (b *SSEBroker) subscribeGlob(pattern, scope string) (msgs <-chan TopicMessage, unsubscribe func()) {
+	ch := make(chan TopicMessage, b.bufferSize)
+	sub := &globSub{
+		pattern:  pattern,
+		ch:       ch,
+		scope:    scope,
+		segments: strings.Split(pattern, "/"),
+	}
+
+	b.globMu.Lock()
+	if b.closed {
+		b.globMu.Unlock()
+		close(ch)
+		return ch, func() {}
+	}
+	b.globSubs = append(b.globSubs, sub)
+	b.globMu.Unlock()
+
+	var once sync.Once
+	return ch, func() {
+		once.Do(func() {
+			b.globMu.Lock()
+			for i, s := range b.globSubs {
+				if s == sub {
+					b.globSubs = append(b.globSubs[:i], b.globSubs[i+1:]...)
+					break
+				}
+			}
+			b.globMu.Unlock()
+			close(ch)
+		})
+	}
+}
+
+// UnsubscribeGlob is a convenience alias: callers may pass the channel
+// returned by [SubscribeGlob] but the idiomatic approach is to call the
+// unsubscribe function returned alongside the channel. This method finds and
+// removes the glob subscription associated with ch, closing the channel.
+func (b *SSEBroker) UnsubscribeGlob(ch <-chan TopicMessage) {
+	b.globMu.Lock()
+	for i, s := range b.globSubs {
+		if s.ch == ch {
+			b.globSubs = append(b.globSubs[:i], b.globSubs[i+1:]...)
+			b.globMu.Unlock()
+			close(s.ch)
+			return
+		}
+	}
+	b.globMu.Unlock()
+}
+
+// dispatchToGlobSubscribers sends msg (published to topic) to all glob
+// subscribers whose pattern matches the topic. For scoped subscribers, the
+// scope parameter must match; pass an empty string for unscoped publishes.
+func (b *SSEBroker) dispatchToGlobSubscribers(topic, scope, msg string) {
+	b.globMu.RLock()
+	if len(b.globSubs) == 0 {
+		b.globMu.RUnlock()
+		return
+	}
+	// Snapshot under lock.
+	subs := make([]*globSub, len(b.globSubs))
+	copy(subs, b.globSubs)
+	b.globMu.RUnlock()
+
+	topicSegments := strings.Split(topic, "/")
+	tm := TopicMessage{Topic: topic, Data: msg}
+
+	for _, sub := range subs {
+		// Scope filtering: unscoped glob subs receive unscoped publishes;
+		// scoped glob subs only receive matching scoped publishes.
+		if sub.scope != "" && sub.scope != scope {
+			continue
+		}
+		// Unscoped glob subs should not receive scoped publishes.
+		if sub.scope == "" && scope != "" {
+			continue
+		}
+		if !matchGlob(sub.segments, topicSegments) {
+			continue
+		}
+		func() {
+			defer func() { _ = recover() }()
+			select {
+			case sub.ch <- tm:
+			default:
+				b.drops.Add(1)
+			}
+		}()
+	}
+}
+
+// matchGlob reports whether topicSegments matches the pre-split pattern
+// segments. "*" matches exactly one segment, "**" matches zero or more.
+func matchGlob(pattern, topic []string) bool {
+	return matchGlobRecursive(pattern, 0, topic, 0)
+}
+
+func matchGlobRecursive(pattern []string, pi int, topic []string, ti int) bool {
+	for pi < len(pattern) {
+		if pattern[pi] == "**" {
+			// "**" matches zero or more segments.
+			// Try matching the rest of the pattern against every suffix of topic.
+			for k := ti; k <= len(topic); k++ {
+				if matchGlobRecursive(pattern, pi+1, topic, k) {
+					return true
+				}
+			}
+			return false
+		}
+		if ti >= len(topic) {
+			return false
+		}
+		if pattern[pi] == "*" {
+			// "*" matches exactly one non-empty segment.
+			if topic[ti] == "" {
+				return false
+			}
+			pi++
+			ti++
+			continue
+		}
+		if pattern[pi] != topic[ti] {
+			return false
+		}
+		pi++
+		ti++
+	}
+	return ti == len(topic)
+}

--- a/glob_test.go
+++ b/glob_test.go
@@ -1,0 +1,446 @@
+package tavern
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// --- matchGlob unit tests ---
+
+func TestMatchGlob(t *testing.T) {
+	tests := []struct {
+		pattern string
+		topic   string
+		want    bool
+	}{
+		// Exact match
+		{"app/dashboard/metrics", "app/dashboard/metrics", true},
+		{"app", "app", true},
+		{"app/dashboard/metrics", "app/dashboard/alerts", false},
+
+		// Single-level wildcard
+		{"app/dashboard/*", "app/dashboard/metrics", true},
+		{"app/dashboard/*", "app/dashboard/alerts", true},
+		{"app/dashboard/*", "app/dashboard/metrics/cpu", false},
+		{"app/*/status", "app/orders/status", true},
+		{"app/*/status", "app/users/status", true},
+		{"app/*/status", "app/orders/detail/status", false},
+		{"*/dashboard", "app/dashboard", true},
+		{"*/dashboard", "dashboard", false},
+
+		// Multi-level wildcard
+		{"app/dashboard/**", "app/dashboard", true},
+		{"app/dashboard/**", "app/dashboard/metrics", true},
+		{"app/dashboard/**", "app/dashboard/metrics/cpu", true},
+		{"app/dashboard/**", "app/other", false},
+		{"**", "anything", true},
+		{"**", "a/b/c/d", true},
+		{"**", "app", true},
+
+		// Cross-hierarchy wildcard
+		{"**/alerts", "alerts", true},
+		{"**/alerts", "app/alerts", true},
+		{"**/alerts", "app/dashboard/alerts", true},
+		{"**/alerts", "app/dashboard/alerts/critical", false},
+		{"**/alerts/critical", "alerts/critical", true},
+		{"**/alerts/critical", "app/alerts/critical", true},
+		{"**/alerts/critical", "app/dashboard/alerts/critical", true},
+		{"**/alerts/critical", "alerts", false},
+
+		// Mixed wildcards
+		{"app/**/status", "app/status", true},
+		{"app/**/status", "app/orders/status", true},
+		{"app/**/status", "app/orders/123/status", true},
+		{"app/*/events/**", "app/orders/events", true},
+		{"app/*/events/**", "app/orders/events/click", true},
+		{"app/*/events/**", "app/orders/events/click/detail", true},
+
+		// Edge cases
+		{"", "", true},
+		{"*", "x", true},
+		{"*", "", false},
+		{"**", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"→"+tt.topic, func(t *testing.T) {
+			pSegs := splitSegments(tt.pattern)
+			tSegs := splitSegments(tt.topic)
+			got := matchGlob(pSegs, tSegs)
+			if got != tt.want {
+				t.Errorf("matchGlob(%q, %q) = %v, want %v", tt.pattern, tt.topic, got, tt.want)
+			}
+		})
+	}
+}
+
+// splitSegments splits on "/" but handles the empty-string edge case.
+func splitSegments(s string) []string {
+	if s == "" {
+		return []string{""}
+	}
+	return split(s)
+}
+
+func split(s string) []string {
+	var parts []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '/' {
+			parts = append(parts, s[start:i])
+			start = i + 1
+		}
+	}
+	parts = append(parts, s[start:])
+	return parts
+}
+
+// --- SubscribeGlob integration tests ---
+
+func TestSubscribeGlob_SingleLevelWildcard(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeGlob("app/dashboard/*")
+	defer unsub()
+
+	b.Publish("app/dashboard/metrics", "cpu=42")
+	b.Publish("app/dashboard/alerts", "warn")
+	b.Publish("app/dashboard/metrics/cpu", "should-not-match")
+	b.Publish("app/other/stuff", "should-not-match")
+
+	assertGlobMessage(t, ch, "app/dashboard/metrics", "cpu=42")
+	assertGlobMessage(t, ch, "app/dashboard/alerts", "warn")
+	assertNoGlobMessage(t, ch)
+}
+
+func TestSubscribeGlob_MultiLevelWildcard(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeGlob("app/dashboard/**")
+	defer unsub()
+
+	b.Publish("app/dashboard", "root")
+	b.Publish("app/dashboard/metrics", "m")
+	b.Publish("app/dashboard/metrics/cpu", "c")
+	b.Publish("app/other", "no")
+
+	assertGlobMessage(t, ch, "app/dashboard", "root")
+	assertGlobMessage(t, ch, "app/dashboard/metrics", "m")
+	assertGlobMessage(t, ch, "app/dashboard/metrics/cpu", "c")
+	assertNoGlobMessage(t, ch)
+}
+
+func TestSubscribeGlob_CrossHierarchy(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeGlob("**/alerts/critical")
+	defer unsub()
+
+	b.Publish("alerts/critical", "a")
+	b.Publish("app/alerts/critical", "b")
+	b.Publish("app/dashboard/alerts/critical", "c")
+	b.Publish("alerts", "no")
+	b.Publish("alerts/info", "no")
+
+	assertGlobMessage(t, ch, "alerts/critical", "a")
+	assertGlobMessage(t, ch, "app/alerts/critical", "b")
+	assertGlobMessage(t, ch, "app/dashboard/alerts/critical", "c")
+	assertNoGlobMessage(t, ch)
+}
+
+func TestSubscribeGlob_ExactAndGlobCombined(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	// Exact subscriber
+	exactCh, exactUnsub := b.Subscribe("app/dashboard/metrics")
+	defer exactUnsub()
+
+	// Glob subscriber
+	globCh, globUnsub := b.SubscribeGlob("app/dashboard/*")
+	defer globUnsub()
+
+	b.Publish("app/dashboard/metrics", "data")
+
+	// Both should receive the message.
+	select {
+	case msg := <-exactCh:
+		if msg != "data" {
+			t.Errorf("exact subscriber got %q, want %q", msg, "data")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("exact subscriber did not receive message")
+	}
+
+	assertGlobMessage(t, globCh, "app/dashboard/metrics", "data")
+}
+
+func TestSubscribeGlob_Unsubscribe(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeGlob("app/**")
+
+	b.Publish("app/test", "before")
+	assertGlobMessage(t, ch, "app/test", "before")
+
+	unsub()
+
+	// Channel should be closed after unsubscribe.
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Error("expected channel to be closed after unsubscribe")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("channel not closed after unsubscribe")
+	}
+}
+
+func TestSubscribeGlob_DoubleUnsubscribe(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeGlob("app/**")
+	unsub()
+	unsub() // should not panic
+}
+
+func TestUnsubscribeGlob(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, _ := b.SubscribeGlob("app/**")
+
+	b.Publish("app/test", "before")
+	assertGlobMessage(t, ch, "app/test", "before")
+
+	b.UnsubscribeGlob(ch)
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Error("expected channel to be closed after UnsubscribeGlob")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("channel not closed after UnsubscribeGlob")
+	}
+}
+
+func TestSubscribeGlobScoped(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeGlobScoped("app/orders/*/status", "user:123")
+	defer unsub()
+
+	// Scoped publish matching pattern and scope.
+	b.PublishTo("app/orders/456/status", "user:123", "shipped")
+	assertGlobMessage(t, ch, "app/orders/456/status", "shipped")
+
+	// Scoped publish matching pattern but wrong scope.
+	b.PublishTo("app/orders/789/status", "user:456", "pending")
+	assertNoGlobMessage(t, ch)
+
+	// Unscoped publish should not reach scoped glob subscriber.
+	b.Publish("app/orders/111/status", "unscoped")
+	assertNoGlobMessage(t, ch)
+}
+
+func TestSubscribeGlob_UnscopedDoesNotReceiveScopedPublish(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeGlob("app/orders/**")
+	defer unsub()
+
+	// Scoped publish should not reach unscoped glob subscriber.
+	b.PublishTo("app/orders/123/status", "user:123", "scoped-msg")
+	assertNoGlobMessage(t, ch)
+
+	// Unscoped publish should reach.
+	b.Publish("app/orders/123/status", "unscoped-msg")
+	assertGlobMessage(t, ch, "app/orders/123/status", "unscoped-msg")
+}
+
+func TestSubscribeGlob_LifecycleHooksFireForConcreteTopic(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	var mu sync.Mutex
+	var firstTopics, lastTopics []string
+
+	b.OnFirstSubscriber("app/orders/123/status", func(topic string) {
+		mu.Lock()
+		firstTopics = append(firstTopics, topic)
+		mu.Unlock()
+	})
+	b.OnLastUnsubscribe("app/orders/123/status", func(topic string) {
+		mu.Lock()
+		lastTopics = append(lastTopics, topic)
+		mu.Unlock()
+	})
+
+	// Glob subscribe does NOT trigger lifecycle hooks on the concrete topic
+	// (the glob subscriber is not subscribed to a concrete topic).
+	globCh, globUnsub := b.SubscribeGlob("app/orders/*/status")
+	_ = globCh
+
+	time.Sleep(20 * time.Millisecond)
+	mu.Lock()
+	if len(firstTopics) != 0 {
+		t.Errorf("glob subscribe should not fire OnFirstSubscriber, got %v", firstTopics)
+	}
+	mu.Unlock()
+
+	// Exact subscribe should fire the hook.
+	exactCh, exactUnsub := b.Subscribe("app/orders/123/status")
+	_ = exactCh
+	time.Sleep(20 * time.Millisecond)
+	mu.Lock()
+	if len(firstTopics) != 1 || firstTopics[0] != "app/orders/123/status" {
+		t.Errorf("expected OnFirstSubscriber for concrete topic, got %v", firstTopics)
+	}
+	mu.Unlock()
+
+	exactUnsub()
+	time.Sleep(20 * time.Millisecond)
+	mu.Lock()
+	if len(lastTopics) != 1 || lastTopics[0] != "app/orders/123/status" {
+		t.Errorf("expected OnLastUnsubscribe for concrete topic, got %v", lastTopics)
+	}
+	mu.Unlock()
+
+	globUnsub()
+}
+
+func TestSubscribeGlob_BrokerClose(t *testing.T) {
+	b := NewSSEBroker()
+
+	ch, _ := b.SubscribeGlob("app/**")
+
+	b.Close()
+
+	// Channel should be closed when broker closes.
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Error("expected glob channel to be closed on broker close")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("glob channel not closed after broker close")
+	}
+}
+
+func TestSubscribeGlob_ClosedBroker(t *testing.T) {
+	b := NewSSEBroker()
+	b.Close()
+
+	ch, unsub := b.SubscribeGlob("app/**")
+	defer unsub()
+
+	// Should get a closed channel immediately.
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Error("expected closed channel from closed broker")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("channel not closed from closed broker")
+	}
+}
+
+func TestSubscribeGlob_MultipleGlobSubscribers(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch1, unsub1 := b.SubscribeGlob("app/**")
+	defer unsub1()
+	ch2, unsub2 := b.SubscribeGlob("app/dashboard/*")
+	defer unsub2()
+	ch3, unsub3 := b.SubscribeGlob("**/metrics")
+	defer unsub3()
+
+	b.Publish("app/dashboard/metrics", "data")
+
+	// All three should match.
+	assertGlobMessage(t, ch1, "app/dashboard/metrics", "data")
+	assertGlobMessage(t, ch2, "app/dashboard/metrics", "data")
+	assertGlobMessage(t, ch3, "app/dashboard/metrics", "data")
+}
+
+func TestSubscribeGlob_ConcurrentPublish(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(100))
+	defer b.Close()
+
+	ch, unsub := b.SubscribeGlob("app/**")
+	defer unsub()
+
+	const n = 50
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			b.Publish("app/test", "msg")
+		}()
+	}
+	wg.Wait()
+
+	count := 0
+	for {
+		select {
+		case <-ch:
+			count++
+		case <-time.After(50 * time.Millisecond):
+			goto done
+		}
+	}
+done:
+	if count == 0 {
+		t.Fatal("expected at least some messages from concurrent publishes")
+	}
+}
+
+func TestSubscribeGlob_PublishWithReplay(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeGlob("app/dashboard/*")
+	defer unsub()
+
+	b.PublishWithReplay("app/dashboard/metrics", "replayed")
+
+	assertGlobMessage(t, ch, "app/dashboard/metrics", "replayed")
+}
+
+// --- helpers ---
+
+func assertGlobMessage(t *testing.T, ch <-chan TopicMessage, wantTopic, wantData string) {
+	t.Helper()
+	select {
+	case msg := <-ch:
+		if msg.Topic != wantTopic {
+			t.Errorf("got topic %q, want %q", msg.Topic, wantTopic)
+		}
+		if msg.Data != wantData {
+			t.Errorf("got data %q, want %q", msg.Data, wantData)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatalf("timeout waiting for message on topic %q", wantTopic)
+	}
+}
+
+func assertNoGlobMessage(t *testing.T, ch <-chan TopicMessage) {
+	t.Helper()
+	select {
+	case msg := <-ch:
+		t.Errorf("unexpected message: topic=%q data=%q", msg.Topic, msg.Data)
+	case <-time.After(50 * time.Millisecond):
+		// OK: no message expected.
+	}
+}


### PR DESCRIPTION
## Summary

- Add `SubscribeGlob` and `SubscribeGlobScoped` methods for hierarchical topic subscriptions using `/`-separated topic names with `*` (single-level) and `**` (multi-level) wildcards
- Publishing to a concrete topic dispatches to both exact subscribers and matching glob subscribers; glob subscribers receive `TopicMessage` values tagged with the actual topic
- Zero overhead for existing non-glob code paths: the flat topic map is unchanged, glob matching only runs when glob subscribers exist

## Test plan

- [x] `matchGlob` unit tests: exact match, single-level `*`, multi-level `**`, cross-hierarchy `**/x`, mixed wildcards, edge cases
- [x] Integration tests: single-level wildcard, multi-level wildcard, cross-hierarchy, exact+glob combined, scoped glob, unscoped isolation from scoped publishes, unsubscribe, `UnsubscribeGlob`, double unsubscribe safety, lifecycle hooks fire for concrete topics only, broker close cleanup, closed broker subscribe, multiple concurrent glob subscribers, concurrent publish, `PublishWithReplay` dispatch
- [x] All existing tests pass unchanged
- [x] `golangci-lint run ./...` clean

Closes #88