### PR TITLE
feat: structured presence tracking subpackage

### DIFF
--- a/presence/presence.go
+++ b/presence/presence.go
@@ -1,0 +1,349 @@
+// Package presence provides structured presence tracking built on top of a
+// tavern SSE broker. It manages per-topic user presence with heartbeat-based
+// stale detection and optional OOB publishing for real-time UI updates.
+//
+// The package imports tavern (not the other way around) so there is no circular
+// dependency. Presence is opt-in — the core broker knows nothing about it.
+package presence
+
+import (
+	"sync"
+	"time"
+
+	"github.com/catgoose/tavern"
+)
+
+const (
+	// DefaultStaleTimeout is the default duration after which a user with no
+	// heartbeat is considered stale and removed.
+	DefaultStaleTimeout = 30 * time.Second
+
+	// DefaultPresenceTopicSuffix is appended to the base topic when
+	// publishing OOB presence updates.
+	DefaultPresenceTopicSuffix = ":presence"
+
+	// DefaultTargetID is the default OOB swap target element ID.
+	DefaultTargetID = "presence-list"
+)
+
+// RenderFunc converts the current presence list for a topic into an HTML
+// string suitable for OOB publishing. If nil, the tracker operates in
+// server-side-only mode (no OOB updates are published).
+type RenderFunc func(topic string, users []Info) string
+
+// Config configures a presence [Tracker].
+type Config struct {
+	// StaleTimeout is how long since the last heartbeat before a user is
+	// removed. Zero or negative values use [DefaultStaleTimeout].
+	StaleTimeout time.Duration
+
+	// OnJoin fires when a user joins a topic.
+	OnJoin func(topic string, info Info)
+	// OnLeave fires when a user leaves a topic (explicit or stale).
+	OnLeave func(topic string, info Info)
+	// OnUpdate fires when a user's presence metadata is updated.
+	OnUpdate func(topic string, info Info)
+
+	// RenderFunc converts presence state to HTML for OOB publishing.
+	// When nil, no OOB updates are published.
+	RenderFunc RenderFunc
+
+	// PresenceTopicSuffix is appended to the base topic for OOB publishes.
+	// Defaults to [DefaultPresenceTopicSuffix].
+	PresenceTopicSuffix string
+
+	// TargetID is the element ID used in OOB swap fragments.
+	// Defaults to [DefaultTargetID].
+	TargetID string
+}
+
+// Info represents a user's presence on a topic.
+type Info struct {
+	UserID   string
+	Name     string
+	Avatar   string
+	Metadata map[string]any // arbitrary fields (cursor position, status, etc.)
+	JoinedAt time.Time
+	LastSeen time.Time
+}
+
+// Tracker manages presence state for topics. It is safe for concurrent use.
+type Tracker struct {
+	broker *tavern.SSEBroker
+	cfg    Config
+
+	mu     sync.RWMutex
+	topics map[string]map[string]*Info // topic → userID → *Info
+
+	done chan struct{}
+	once sync.Once // ensures Close only runs once
+}
+
+// New creates a presence tracker backed by a tavern broker. The background
+// stale-checker goroutine starts immediately and runs until [Tracker.Close]
+// is called.
+func New(broker *tavern.SSEBroker, cfg Config) *Tracker {
+	if cfg.StaleTimeout <= 0 {
+		cfg.StaleTimeout = DefaultStaleTimeout
+	}
+	if cfg.PresenceTopicSuffix == "" {
+		cfg.PresenceTopicSuffix = DefaultPresenceTopicSuffix
+	}
+	if cfg.TargetID == "" {
+		cfg.TargetID = DefaultTargetID
+	}
+
+	t := &Tracker{
+		broker: broker,
+		cfg:    cfg,
+		topics: make(map[string]map[string]*Info),
+		done:   make(chan struct{}),
+	}
+	go t.sweepLoop()
+	return t
+}
+
+// Join registers presence on a topic. If the user is already present the call
+// is a no-op (use [Tracker.Update] to change metadata).
+func (t *Tracker) Join(topic string, info Info) {
+	now := time.Now()
+	t.mu.Lock()
+	users := t.topics[topic]
+	if users == nil {
+		users = make(map[string]*Info)
+		t.topics[topic] = users
+	}
+	if _, exists := users[info.UserID]; exists {
+		t.mu.Unlock()
+		return
+	}
+	info.JoinedAt = now
+	info.LastSeen = now
+	// Deep-copy metadata so the caller can't mutate internal state.
+	if info.Metadata != nil {
+		cp := make(map[string]any, len(info.Metadata))
+		for k, v := range info.Metadata {
+			cp[k] = v
+		}
+		info.Metadata = cp
+	}
+	users[info.UserID] = &info
+	snapshot := t.snapshotLocked(topic)
+	t.mu.Unlock()
+
+	if t.cfg.OnJoin != nil {
+		t.cfg.OnJoin(topic, info)
+	}
+	t.publishOOB(topic, snapshot)
+}
+
+// Leave removes presence from a topic.
+func (t *Tracker) Leave(topic, userID string) {
+	t.mu.Lock()
+	users := t.topics[topic]
+	if users == nil {
+		t.mu.Unlock()
+		return
+	}
+	info, ok := users[userID]
+	if !ok {
+		t.mu.Unlock()
+		return
+	}
+	cp := *info
+	delete(users, userID)
+	if len(users) == 0 {
+		delete(t.topics, topic)
+	}
+	snapshot := t.snapshotLocked(topic)
+	t.mu.Unlock()
+
+	if t.cfg.OnLeave != nil {
+		t.cfg.OnLeave(topic, cp)
+	}
+	t.publishOOB(topic, snapshot)
+}
+
+// Update merges partial presence state. Only non-zero fields in metadata are
+// merged — existing keys not present in the update are preserved. Name and
+// Avatar are not changed by Update; use Join for initial values.
+func (t *Tracker) Update(topic, userID string, metadata map[string]any) {
+	t.mu.Lock()
+	users := t.topics[topic]
+	if users == nil {
+		t.mu.Unlock()
+		return
+	}
+	info, ok := users[userID]
+	if !ok {
+		t.mu.Unlock()
+		return
+	}
+	if info.Metadata == nil {
+		info.Metadata = make(map[string]any)
+	}
+	for k, v := range metadata {
+		info.Metadata[k] = v
+	}
+	info.LastSeen = time.Now()
+	cp := *info
+	if info.Metadata != nil {
+		cp.Metadata = make(map[string]any, len(info.Metadata))
+		for k, v := range info.Metadata {
+			cp.Metadata[k] = v
+		}
+	}
+	snapshot := t.snapshotLocked(topic)
+	t.mu.Unlock()
+
+	if t.cfg.OnUpdate != nil {
+		t.cfg.OnUpdate(topic, cp)
+	}
+	t.publishOOB(topic, snapshot)
+}
+
+// Heartbeat refreshes a user's LastSeen time without changing any other state.
+func (t *Tracker) Heartbeat(topic, userID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	users := t.topics[topic]
+	if users == nil {
+		return
+	}
+	if info, ok := users[userID]; ok {
+		info.LastSeen = time.Now()
+	}
+}
+
+// List returns a snapshot of all current presence entries for a topic.
+// The returned slice is a copy and safe to use without synchronization.
+func (t *Tracker) List(topic string) []Info {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.snapshotLocked(topic)
+}
+
+// Get returns a specific user's presence info. The second return value is
+// false if the user is not present on the topic.
+func (t *Tracker) Get(topic, userID string) (Info, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	users := t.topics[topic]
+	if users == nil {
+		return Info{}, false
+	}
+	info, ok := users[userID]
+	if !ok {
+		return Info{}, false
+	}
+	cp := *info
+	if info.Metadata != nil {
+		cp.Metadata = make(map[string]any, len(info.Metadata))
+		for k, v := range info.Metadata {
+			cp.Metadata[k] = v
+		}
+	}
+	return cp, true
+}
+
+// Close stops the stale checker goroutine and cleans up. It is safe to call
+// multiple times.
+func (t *Tracker) Close() {
+	t.once.Do(func() {
+		close(t.done)
+	})
+}
+
+// snapshotLocked returns a copy of all presence entries for a topic. The
+// caller must hold at least a read lock on t.mu.
+func (t *Tracker) snapshotLocked(topic string) []Info {
+	users := t.topics[topic]
+	if len(users) == 0 {
+		return nil
+	}
+	result := make([]Info, 0, len(users))
+	for _, info := range users {
+		cp := *info
+		if info.Metadata != nil {
+			cp.Metadata = make(map[string]any, len(info.Metadata))
+			for k, v := range info.Metadata {
+				cp.Metadata[k] = v
+			}
+		}
+		result = append(result, cp)
+	}
+	return result
+}
+
+// publishOOB publishes presence state as an OOB fragment via the broker.
+// If no RenderFunc is configured this is a no-op.
+func (t *Tracker) publishOOB(topic string, users []Info) {
+	if t.cfg.RenderFunc == nil {
+		return
+	}
+	html := t.cfg.RenderFunc(topic, users)
+	presenceTopic := topic + t.cfg.PresenceTopicSuffix
+	t.broker.PublishOOB(presenceTopic, tavern.Replace(t.cfg.TargetID, html))
+}
+
+// sweepLoop periodically checks for stale presence entries.
+func (t *Tracker) sweepLoop() {
+	interval := t.cfg.StaleTimeout / 2
+	if interval <= 0 {
+		interval = 15 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-t.done:
+			return
+		case <-ticker.C:
+			t.sweep()
+		}
+	}
+}
+
+// sweep removes stale entries from all topics.
+func (t *Tracker) sweep() {
+	now := time.Now()
+	type staleEntry struct {
+		topic    string
+		info     Info
+		snapshot []Info
+	}
+
+	var stale []staleEntry
+
+	t.mu.Lock()
+	for topic, users := range t.topics {
+		for userID, info := range users {
+			if now.Sub(info.LastSeen) > t.cfg.StaleTimeout {
+				cp := *info
+				if info.Metadata != nil {
+					cp.Metadata = make(map[string]any, len(info.Metadata))
+					for k, v := range info.Metadata {
+						cp.Metadata[k] = v
+					}
+				}
+				delete(users, userID)
+				stale = append(stale, staleEntry{topic: topic, info: cp})
+			}
+		}
+		if len(users) == 0 {
+			delete(t.topics, topic)
+		}
+	}
+	// Build snapshots after all removals for accurate state.
+	for i := range stale {
+		stale[i].snapshot = t.snapshotLocked(stale[i].topic)
+	}
+	t.mu.Unlock()
+
+	for _, s := range stale {
+		if t.cfg.OnLeave != nil {
+			t.cfg.OnLeave(s.topic, s.info)
+		}
+		t.publishOOB(s.topic, s.snapshot)
+	}
+}

--- a/presence/presence_test.go
+++ b/presence/presence_test.go
@@ -1,0 +1,510 @@
+package presence
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/catgoose/tavern"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newBroker(t *testing.T) *tavern.SSEBroker {
+	t.Helper()
+	b := tavern.NewSSEBroker()
+	t.Cleanup(b.Close)
+	return b
+}
+
+func TestJoinAndList(t *testing.T) {
+	b := newBroker(t)
+	tr := New(b, Config{StaleTimeout: time.Minute})
+	defer tr.Close()
+
+	tr.Join("room", Info{UserID: "alice", Name: "Alice"})
+	tr.Join("room", Info{UserID: "bob", Name: "Bob"})
+
+	users := tr.List("room")
+	require.Len(t, users, 2)
+
+	ids := map[string]bool{}
+	for _, u := range users {
+		ids[u.UserID] = true
+		assert.False(t, u.JoinedAt.IsZero())
+		assert.False(t, u.LastSeen.IsZero())
+	}
+	assert.True(t, ids["alice"])
+	assert.True(t, ids["bob"])
+}
+
+func TestJoinDuplicateIsNoop(t *testing.T) {
+	b := newBroker(t)
+	tr := New(b, Config{StaleTimeout: time.Minute})
+	defer tr.Close()
+
+	tr.Join("room", Info{UserID: "alice", Name: "Alice"})
+	tr.Join("room", Info{UserID: "alice", Name: "Alice2"})
+
+	users := tr.List("room")
+	require.Len(t, users, 1)
+	assert.Equal(t, "Alice", users[0].Name)
+}
+
+func TestLeave(t *testing.T) {
+	b := newBroker(t)
+	tr := New(b, Config{StaleTimeout: time.Minute})
+	defer tr.Close()
+
+	tr.Join("room", Info{UserID: "alice"})
+	tr.Join("room", Info{UserID: "bob"})
+	tr.Leave("room", "alice")
+
+	users := tr.List("room")
+	require.Len(t, users, 1)
+	assert.Equal(t, "bob", users[0].UserID)
+}
+
+func TestLeaveNonexistent(t *testing.T) {
+	b := newBroker(t)
+	tr := New(b, Config{StaleTimeout: time.Minute})
+	defer tr.Close()
+
+	// Should not panic.
+	tr.Leave("room", "ghost")
+	tr.Join("room", Info{UserID: "alice"})
+	tr.Leave("room", "ghost")
+
+	users := tr.List("room")
+	require.Len(t, users, 1)
+}
+
+func TestGet(t *testing.T) {
+	b := newBroker(t)
+	tr := New(b, Config{StaleTimeout: time.Minute})
+	defer tr.Close()
+
+	tr.Join("room", Info{UserID: "alice", Name: "Alice", Metadata: map[string]any{"role": "admin"}})
+
+	info, ok := tr.Get("room", "alice")
+	require.True(t, ok)
+	assert.Equal(t, "Alice", info.Name)
+	assert.Equal(t, "admin", info.Metadata["role"])
+
+	_, ok = tr.Get("room", "bob")
+	assert.False(t, ok)
+
+	_, ok = tr.Get("other", "alice")
+	assert.False(t, ok)
+}
+
+func TestUpdate(t *testing.T) {
+	b := newBroker(t)
+	tr := New(b, Config{StaleTimeout: time.Minute})
+	defer tr.Close()
+
+	tr.Join("room", Info{
+		UserID:   "alice",
+		Name:     "Alice",
+		Metadata: map[string]any{"cursor": "line:1", "status": "active"},
+	})
+
+	// Partial update: change cursor, leave status alone.
+	tr.Update("room", "alice", map[string]any{"cursor": "line:42"})
+
+	info, ok := tr.Get("room", "alice")
+	require.True(t, ok)
+	assert.Equal(t, "line:42", info.Metadata["cursor"])
+	assert.Equal(t, "active", info.Metadata["status"])
+	assert.Equal(t, "Alice", info.Name, "name should not change on Update")
+}
+
+func TestUpdateNonexistent(t *testing.T) {
+	b := newBroker(t)
+	tr := New(b, Config{StaleTimeout: time.Minute})
+	defer tr.Close()
+
+	// Should not panic.
+	tr.Update("room", "ghost", map[string]any{"x": 1})
+	tr.Join("room", Info{UserID: "alice"})
+	tr.Update("room", "ghost", map[string]any{"x": 1})
+}
+
+func TestUpdateAddsMetadataIfNil(t *testing.T) {
+	b := newBroker(t)
+	tr := New(b, Config{StaleTimeout: time.Minute})
+	defer tr.Close()
+
+	tr.Join("room", Info{UserID: "alice"})
+	tr.Update("room", "alice", map[string]any{"cursor": "line:1"})
+
+	info, ok := tr.Get("room", "alice")
+	require.True(t, ok)
+	assert.Equal(t, "line:1", info.Metadata["cursor"])
+}
+
+func TestHeartbeat(t *testing.T) {
+	b := newBroker(t)
+	tr := New(b, Config{StaleTimeout: time.Minute})
+	defer tr.Close()
+
+	tr.Join("room", Info{UserID: "alice"})
+	before, _ := tr.Get("room", "alice")
+
+	time.Sleep(5 * time.Millisecond)
+	tr.Heartbeat("room", "alice")
+
+	after, _ := tr.Get("room", "alice")
+	assert.True(t, after.LastSeen.After(before.LastSeen))
+}
+
+func TestHeartbeatNonexistent(t *testing.T) {
+	b := newBroker(t)
+	tr := New(b, Config{StaleTimeout: time.Minute})
+	defer tr.Close()
+
+	// Should not panic.
+	tr.Heartbeat("room", "ghost")
+}
+
+func TestStaleDetection(t *testing.T) {
+	b := newBroker(t)
+
+	var mu sync.Mutex
+	var leaves []string
+
+	tr := New(b, Config{
+		StaleTimeout: 50 * time.Millisecond,
+		OnLeave: func(_ string, info Info) {
+			mu.Lock()
+			leaves = append(leaves, info.UserID)
+			mu.Unlock()
+		},
+	})
+	defer tr.Close()
+
+	tr.Join("room", Info{UserID: "alice"})
+	tr.Join("room", Info{UserID: "bob"})
+
+	// Keep bob alive.
+	go func() {
+		for range 10 {
+			time.Sleep(10 * time.Millisecond)
+			tr.Heartbeat("room", "bob")
+		}
+	}()
+
+	// Wait for sweep to fire (interval = StaleTimeout/2 = 25ms).
+	time.Sleep(120 * time.Millisecond)
+
+	mu.Lock()
+	assert.Contains(t, leaves, "alice")
+	assert.NotContains(t, leaves, "bob")
+	mu.Unlock()
+
+	users := tr.List("room")
+	require.Len(t, users, 1)
+	assert.Equal(t, "bob", users[0].UserID)
+}
+
+func TestCallbacks(t *testing.T) {
+	b := newBroker(t)
+
+	var joins, leaves, updates []string
+	var mu sync.Mutex
+
+	tr := New(b, Config{
+		StaleTimeout: time.Minute,
+		OnJoin: func(_ string, info Info) {
+			mu.Lock()
+			joins = append(joins, info.UserID)
+			mu.Unlock()
+		},
+		OnLeave: func(_ string, info Info) {
+			mu.Lock()
+			leaves = append(leaves, info.UserID)
+			mu.Unlock()
+		},
+		OnUpdate: func(_ string, info Info) {
+			mu.Lock()
+			updates = append(updates, info.UserID)
+			mu.Unlock()
+		},
+	})
+	defer tr.Close()
+
+	tr.Join("room", Info{UserID: "alice"})
+	tr.Update("room", "alice", map[string]any{"x": 1})
+	tr.Leave("room", "alice")
+
+	mu.Lock()
+	assert.Equal(t, []string{"alice"}, joins)
+	assert.Equal(t, []string{"alice"}, leaves)
+	assert.Equal(t, []string{"alice"}, updates)
+	mu.Unlock()
+}
+
+func TestOOBPublishing(t *testing.T) {
+	b := newBroker(t)
+
+	// Subscribe to the presence OOB topic to capture publishes.
+	ch, unsub := b.Subscribe("room:presence")
+	defer unsub()
+
+	tr := New(b, Config{
+		StaleTimeout: time.Minute,
+		RenderFunc: func(_ string, users []Info) string {
+			return fmt.Sprintf("<ul>%d users</ul>", len(users))
+		},
+	})
+	defer tr.Close()
+
+	tr.Join("room", Info{UserID: "alice"})
+
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "1 users")
+		assert.Contains(t, msg, "presence-list")
+		assert.Contains(t, msg, "hx-swap-oob")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for OOB message")
+	}
+
+	tr.Join("room", Info{UserID: "bob"})
+
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "2 users")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for OOB message")
+	}
+
+	tr.Leave("room", "alice")
+
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "1 users")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for OOB message")
+	}
+}
+
+func TestOOBNotPublishedWithoutRenderFunc(t *testing.T) {
+	b := newBroker(t)
+
+	ch, unsub := b.Subscribe("room:presence")
+	defer unsub()
+
+	tr := New(b, Config{StaleTimeout: time.Minute})
+	defer tr.Close()
+
+	tr.Join("room", Info{UserID: "alice"})
+	tr.Leave("room", "alice")
+
+	select {
+	case <-ch:
+		t.Fatal("should not receive OOB message without RenderFunc")
+	case <-time.After(50 * time.Millisecond):
+		// Expected.
+	}
+}
+
+func TestCustomTopicSuffixAndTargetID(t *testing.T) {
+	b := newBroker(t)
+
+	ch, unsub := b.Subscribe("room.presence")
+	defer unsub()
+
+	tr := New(b, Config{
+		StaleTimeout:        time.Minute,
+		PresenceTopicSuffix: ".presence",
+		TargetID:            "user-list",
+		RenderFunc: func(_ string, _ []Info) string {
+			return "<div>users</div>"
+		},
+	})
+	defer tr.Close()
+
+	tr.Join("room", Info{UserID: "alice"})
+
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "user-list")
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestOOBOnUpdate(t *testing.T) {
+	b := newBroker(t)
+
+	ch, unsub := b.Subscribe("room:presence")
+	defer unsub()
+
+	tr := New(b, Config{
+		StaleTimeout: time.Minute,
+		RenderFunc: func(_ string, users []Info) string {
+			for _, u := range users {
+				if u.UserID == "alice" {
+					if c, ok := u.Metadata["cursor"]; ok {
+						return fmt.Sprintf("<span>%s</span>", c)
+					}
+				}
+			}
+			return "<span>no cursor</span>"
+		},
+	})
+	defer tr.Close()
+
+	tr.Join("room", Info{UserID: "alice"})
+	<-ch // drain join message
+
+	tr.Update("room", "alice", map[string]any{"cursor": "line:99"})
+
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "line:99")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for update OOB")
+	}
+}
+
+func TestCloseIdempotent(t *testing.T) {
+	b := newBroker(t)
+	tr := New(b, Config{StaleTimeout: time.Minute})
+
+	// Multiple closes should not panic.
+	tr.Close()
+	tr.Close()
+	tr.Close()
+}
+
+func TestCloseStopsSweep(t *testing.T) {
+	b := newBroker(t)
+
+	var leaveCount atomic.Int64
+
+	tr := New(b, Config{
+		StaleTimeout: 20 * time.Millisecond,
+		OnLeave: func(_ string, _ Info) {
+			leaveCount.Add(1)
+		},
+	})
+
+	tr.Join("room", Info{UserID: "alice"})
+	tr.Close()
+
+	// Wait longer than sweep interval.
+	time.Sleep(50 * time.Millisecond)
+
+	// The sweep may or may not have fired before Close — but after Close no
+	// new sweep should start, so the count should be stable.
+	count := leaveCount.Load()
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, count, leaveCount.Load(), "no new sweeps after Close")
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	b := newBroker(t)
+	tr := New(b, Config{StaleTimeout: time.Minute})
+	defer tr.Close()
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+
+	for i := range goroutines {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			uid := fmt.Sprintf("user-%d", id)
+			tr.Join("room", Info{UserID: uid, Name: uid})
+			tr.Heartbeat("room", uid)
+			tr.Update("room", uid, map[string]any{"n": id})
+			tr.List("room")
+			tr.Get("room", uid)
+			tr.Leave("room", uid)
+		}(i)
+	}
+	wg.Wait()
+
+	// All users should have left.
+	assert.Empty(t, tr.List("room"))
+}
+
+func TestMetadataCopyOnJoin(t *testing.T) {
+	b := newBroker(t)
+	tr := New(b, Config{StaleTimeout: time.Minute})
+	defer tr.Close()
+
+	meta := map[string]any{"key": "original"}
+	tr.Join("room", Info{UserID: "alice", Metadata: meta})
+
+	// Mutate the caller's map — should not affect internal state.
+	meta["key"] = "mutated"
+
+	info, ok := tr.Get("room", "alice")
+	require.True(t, ok)
+	assert.Equal(t, "original", info.Metadata["key"])
+}
+
+func TestMetadataCopyOnGet(t *testing.T) {
+	b := newBroker(t)
+	tr := New(b, Config{StaleTimeout: time.Minute})
+	defer tr.Close()
+
+	tr.Join("room", Info{UserID: "alice", Metadata: map[string]any{"key": "value"}})
+
+	info, _ := tr.Get("room", "alice")
+	info.Metadata["key"] = "changed"
+
+	info2, _ := tr.Get("room", "alice")
+	assert.Equal(t, "value", info2.Metadata["key"])
+}
+
+func TestListEmptyTopic(t *testing.T) {
+	b := newBroker(t)
+	tr := New(b, Config{StaleTimeout: time.Minute})
+	defer tr.Close()
+
+	assert.Empty(t, tr.List("nonexistent"))
+}
+
+func TestDefaultConfig(t *testing.T) {
+	b := newBroker(t)
+	tr := New(b, Config{})
+	defer tr.Close()
+
+	assert.Equal(t, DefaultStaleTimeout, tr.cfg.StaleTimeout)
+	assert.Equal(t, DefaultPresenceTopicSuffix, tr.cfg.PresenceTopicSuffix)
+	assert.Equal(t, DefaultTargetID, tr.cfg.TargetID)
+}
+
+func TestStaleDetectionPublishesOOB(t *testing.T) {
+	b := newBroker(t)
+
+	ch, unsub := b.Subscribe("room:presence")
+	defer unsub()
+
+	tr := New(b, Config{
+		StaleTimeout: 30 * time.Millisecond,
+		RenderFunc: func(_ string, users []Info) string {
+			return fmt.Sprintf("<ul>%d</ul>", len(users))
+		},
+	})
+	defer tr.Close()
+
+	tr.Join("room", Info{UserID: "alice"})
+	<-ch // drain join OOB
+
+	// Wait for stale removal.
+	time.Sleep(80 * time.Millisecond)
+
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "<ul>0</ul>")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stale OOB")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `presence/` subpackage with `Tracker` type for per-topic user presence management
- Supports join/leave, partial metadata updates, heartbeat, and automatic stale detection via background goroutine
- Optional OOB publishing via the broker's `PublishOOB` with configurable `RenderFunc`, topic suffix, and target ID
- Thread-safe with comprehensive test coverage (24 tests including race detection, concurrency, stale expiry, OOB publishing, metadata copy safety)

## Test plan
- [x] All 24 presence tests pass with `-race`
- [x] Full `go test ./...` passes
- [x] `golangci-lint run ./...` clean (0 issues)

Closes #79