### PR TITLE
feat: distributed fan-out (pluggable backend)

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -1,0 +1,41 @@
+// Package backend defines the pluggable interface for cross-process fan-out
+// in tavern. Backends transport messages between broker instances so that a
+// publish on one process reaches subscribers connected to another.
+package backend
+
+import "context"
+
+// MessageEnvelope is the unit of data exchanged between broker instances
+// through a Backend.
+type MessageEnvelope struct {
+	// Topic is the pub/sub topic the message belongs to.
+	Topic string `json:"topic"`
+	// Data is the serialised message payload (typically SSE-formatted text).
+	Data string `json:"data"`
+	// Scope restricts delivery to scoped subscribers when non-empty.
+	Scope string `json:"scope,omitempty"`
+}
+
+// Backend is the interface that cross-process fan-out implementations must
+// satisfy. A Backend transports messages between independent broker instances
+// so that a publish on instance A reaches subscribers connected to instance B.
+//
+// Implementations must be safe for concurrent use by multiple goroutines.
+type Backend interface {
+	// Publish sends an envelope to all other instances subscribed to the
+	// same topic. The call should be non-blocking or return quickly.
+	Publish(ctx context.Context, env MessageEnvelope) error
+
+	// Subscribe registers interest in a topic and returns a channel that
+	// receives envelopes published by other instances. The returned channel
+	// is closed when the topic is unsubscribed or the backend is closed.
+	Subscribe(ctx context.Context, topic string) (<-chan MessageEnvelope, error)
+
+	// Unsubscribe removes a previously registered subscription for the
+	// given topic. The channel returned by Subscribe will be closed.
+	Unsubscribe(topic string) error
+
+	// Close shuts down the backend and releases all resources. Any open
+	// subscription channels are closed.
+	Close() error
+}

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -1,0 +1,33 @@
+package backend
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageEnvelopeJSON(t *testing.T) {
+	env := MessageEnvelope{
+		Topic: "orders",
+		Data:  `{"id":1}`,
+		Scope: "user:42",
+	}
+	data, err := json.Marshal(env)
+	require.NoError(t, err)
+
+	var decoded MessageEnvelope
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+	require.Equal(t, env, decoded)
+}
+
+func TestMessageEnvelopeJSON_OmitEmptyScope(t *testing.T) {
+	env := MessageEnvelope{
+		Topic: "orders",
+		Data:  "hello",
+	}
+	data, err := json.Marshal(env)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "scope")
+}

--- a/backend/memory/memory.go
+++ b/backend/memory/memory.go
@@ -1,0 +1,171 @@
+// Package memory provides an in-process Backend implementation for testing
+// and single-instance deployments. Multiple linked backends can be created
+// via Fork to simulate cross-process fan-out within a single process.
+package memory
+
+import (
+	"context"
+	"sync"
+
+	"github.com/catgoose/tavern/backend"
+)
+
+// bus is the shared message transport that links forked backends together.
+type bus struct {
+	mu   sync.RWMutex
+	subs map[string]map[*Backend]chan backend.MessageEnvelope // topic → backend → channel
+}
+
+func newBus() *bus {
+	return &bus{
+		subs: make(map[string]map[*Backend]chan backend.MessageEnvelope),
+	}
+}
+
+// publish fans out env to all backends subscribed to env.Topic except the
+// sender.
+func (b *bus) publish(sender *Backend, env backend.MessageEnvelope) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for be, ch := range b.subs[env.Topic] {
+		if be == sender {
+			continue
+		}
+		select {
+		case ch <- env:
+		default:
+			// drop if the receiver is slow — same as the broker's local fan-out
+		}
+	}
+}
+
+// subscribe registers a backend for the given topic and returns a channel.
+func (b *bus) subscribe(be *Backend, topic string) chan backend.MessageEnvelope {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	ch := make(chan backend.MessageEnvelope, 64)
+	if b.subs[topic] == nil {
+		b.subs[topic] = make(map[*Backend]chan backend.MessageEnvelope)
+	}
+	b.subs[topic][be] = ch
+	return ch
+}
+
+// unsubscribe removes a backend from the given topic and closes its channel.
+func (b *bus) unsubscribe(be *Backend, topic string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if ch, ok := b.subs[topic][be]; ok {
+		close(ch)
+		delete(b.subs[topic], be)
+	}
+}
+
+// removeAll removes all subscriptions for the given backend and closes their
+// channels.
+func (b *bus) removeAll(be *Backend) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for topic, backends := range b.subs {
+		if ch, ok := backends[be]; ok {
+			close(ch)
+			delete(backends, be)
+		}
+		if len(backends) == 0 {
+			delete(b.subs, topic)
+		}
+	}
+}
+
+// Backend is an in-process implementation of [backend.Backend] backed by a
+// shared bus. Use [New] to create one. Call [Backend.Fork] to create a linked
+// instance that shares the same bus — publishes on either instance are visible
+// to subscribers on the other.
+type Backend struct {
+	bus    *bus
+	mu     sync.Mutex
+	subs   map[string]chan backend.MessageEnvelope
+	closed bool
+}
+
+// New creates a new in-process Backend with its own bus.
+func New() *Backend {
+	return &Backend{
+		bus:  newBus(),
+		subs: make(map[string]chan backend.MessageEnvelope),
+	}
+}
+
+// Fork creates a new Backend that shares the same message bus as the
+// receiver. Messages published on any fork are delivered to subscribers on
+// all other forks (but not back to the publisher).
+func (b *Backend) Fork() *Backend {
+	return &Backend{
+		bus:  b.bus,
+		subs: make(map[string]chan backend.MessageEnvelope),
+	}
+}
+
+// Publish sends env to all other backends subscribed to the same topic.
+func (b *Backend) Publish(_ context.Context, env backend.MessageEnvelope) error {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return ErrClosed
+	}
+	b.mu.Unlock()
+	b.bus.publish(b, env)
+	return nil
+}
+
+// Subscribe registers interest in a topic and returns a channel that receives
+// envelopes published by other backends sharing the same bus.
+func (b *Backend) Subscribe(_ context.Context, topic string) (<-chan backend.MessageEnvelope, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return nil, ErrClosed
+	}
+	if _, ok := b.subs[topic]; ok {
+		// Already subscribed — return existing channel.
+		return b.subs[topic], nil
+	}
+	ch := b.bus.subscribe(b, topic)
+	b.subs[topic] = ch
+	return ch, nil
+}
+
+// Unsubscribe removes the subscription for the given topic.
+func (b *Backend) Unsubscribe(topic string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return ErrClosed
+	}
+	if _, ok := b.subs[topic]; !ok {
+		return nil
+	}
+	delete(b.subs, topic)
+	b.bus.unsubscribe(b, topic)
+	return nil
+}
+
+// Close shuts down the backend and closes all subscription channels.
+func (b *Backend) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return nil
+	}
+	b.closed = true
+	b.bus.removeAll(b)
+	b.subs = nil
+	return nil
+}
+
+// ErrClosed is returned when an operation is attempted on a closed backend.
+var ErrClosed = errClosed{}
+
+type errClosed struct{}
+
+func (errClosed) Error() string { return "memory backend: closed" }

--- a/backend/memory/memory_test.go
+++ b/backend/memory/memory_test.go
@@ -1,0 +1,180 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/catgoose/tavern/backend"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishReachesFork(t *testing.T) {
+	b1 := New()
+	b2 := b1.Fork()
+	defer b1.Close()
+	defer b2.Close()
+
+	ctx := context.Background()
+	ch, err := b2.Subscribe(ctx, "orders")
+	require.NoError(t, err)
+
+	env := backend.MessageEnvelope{Topic: "orders", Data: "new-order"}
+	require.NoError(t, b1.Publish(ctx, env))
+
+	select {
+	case got := <-ch:
+		require.Equal(t, env, got)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+}
+
+func TestPublishDoesNotEcho(t *testing.T) {
+	b1 := New()
+	defer b1.Close()
+
+	ctx := context.Background()
+	ch, err := b1.Subscribe(ctx, "orders")
+	require.NoError(t, err)
+
+	env := backend.MessageEnvelope{Topic: "orders", Data: "self"}
+	require.NoError(t, b1.Publish(ctx, env))
+
+	select {
+	case <-ch:
+		t.Fatal("message should not echo back to sender")
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+}
+
+func TestBidirectional(t *testing.T) {
+	b1 := New()
+	b2 := b1.Fork()
+	defer b1.Close()
+	defer b2.Close()
+
+	ctx := context.Background()
+	ch1, err := b1.Subscribe(ctx, "chat")
+	require.NoError(t, err)
+	ch2, err := b2.Subscribe(ctx, "chat")
+	require.NoError(t, err)
+
+	// b1 → b2
+	require.NoError(t, b1.Publish(ctx, backend.MessageEnvelope{Topic: "chat", Data: "hello"}))
+	select {
+	case got := <-ch2:
+		require.Equal(t, "hello", got.Data)
+	case <-time.After(time.Second):
+		t.Fatal("b2 did not receive message from b1")
+	}
+
+	// b2 → b1
+	require.NoError(t, b2.Publish(ctx, backend.MessageEnvelope{Topic: "chat", Data: "world"}))
+	select {
+	case got := <-ch1:
+		require.Equal(t, "world", got.Data)
+	case <-time.After(time.Second):
+		t.Fatal("b1 did not receive message from b2")
+	}
+}
+
+func TestUnsubscribe(t *testing.T) {
+	b1 := New()
+	b2 := b1.Fork()
+	defer b1.Close()
+	defer b2.Close()
+
+	ctx := context.Background()
+	ch, err := b2.Subscribe(ctx, "orders")
+	require.NoError(t, err)
+
+	require.NoError(t, b2.Unsubscribe("orders"))
+
+	// Channel should be closed after unsubscribe.
+	_, open := <-ch
+	require.False(t, open)
+}
+
+func TestCloseClosesChannels(t *testing.T) {
+	b1 := New()
+	b2 := b1.Fork()
+
+	ctx := context.Background()
+	ch, err := b2.Subscribe(ctx, "orders")
+	require.NoError(t, err)
+
+	require.NoError(t, b2.Close())
+	_, open := <-ch
+	require.False(t, open)
+
+	// Operations on closed backend return ErrClosed.
+	require.ErrorIs(t, b2.Publish(ctx, backend.MessageEnvelope{}), ErrClosed)
+	_, err = b2.Subscribe(ctx, "orders")
+	require.ErrorIs(t, err, ErrClosed)
+	require.ErrorIs(t, b2.Unsubscribe("orders"), ErrClosed)
+
+	b1.Close()
+}
+
+func TestSubscribeIdempotent(t *testing.T) {
+	b := New()
+	defer b.Close()
+
+	ctx := context.Background()
+	ch1, err := b.Subscribe(ctx, "t")
+	require.NoError(t, err)
+	ch2, err := b.Subscribe(ctx, "t")
+	require.NoError(t, err)
+
+	// Same channel returned for duplicate subscribe.
+	require.Equal(t, ch1, ch2)
+}
+
+func TestScopedEnvelope(t *testing.T) {
+	b1 := New()
+	b2 := b1.Fork()
+	defer b1.Close()
+	defer b2.Close()
+
+	ctx := context.Background()
+	ch, err := b2.Subscribe(ctx, "orders")
+	require.NoError(t, err)
+
+	env := backend.MessageEnvelope{Topic: "orders", Data: "scoped", Scope: "user:42"}
+	require.NoError(t, b1.Publish(ctx, env))
+
+	select {
+	case got := <-ch:
+		require.Equal(t, "user:42", got.Scope)
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestMultipleForks(t *testing.T) {
+	b1 := New()
+	b2 := b1.Fork()
+	b3 := b1.Fork()
+	defer b1.Close()
+	defer b2.Close()
+	defer b3.Close()
+
+	ctx := context.Background()
+	ch2, err := b2.Subscribe(ctx, "x")
+	require.NoError(t, err)
+	ch3, err := b3.Subscribe(ctx, "x")
+	require.NoError(t, err)
+
+	require.NoError(t, b1.Publish(ctx, backend.MessageEnvelope{Topic: "x", Data: "fan"}))
+
+	for _, ch := range []<-chan backend.MessageEnvelope{ch2, ch3} {
+		select {
+		case got := <-ch:
+			require.Equal(t, "fan", got.Data)
+		case <-time.After(time.Second):
+			t.Fatal("timed out")
+		}
+	}
+}

--- a/backend_integration.go
+++ b/backend_integration.go
@@ -1,0 +1,131 @@
+package tavern
+
+import (
+	"context"
+
+	"github.com/catgoose/tavern/backend"
+)
+
+// WithBackend configures the broker to use a cross-process fan-out backend.
+// When set, every Publish also forwards the message to the backend, and the
+// broker automatically subscribes to the backend when the first local
+// subscriber joins a topic and unsubscribes when the last local subscriber
+// leaves.
+//
+// Messages arriving from the backend are dispatched directly to local
+// subscriber channels — they skip middleware and After hooks to avoid
+// duplicate side-effects across instances.
+func WithBackend(b backend.Backend) BrokerOption {
+	return func(br *SSEBroker) {
+		br.backend = b
+	}
+}
+
+// initBackend is a no-op placeholder called from NewSSEBroker. The actual
+// integration happens inline: Subscribe/Unsubscribe call
+// backendSubscribe/backendUnsubscribe when the first/last subscriber
+// joins/leaves, and the Publish methods call backendPublish after local
+// fan-out.
+func (b *SSEBroker) initBackend() {}
+
+// backendSubscribe registers the broker with the backend for the given topic
+// and starts a goroutine that forwards incoming envelopes to local
+// subscribers. It is called when the first local subscriber joins a topic
+// and a backend is configured.
+func (b *SSEBroker) backendSubscribe(topic string) {
+	if b.backend == nil {
+		return
+	}
+	ch, err := b.backend.Subscribe(context.Background(), topic)
+	if err != nil {
+		if b.logger != nil {
+			b.logger.Error("backend subscribe failed", "topic", topic, "err", err)
+		}
+		return
+	}
+	go b.backendFanIn(topic, ch)
+}
+
+// backendUnsubscribe removes the broker's subscription from the backend for
+// the given topic. It is called when the last local subscriber leaves a topic
+// and a backend is configured.
+func (b *SSEBroker) backendUnsubscribe(topic string) {
+	if b.backend == nil {
+		return
+	}
+	if err := b.backend.Unsubscribe(topic); err != nil {
+		if b.logger != nil {
+			b.logger.Error("backend unsubscribe failed", "topic", topic, "err", err)
+		}
+	}
+}
+
+// backendPublish forwards a message to the backend for cross-instance
+// delivery. Scoped messages include the scope in the envelope.
+func (b *SSEBroker) backendPublish(topic, msg, scope string) {
+	if b.backend == nil {
+		return
+	}
+	env := backend.MessageEnvelope{
+		Topic: topic,
+		Data:  msg,
+		Scope: scope,
+	}
+	if err := b.backend.Publish(context.Background(), env); err != nil {
+		if b.logger != nil {
+			b.logger.Error("backend publish failed", "topic", topic, "err", err)
+		}
+	}
+}
+
+// backendFanIn reads envelopes from the backend channel and dispatches them
+// directly to local subscribers. Messages skip middleware and After hooks
+// because the originating instance already applied those.
+func (b *SSEBroker) backendFanIn(topic string, ch <-chan backend.MessageEnvelope) {
+	for env := range ch {
+		if env.Scope != "" {
+			b.dispatchScoped(env.Topic, env.Scope, env.Data)
+		} else {
+			b.dispatchDirect(env.Topic, env.Data)
+		}
+	}
+}
+
+// dispatchDirect sends msg to all unscoped subscribers of the topic without
+// applying middleware or firing After hooks. Used for messages arriving from
+// the backend.
+func (b *SSEBroker) dispatchDirect(topic, msg string) {
+	b.mu.RLock()
+	subscribers, exists := b.topics[topic]
+	if !exists || len(subscribers) == 0 {
+		b.mu.RUnlock()
+		return
+	}
+	channels := make([]chan string, 0, len(subscribers))
+	for ch := range subscribers {
+		channels = append(channels, ch)
+	}
+	b.mu.RUnlock()
+	b.publishToChannels(topic, channels, msg)
+}
+
+// dispatchScoped sends msg to scoped subscribers matching the given scope
+// without applying middleware or firing After hooks.
+func (b *SSEBroker) dispatchScoped(topic, scope, msg string) {
+	b.mu.RLock()
+	scopedSubs, exists := b.scopedTopics[topic]
+	if !exists || len(scopedSubs) == 0 {
+		b.mu.RUnlock()
+		return
+	}
+	channels := make([]chan string, 0, len(scopedSubs))
+	for ch, sub := range scopedSubs {
+		if sub.scope == scope {
+			channels = append(channels, ch)
+		}
+	}
+	b.mu.RUnlock()
+	if len(channels) > 0 {
+		b.publishToChannels(topic, channels, msg)
+	}
+}

--- a/backend_integration_test.go
+++ b/backend_integration_test.go
@@ -1,0 +1,115 @@
+package tavern
+
+import (
+	"testing"
+	"time"
+
+	"github.com/catgoose/tavern/backend/memory"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackendCrossInstancePublish(t *testing.T) {
+	mem := memory.New()
+	defer mem.Close()
+
+	b1 := NewSSEBroker(WithBackend(mem))
+	b2 := NewSSEBroker(WithBackend(mem.Fork()))
+	defer b1.Close()
+	defer b2.Close()
+
+	// Subscribe on b2.
+	ch, unsub := b2.Subscribe("orders")
+	defer unsub()
+
+	// Give the backend fan-in goroutine a moment to start.
+	time.Sleep(20 * time.Millisecond)
+
+	// Publish on b1 — should reach b2's subscriber.
+	b1.Publish("orders", "order-1")
+
+	select {
+	case got := <-ch:
+		require.Equal(t, "order-1", got)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for cross-instance message")
+	}
+}
+
+func TestBackendScopedCrossInstance(t *testing.T) {
+	mem := memory.New()
+	defer mem.Close()
+
+	b1 := NewSSEBroker(WithBackend(mem))
+	b2 := NewSSEBroker(WithBackend(mem.Fork()))
+	defer b1.Close()
+	defer b2.Close()
+
+	ch, unsub := b2.SubscribeScoped("orders", "user:42")
+	defer unsub()
+
+	time.Sleep(20 * time.Millisecond)
+
+	b1.PublishTo("orders", "user:42", "scoped-msg")
+
+	select {
+	case got := <-ch:
+		require.Equal(t, "scoped-msg", got)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for scoped cross-instance message")
+	}
+}
+
+func TestBackendLocalPublishStillWorks(t *testing.T) {
+	mem := memory.New()
+	defer mem.Close()
+
+	b := NewSSEBroker(WithBackend(mem))
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("orders")
+	defer unsub()
+
+	b.Publish("orders", "local")
+
+	select {
+	case got := <-ch:
+		require.Equal(t, "local", got)
+	case <-time.After(time.Second):
+		t.Fatal("local message not received")
+	}
+}
+
+func TestBackendUnsubscribeOnLastLeave(t *testing.T) {
+	mem := memory.New()
+	defer mem.Close()
+
+	b := NewSSEBroker(WithBackend(mem))
+	defer b.Close()
+
+	_, unsub := b.Subscribe("orders")
+	unsub()
+
+	// After unsubscribe, the backend subscription for the topic should be
+	// cleaned up. Publishing should not panic or block.
+	b2 := NewSSEBroker(WithBackend(mem.Fork()))
+	defer b2.Close()
+	b2.Publish("orders", "after-unsub")
+	// No assertion needed — just verify no deadlock or panic.
+}
+
+func TestBackendNilDoesNotPanic(t *testing.T) {
+	b := NewSSEBroker() // no backend
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("orders")
+	defer unsub()
+
+	b.Publish("orders", "hello")
+
+	select {
+	case got := <-ch:
+		require.Equal(t, "hello", got)
+	case <-time.After(time.Second):
+		t.Fatal("message not received")
+	}
+}

--- a/broker.go
+++ b/broker.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/catgoose/tavern/backend"
 )
 
 // SSEBroker is a thread-safe, topic-based pub/sub message broker. Subscribers
@@ -73,6 +75,7 @@ type SSEBroker struct {
 	multiSubs         map[string]*multiSub             // subscriberID → managed multi-subscription
 	globSubs          []*globSub                       // glob/wildcard subscriptions
 	globMu            sync.RWMutex                     // protects globSubs
+	backend           backend.Backend                  // nil = no cross-process fan-out
 }
 
 // Topic name constants are conventions for common real-time use cases.
@@ -218,6 +221,7 @@ func NewSSEBroker(opts ...BrokerOption) *SSEBroker {
 	if b.topicTTL > 0 {
 		go b.startTopicSweep()
 	}
+	b.initBackend()
 	return b
 }
 
@@ -264,9 +268,13 @@ func (b *SSEBroker) Subscribe(topic string) (msgs <-chan string, unsubscribe fun
 	}
 	replayMsgs := append([]string(nil), b.replayCache[topic]...)
 	delete(b.topicEmpty, topic)
+	hasBackend := b.backend != nil
 	b.mu.Unlock()
 	for _, fn := range firstHooks {
 		go fn(topic)
+	}
+	if hasBackend && total == 1 {
+		b.backendSubscribe(topic)
 	}
 	b.publishConnectionEvent("subscribe", topic, total)
 	for _, msg := range replayMsgs {
@@ -279,6 +287,7 @@ func (b *SSEBroker) Subscribe(topic string) (msgs <-chan string, unsubscribe fun
 	return ch, func() {
 		b.mu.Lock()
 		var lastHooks []func(string)
+		var isLast bool
 		if _, ok := b.topics[topic][ch]; ok {
 			delete(b.topics[topic], ch)
 			delete(b.subscriberMeta, ch)
@@ -286,6 +295,7 @@ func (b *SSEBroker) Subscribe(topic string) (msgs <-chan string, unsubscribe fun
 			close(ch)
 			total := len(b.topics[topic]) + len(b.scopedTopics[topic])
 			if total == 0 {
+				isLast = true
 				lastHooks = b.onLast[topic]
 				b.topicEmpty[topic] = time.Now()
 			}
@@ -304,6 +314,9 @@ func (b *SSEBroker) Subscribe(topic string) (msgs <-chan string, unsubscribe fun
 		}
 		for _, fn := range lastHooks {
 			go fn(topic)
+		}
+		if hasBackend && isLast {
+			b.backendUnsubscribe(topic)
 		}
 		b.publishConnectionEvent("unsubscribe", topic, -1)
 	}
@@ -346,10 +359,14 @@ func (b *SSEBroker) SubscribeScoped(topic, scope string) (msgs <-chan string, un
 		b.adaptive.getState(ch) // pre-create state
 	}
 	replayMsgs := append([]string(nil), b.replayCache[topic]...)
+	hasBackendScoped := b.backend != nil
 	delete(b.topicEmpty, topic)
 	b.mu.Unlock()
 	for _, fn := range firstHooks {
 		go fn(topic)
+	}
+	if hasBackendScoped && total == 1 {
+		b.backendSubscribe(topic)
 	}
 	b.publishConnectionEvent("subscribe", topic, total)
 	for _, msg := range replayMsgs {
@@ -362,6 +379,7 @@ func (b *SSEBroker) SubscribeScoped(topic, scope string) (msgs <-chan string, un
 	return ch, func() {
 		b.mu.Lock()
 		var lastHooks []func(string)
+		var isLastScoped bool
 		if _, ok := b.scopedTopics[topic][ch]; ok {
 			delete(b.scopedTopics[topic], ch)
 			delete(b.subscriberMeta, ch)
@@ -369,6 +387,7 @@ func (b *SSEBroker) SubscribeScoped(topic, scope string) (msgs <-chan string, un
 			close(ch)
 			total := len(b.topics[topic]) + len(b.scopedTopics[topic])
 			if total == 0 {
+				isLastScoped = true
 				lastHooks = b.onLast[topic]
 				b.topicEmpty[topic] = time.Now()
 			}
@@ -387,6 +406,9 @@ func (b *SSEBroker) SubscribeScoped(topic, scope string) (msgs <-chan string, un
 		}
 		for _, fn := range lastHooks {
 			go fn(topic)
+		}
+		if hasBackendScoped && isLastScoped {
+			b.backendUnsubscribe(topic)
 		}
 		b.publishConnectionEvent("unsubscribe", topic, -1)
 	}
@@ -775,6 +797,7 @@ func (b *SSEBroker) publishDirect(topic, msg string) {
 		b.obs.recordPublishLatency(topic, now.Sub(start))
 		b.obs.recordThroughput(topic, now)
 	}
+	b.backendPublish(topic, msg, "")
 	b.fireAfterHooks(topic)
 }
 
@@ -830,6 +853,7 @@ func (b *SSEBroker) publishWithReplayDirect(topic, msg string) {
 		b.obs.recordPublishLatency(topic, now.Sub(start))
 		b.obs.recordThroughput(topic, now)
 	}
+	b.backendPublish(topic, msg, "")
 	b.fireAfterHooks(topic)
 }
 
@@ -912,6 +936,7 @@ func (b *SSEBroker) publishToDirect(topic, scope, msg string) {
 		b.obs.recordPublishLatency(topic, now.Sub(start))
 		b.obs.recordThroughput(topic, now)
 	}
+	b.backendPublish(topic, msg, scope)
 	b.fireAfterHooks(topic)
 }
 
@@ -1172,6 +1197,9 @@ func (b *SSEBroker) Close() {
 	}
 	b.throttle.mu.Unlock()
 	b.rateLimit.stop()
+	if b.backend != nil {
+		b.backend.Close() //nolint:errcheck // best-effort cleanup
+	}
 }
 
 // startTopicSweep periodically removes topics that have had zero subscribers


### PR DESCRIPTION
## Summary

- Adds `backend/` subpackage with a `Backend` interface (`Publish`, `Subscribe`, `Unsubscribe`, `Close`) and `MessageEnvelope` type for cross-process fan-out
- Adds `backend/memory/` in-process implementation with `Fork()` for creating linked backends that share a message bus (useful for testing)
- Integrates backend into `SSEBroker` via `WithBackend(b)` option: publishes forward to backend after local fan-out, auto-subscribes on first local subscriber, auto-unsubscribes on last leave
- Messages arriving from the backend dispatch directly to local subscribers, skipping middleware and After hooks to avoid duplicate side-effects

## Test plan

- [x] `backend/` package: MessageEnvelope JSON serialization tests
- [x] `backend/memory/`: publish reaches fork, no echo to sender, bidirectional, unsubscribe closes channel, close cleans up, multiple forks, scoped envelopes
- [x] Integration tests: cross-instance publish, scoped cross-instance, local publish still works, unsubscribe cleanup, nil backend no-panic
- [x] All existing tests pass (`go test ./...`)
- [x] Lint clean (`golangci-lint run ./...`)

Closes #89