### PR TITLE
fix: critical gaps in backend dispatch, group resumption, panic recovery

### DIFF
--- a/backend_integration.go
+++ b/backend_integration.go
@@ -99,6 +99,7 @@ func (b *SSEBroker) dispatchDirect(topic, msg string) {
 	subscribers, exists := b.topics[topic]
 	if !exists || len(subscribers) == 0 {
 		b.mu.RUnlock()
+		b.dispatchToGlobSubscribers(topic, "", msg)
 		return
 	}
 	channels := make([]chan string, 0, len(subscribers))
@@ -107,6 +108,7 @@ func (b *SSEBroker) dispatchDirect(topic, msg string) {
 	}
 	b.mu.RUnlock()
 	b.publishToChannels(topic, channels, msg)
+	b.dispatchToGlobSubscribers(topic, "", msg)
 }
 
 // dispatchScoped sends msg to scoped subscribers matching the given scope
@@ -116,6 +118,7 @@ func (b *SSEBroker) dispatchScoped(topic, scope, msg string) {
 	scopedSubs, exists := b.scopedTopics[topic]
 	if !exists || len(scopedSubs) == 0 {
 		b.mu.RUnlock()
+		b.dispatchToGlobSubscribers(topic, scope, msg)
 		return
 	}
 	channels := make([]chan string, 0, len(scopedSubs))
@@ -128,4 +131,5 @@ func (b *SSEBroker) dispatchScoped(topic, scope, msg string) {
 	if len(channels) > 0 {
 		b.publishToChannels(topic, channels, msg)
 	}
+	b.dispatchToGlobSubscribers(topic, scope, msg)
 }

--- a/backend_integration_test.go
+++ b/backend_integration_test.go
@@ -113,3 +113,148 @@ func TestBackendNilDoesNotPanic(t *testing.T) {
 		t.Fatal("message not received")
 	}
 }
+
+func TestBackendGlobSubscribers(t *testing.T) {
+	mem := memory.New()
+	defer mem.Close()
+
+	b1 := NewSSEBroker(WithBackend(mem))
+	b2 := NewSSEBroker(WithBackend(mem.Fork()))
+	defer b1.Close()
+	defer b2.Close()
+
+	// Subscribe a regular subscriber on b2 to trigger backend subscription.
+	_, regularUnsub := b2.Subscribe("orders")
+	defer regularUnsub()
+
+	// Subscribe a glob subscriber on b2.
+	globCh, globUnsub := b2.SubscribeGlob("orders")
+	defer globUnsub()
+
+	time.Sleep(20 * time.Millisecond)
+
+	// Publish on b1 — should reach b2's glob subscriber.
+	b1.Publish("orders", "glob-msg")
+
+	select {
+	case got := <-globCh:
+		require.Equal(t, "orders", got.Topic)
+		require.Equal(t, "glob-msg", got.Data)
+	case <-time.After(time.Second):
+		t.Fatal("glob subscriber did not receive cross-instance message")
+	}
+}
+
+func TestBackendScopedGlobSubscribers(t *testing.T) {
+	mem := memory.New()
+	defer mem.Close()
+
+	b1 := NewSSEBroker(WithBackend(mem))
+	b2 := NewSSEBroker(WithBackend(mem.Fork()))
+	defer b1.Close()
+	defer b2.Close()
+
+	// Subscribe a regular scoped subscriber on b2 to trigger backend subscription.
+	_, regularUnsub := b2.SubscribeScoped("orders", "user:42")
+	defer regularUnsub()
+
+	// Subscribe a scoped glob subscriber on b2.
+	globCh, globUnsub := b2.SubscribeGlobScoped("orders", "user:42")
+	defer globUnsub()
+
+	time.Sleep(20 * time.Millisecond)
+
+	// Scoped publish on b1 — should reach b2's scoped glob subscriber.
+	b1.PublishTo("orders", "user:42", "scoped-glob-msg")
+
+	select {
+	case got := <-globCh:
+		require.Equal(t, "orders", got.Topic)
+		require.Equal(t, "scoped-glob-msg", got.Data)
+	case <-time.After(time.Second):
+		t.Fatal("scoped glob subscriber did not receive cross-instance message")
+	}
+}
+
+func TestBackendFilteredSubscribers(t *testing.T) {
+	mem := memory.New()
+	defer mem.Close()
+
+	b1 := NewSSEBroker(WithBackend(mem))
+	b2 := NewSSEBroker(WithBackend(mem.Fork()))
+	defer b1.Close()
+	defer b2.Close()
+
+	// A regular subscriber triggers the backend subscription for this topic.
+	_, triggerUnsub := b2.Subscribe("orders")
+	defer triggerUnsub()
+
+	// Filtered subscriber on b2 that only accepts messages containing "important".
+	ch, unsub := b2.SubscribeWithFilter("orders", func(msg string) bool {
+		return msg == "important"
+	})
+	defer unsub()
+
+	time.Sleep(20 * time.Millisecond)
+
+	// Publish messages on b1.
+	b1.Publish("orders", "boring")
+	b1.Publish("orders", "important")
+
+	select {
+	case got := <-ch:
+		require.Equal(t, "important", got)
+	case <-time.After(time.Second):
+		t.Fatal("filtered subscriber did not receive matching cross-instance message")
+	}
+
+	// Verify "boring" was not delivered.
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected message: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+		// expected: no more messages
+	}
+}
+
+func TestBackendFilteredScopedSubscribers(t *testing.T) {
+	mem := memory.New()
+	defer mem.Close()
+
+	b1 := NewSSEBroker(WithBackend(mem))
+	b2 := NewSSEBroker(WithBackend(mem.Fork()))
+	defer b1.Close()
+	defer b2.Close()
+
+	// A regular scoped subscriber triggers the backend subscription.
+	_, triggerUnsub := b2.SubscribeScoped("orders", "user:42")
+	defer triggerUnsub()
+
+	// Filtered scoped subscriber on b2.
+	ch, unsub := b2.SubscribeScopedWithFilter("orders", "user:42", func(msg string) bool {
+		return msg == "match"
+	})
+	defer unsub()
+
+	time.Sleep(20 * time.Millisecond)
+
+	// Publish messages on b1.
+	b1.PublishTo("orders", "user:42", "nomatch")
+	b1.PublishTo("orders", "user:42", "match")
+	b1.PublishTo("orders", "user:99", "match") // wrong scope
+
+	select {
+	case got := <-ch:
+		require.Equal(t, "match", got)
+	case <-time.After(time.Second):
+		t.Fatal("filtered scoped subscriber did not receive matching message")
+	}
+
+	// Verify no extra messages.
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected message: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+}

--- a/broker.go
+++ b/broker.go
@@ -76,6 +76,7 @@ type SSEBroker struct {
 	globSubs          []*globSub                       // glob/wildcard subscriptions
 	globMu            sync.RWMutex                     // protects globSubs
 	backend           backend.Backend                  // nil = no cross-process fan-out
+	afterHookSem      chan struct{}                     // semaphore limiting concurrent After hook goroutines
 }
 
 // Topic name constants are conventions for common real-time use cases.
@@ -208,6 +209,7 @@ func NewSSEBroker(opts ...BrokerOption) *SSEBroker {
 	for _, opt := range opts {
 		opt(b)
 	}
+	b.afterHookSem = make(chan struct{}, defaultAfterHookConcurrency)
 	initGroupFields(b)
 	b.debounce.timers = make(map[string]*debounceEntry)
 	b.throttle.state = make(map[string]*throttleEntry)

--- a/group.go
+++ b/group.go
@@ -3,6 +3,7 @@ package tavern
 import (
 	"fmt"
 	"net/http"
+	"sync"
 )
 
 // groupDef is a static topic group definition.
@@ -122,13 +123,29 @@ func (h *dynamicGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 // serveGroupSSE is the shared streaming loop for static and dynamic group
 // handlers. It subscribes to all topics via SubscribeMulti and writes each
-// message as an SSE event with the topic as the event type.
+// message as an SSE event with the topic as the event type. When the request
+// includes a Last-Event-ID header, cached messages after that ID are replayed
+// for each topic before the live stream begins.
 func serveGroupSSE(w http.ResponseWriter, r *http.Request, broker *SSEBroker, topics []string, writer SSEWriterFunc) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 
-	ch, unsub := broker.SubscribeMulti(topics...)
+	lastID := r.Header.Get("Last-Event-ID")
+
+	var ch <-chan TopicMessage
+	var unsub func()
+
+	if lastID != "" {
+		// When Last-Event-ID is present, use subscribeMultiFromID to replay
+		// only messages after the given ID from each topic's replay log.
+		ch, unsub = broker.subscribeMultiFromID(topics, lastID, writer, w)
+		if ch == nil {
+			return // writer error during replay
+		}
+	} else {
+		ch, unsub = broker.SubscribeMulti(topics...)
+	}
 	defer unsub()
 
 	for {
@@ -144,6 +161,104 @@ func serveGroupSSE(w http.ResponseWriter, r *http.Request, broker *SSEBroker, to
 		case <-r.Context().Done():
 			return // client disconnected
 		}
+	}
+}
+
+// subscribeMultiFromID subscribes to multiple topics using SubscribeFromID for
+// each topic (with the same lastEventID), then replays the missed messages
+// formatted as SSE events via the writer. It returns a merged channel and
+// unsubscribe function like SubscribeMulti. If a write error occurs during
+// replay, it returns nil for the channel.
+func (b *SSEBroker) subscribeMultiFromID(topics []string, lastEventID string, writer SSEWriterFunc, w http.ResponseWriter) (msgs <-chan TopicMessage, unsubscribe func()) {
+	out := make(chan TopicMessage, b.bufferSize)
+	unsubs := make([]func(), 0, len(topics))
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Collect per-topic channels via SubscribeFromID.
+	perTopic := make([]<-chan string, len(topics))
+	for i, topic := range topics {
+		ch, unsub := b.SubscribeFromID(topic, lastEventID)
+		unsubs = append(unsubs, unsub)
+		perTopic[i] = ch
+	}
+
+	// Drain replay messages from each per-topic channel and write them
+	// directly as SSE events. These are the messages that SubscribeFromID
+	// buffered during subscribe.
+	for i, topic := range topics {
+		ch := perTopic[i]
+	drainTopic:
+		for {
+			select {
+			case msg, ok := <-ch:
+				if !ok {
+					break drainTopic
+				}
+				sseMsg := NewSSEMessage(topic, msg).String()
+				if err := writer(w, sseMsg); err != nil {
+					// Clean up on write error.
+					for _, unsub := range unsubs {
+						unsub()
+					}
+					close(out)
+					return nil, func() {}
+				}
+			default:
+				break drainTopic
+			}
+		}
+	}
+
+	// Start fan-in goroutines for live messages.
+	for i, topic := range topics {
+		ch := perTopic[i]
+		t := topic
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case msg, ok := <-ch:
+					if !ok {
+						return
+					}
+					select {
+					case out <- TopicMessage{Topic: t, Data: msg}:
+					case <-done:
+						return
+					}
+				case <-done:
+					return
+				}
+			}
+		}()
+	}
+
+	var closeOnce sync.Once
+	closeOut := func() {
+		closeOnce.Do(func() { close(out) })
+	}
+
+	var unsubOnce sync.Once
+	doUnsub := func() {
+		unsubOnce.Do(func() {
+			close(done)
+			for _, unsub := range unsubs {
+				unsub()
+			}
+		})
+	}
+
+	go func() {
+		wg.Wait()
+		closeOut()
+	}()
+
+	return out, func() {
+		doUnsub()
+		wg.Wait()
+		closeOut()
 	}
 }
 

--- a/group_test.go
+++ b/group_test.go
@@ -496,6 +496,83 @@ func TestGroupHandler_MultilineData(t *testing.T) {
 	assert.Contains(t, body, "data: line2\n")
 }
 
+func TestGroupHandlerLastEventID(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("metrics", 10)
+	b.SetReplayPolicy("alerts", 10)
+	b.PublishWithID("metrics", "1", "m1")
+	b.PublishWithID("metrics", "2", "m2")
+	b.PublishWithID("alerts", "1", "a1")
+	b.PublishWithID("alerts", "2", "a2")
+
+	b.DefineGroup("dash", []string{"metrics", "alerts"})
+	handler := b.GroupHandler("dash")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/dash", http.NoBody)
+	req.Header.Set("Last-Event-ID", "1") // replay after ID "1"
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+	// Should replay m2 and a2 (after ID "1"), but not m1 or a1.
+	assert.Contains(t, body, "m2")
+	assert.Contains(t, body, "a2")
+	assert.NotContains(t, body, "data: m1\n")
+	assert.NotContains(t, body, "data: a1\n")
+}
+
+func TestDynamicGroupHandlerLastEventID(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("x", 10)
+	b.SetReplayPolicy("y", 10)
+	b.PublishWithID("x", "a", "x1")
+	b.PublishWithID("x", "b", "x2")
+	b.PublishWithID("y", "a", "y1")
+	b.PublishWithID("y", "b", "y2")
+
+	b.DynamicGroup("dyn", func(_ *http.Request) []string {
+		return []string{"x", "y"}
+	})
+	handler := b.DynamicGroupHandler("dyn")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/dyn", http.NoBody)
+	req.Header.Set("Last-Event-ID", "a") // replay after ID "a"
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "x2")
+	assert.Contains(t, body, "y2")
+	assert.NotContains(t, body, "data: x1\n")
+	assert.NotContains(t, body, "data: y1\n")
+}
+
 // collectTopics drains n topic names from ch within the given timeout.
 func collectTopics(t *testing.T, ch <-chan string, n int, timeout time.Duration) []string {
 	t.Helper()

--- a/hooks.go
+++ b/hooks.go
@@ -9,6 +9,10 @@ import (
 // infinite cycles (e.g., After A publishes to B, After B publishes to A).
 const maxAfterDepth = 8
 
+// defaultAfterHookConcurrency is the default limit for concurrent After hook
+// goroutines. When the semaphore is full, hooks run synchronously.
+const defaultAfterHookConcurrency = 64
+
 // afterChain tracks the nesting depth and visited topics within a single
 // After hook execution chain.
 type afterChain struct {
@@ -139,8 +143,9 @@ func (b *SSEBroker) fireAfterHooks(topic string) {
 		return
 	}
 
-	// Top-level publish — fire hooks asynchronously in a new goroutine.
-	go func() {
+	// Top-level publish — fire hooks asynchronously in a new goroutine if the
+	// semaphore has capacity, otherwise run synchronously to avoid dropping hooks.
+	run := func() {
 		chain = &afterChain{
 			depth: 1,
 			seen:  map[string]struct{}{topic: {}},
@@ -152,6 +157,18 @@ func (b *SSEBroker) fireAfterHooks(topic string) {
 		for _, fn := range fns {
 			fn()
 		}
-	}()
+	}
+
+	select {
+	case b.afterHookSem <- struct{}{}:
+		// Acquired semaphore slot — run in a new goroutine.
+		go func() {
+			defer func() { <-b.afterHookSem }()
+			run()
+		}()
+	default:
+		// Semaphore full — run synchronously to avoid dropping the hook.
+		run()
+	}
 }
 

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -550,6 +550,104 @@ func TestAfterHookConcurrentPublish(t *testing.T) {
 	}, time.Second, 10*time.Millisecond, "each publish should trigger its After hook")
 }
 
+func TestAfterHooksConcurrencyLimit(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(200))
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("topic")
+	defer unsub()
+
+	var concurrent atomic.Int32
+	var peak atomic.Int32
+	var total atomic.Int32
+	allDone := make(chan struct{})
+
+	const numPublishes = 200
+	b.After("topic", func() {
+		cur := concurrent.Add(1)
+		for {
+			old := peak.Load()
+			if cur <= old || peak.CompareAndSwap(old, cur) {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond) // slow hook
+		concurrent.Add(-1)
+		if total.Add(1) == numPublishes {
+			close(allDone)
+		}
+	})
+
+	for range numPublishes {
+		b.Publish("topic", "msg")
+	}
+
+	// Drain messages.
+	for range numPublishes {
+		select {
+		case <-ch:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out draining messages")
+		}
+	}
+
+	select {
+	case <-allDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for all hooks to complete")
+	}
+
+	assert.Equal(t, int32(numPublishes), total.Load(), "all hooks should have executed")
+	// The semaphore allows defaultAfterHookConcurrency goroutines, plus
+	// the synchronous fallback can run one hook in the caller's goroutine,
+	// so the peak may be up to semaphore+1.
+	assert.LessOrEqual(t, peak.Load(), int32(defaultAfterHookConcurrency+1),
+		"peak concurrent hooks should not significantly exceed semaphore limit")
+}
+
+func TestAfterHooksSynchronousFallback(t *testing.T) {
+	// Create a broker with a tiny semaphore to force synchronous fallback.
+	b := NewSSEBroker(WithBufferSize(100))
+	b.afterHookSem = make(chan struct{}, 1) // override to tiny semaphore
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("topic")
+	defer unsub()
+
+	var total atomic.Int32
+	const numPublishes = 20
+
+	allDone := make(chan struct{})
+	b.After("topic", func() {
+		time.Sleep(5 * time.Millisecond)
+		if total.Add(1) == numPublishes {
+			close(allDone)
+		}
+	})
+
+	for range numPublishes {
+		b.Publish("topic", "msg")
+	}
+
+	// Drain messages.
+	for range numPublishes {
+		select {
+		case <-ch:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out draining messages")
+		}
+	}
+
+	select {
+	case <-allDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for hooks — synchronous fallback may not be executing")
+	}
+
+	assert.Equal(t, int32(numPublishes), total.Load(),
+		"all hooks should execute even when semaphore is full (synchronous fallback)")
+}
+
 func TestGoroutineID(t *testing.T) {
 	id := goroutineID()
 	assert.NotZero(t, id)

--- a/middleware.go
+++ b/middleware.go
@@ -1,6 +1,9 @@
 package tavern
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // PublishFunc is the function signature for publish operations.
 // Middleware wraps this to intercept, transform, or swallow publishes.
@@ -75,6 +78,20 @@ func (b *SSEBroker) applyMiddleware(topic string, base PublishFunc) PublishFunc 
 	}
 	for i := len(globals) - 1; i >= 0; i-- {
 		fn = globals[i](fn)
+	}
+
+	// Wrap the outermost middleware call with panic recovery so a panicking
+	// middleware does not crash the process.
+	wrapped := fn
+	fn = func(topic, msg string) {
+		defer func() {
+			if r := recover(); r != nil {
+				if b.logger != nil {
+					b.logger.Error("middleware panic recovered", "topic", topic, "panic", fmt.Sprint(r))
+				}
+			}
+		}()
+		wrapped(topic, msg)
 	}
 	return fn
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -483,6 +483,66 @@ func TestMiddlewareTopicSwallow(t *testing.T) {
 	}
 }
 
+func TestMiddlewarePanicRecovery(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.Use(func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			if msg == "boom" {
+				panic("middleware panic")
+			}
+			next(topic, msg)
+		}
+	})
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	// This should not crash.
+	b.Publish("t", "boom")
+
+	// Subsequent publishes should still work.
+	b.Publish("t", "ok")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "ok", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for message after panic recovery")
+	}
+}
+
+func TestTopicMiddlewarePanicRecovery(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.UseTopics("t", func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			if msg == "boom" {
+				panic("topic middleware panic")
+			}
+			next(topic, msg)
+		}
+	})
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	// Should not crash.
+	b.Publish("t", "boom")
+
+	// Subsequent publishes should still work.
+	b.Publish("t", "ok")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "ok", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for message after topic middleware panic recovery")
+	}
+}
+
 func TestMiddlewareMultipleTopicPatterns(t *testing.T) {
 	b := NewSSEBroker()
 	defer b.Close()

--- a/oob.go
+++ b/oob.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 )
 
 // Component renders itself to a writer. This interface is intentionally
@@ -142,8 +143,22 @@ func (b *SSEBroker) PublishLazyOOB(topic string, renderFn func() []Fragment) {
 	if !b.HasSubscribers(topic) {
 		return
 	}
-	fragments := renderFn()
-	if len(fragments) == 0 {
+	var fragments []Fragment
+	panicked := true
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				b.fireRenderError(&RenderError{
+					Topic:     topic,
+					Err:       fmt.Errorf("lazy render panic: %v", r),
+					Timestamp: time.Now(),
+				})
+			}
+		}()
+		fragments = renderFn()
+		panicked = false
+	}()
+	if panicked || len(fragments) == 0 {
 		return
 	}
 	b.PublishOOB(topic, fragments...)
@@ -158,8 +173,22 @@ func (b *SSEBroker) PublishLazyIfChangedOOB(topic string, renderFn func() []Frag
 	if !b.HasSubscribers(topic) {
 		return false
 	}
-	fragments := renderFn()
-	if len(fragments) == 0 {
+	var fragments []Fragment
+	panicked := true
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				b.fireRenderError(&RenderError{
+					Topic:     topic,
+					Err:       fmt.Errorf("lazy render panic: %v", r),
+					Timestamp: time.Now(),
+				})
+			}
+		}()
+		fragments = renderFn()
+		panicked = false
+	}()
+	if panicked || len(fragments) == 0 {
 		return false
 	}
 	return b.PublishIfChangedOOB(topic, fragments...)
@@ -171,8 +200,22 @@ func (b *SSEBroker) PublishLazyOOBTo(topic, scope string, renderFn func() []Frag
 	if !b.HasSubscribers(topic) {
 		return
 	}
-	fragments := renderFn()
-	if len(fragments) == 0 {
+	var fragments []Fragment
+	panicked := true
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				b.fireRenderError(&RenderError{
+					Topic:     topic,
+					Err:       fmt.Errorf("lazy render panic: %v", r),
+					Timestamp: time.Now(),
+				})
+			}
+		}()
+		fragments = renderFn()
+		panicked = false
+	}()
+	if panicked || len(fragments) == 0 {
 		return
 	}
 	b.PublishOOBTo(topic, scope, fragments...)
@@ -185,8 +228,22 @@ func (b *SSEBroker) PublishLazyIfChangedOOBTo(topic, scope string, renderFn func
 	if !b.HasSubscribers(topic) {
 		return false
 	}
-	fragments := renderFn()
-	if len(fragments) == 0 {
+	var fragments []Fragment
+	panicked := true
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				b.fireRenderError(&RenderError{
+					Topic:     topic,
+					Err:       fmt.Errorf("lazy render panic: %v", r),
+					Timestamp: time.Now(),
+				})
+			}
+		}()
+		fragments = renderFn()
+		panicked = false
+	}()
+	if panicked || len(fragments) == 0 {
 		return false
 	}
 	return b.PublishIfChangedOOBTo(topic, scope, fragments...)

--- a/oob_test.go
+++ b/oob_test.go
@@ -329,6 +329,67 @@ func TestPublishLazyIfChangedOOBTo_ScopedDedup(t *testing.T) {
 	assert.False(t, ok2)
 }
 
+func TestPublishLazyOOBPanicRecovery(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	// Should not crash when renderFn panics.
+	b.PublishLazyOOB("t", func() []Fragment {
+		panic("render exploded")
+	})
+
+	// No message should be published.
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected message after panic: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+
+	// Broker should still be functional.
+	b.Publish("t", "after-panic")
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "after-panic", msg)
+	case <-time.After(time.Second):
+		t.Fatal("broker not functional after lazy render panic")
+	}
+}
+
+func TestPublishLazyOOBPanicFiresOnRenderError(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	var gotErr *RenderError
+	b.OnRenderError(func(re *RenderError) {
+		gotErr = re
+	})
+
+	b.PublishLazyOOB("t", func() []Fragment {
+		panic("kaboom")
+	})
+
+	// Give the synchronous callback time to fire (it runs in the same goroutine).
+	time.Sleep(20 * time.Millisecond)
+
+	assert.NotNil(t, gotErr, "OnRenderError should have been called")
+	assert.Equal(t, "t", gotErr.Topic)
+	assert.Contains(t, gotErr.Err.Error(), "kaboom")
+
+	// No message should have been sent.
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected message: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
 func TestRenderComponentError_EscapesComment(t *testing.T) {
 	// An error message containing --> must not break out of the HTML comment.
 	// escapeAttr replaces > with &gt;, turning --> into --&gt; inside the comment body.


### PR DESCRIPTION
## Summary

- **Backend glob subscribers**: `dispatchDirect` and `dispatchScoped` now call `dispatchToGlobSubscribers` so backend messages reach glob/wildcard subscribers
- **Backend filter predicates**: Already handled by `publishToChannels` which checks `filterPredicate`; added tests to verify cross-instance filtered delivery
- **Group handler Last-Event-ID**: `GroupHandler` and `DynamicGroupHandler` now replay cached messages after the given Last-Event-ID before starting the live stream, using `SubscribeFromID` per-topic
- **Middleware panic recovery**: `applyMiddleware` wraps the outermost chain call with `defer/recover`, logging panics via the broker logger
- **Lazy OOB panic recovery**: `PublishLazyOOB` and all lazy variants wrap `renderFn` with `defer/recover` and fire `OnRenderError` on panic
- **After hook concurrency limit**: `fireAfterHooks` uses a buffered channel semaphore (capacity 64) to bound goroutines; when full, hooks run synchronously

## Test plan

- [x] `TestBackendGlobSubscribers` -- glob subscriber on broker2 receives messages published on broker1
- [x] `TestBackendScopedGlobSubscribers` -- scoped glob subscriber across backends
- [x] `TestBackendFilteredSubscribers` -- filtered subscriber only gets matching messages cross-instance
- [x] `TestBackendFilteredScopedSubscribers` -- combined filter + scope across backends
- [x] `TestGroupHandlerLastEventID` -- replay after Last-Event-ID for static groups
- [x] `TestDynamicGroupHandlerLastEventID` -- replay after Last-Event-ID for dynamic groups
- [x] `TestMiddlewarePanicRecovery` -- panicking middleware doesn't crash, subsequent publishes work
- [x] `TestTopicMiddlewarePanicRecovery` -- same for topic-scoped middleware
- [x] `TestPublishLazyOOBPanicRecovery` -- panicking render function doesn't crash
- [x] `TestPublishLazyOOBPanicFiresOnRenderError` -- OnRenderError fires on lazy render panic
- [x] `TestAfterHooksConcurrencyLimit` -- peak goroutines bounded by semaphore
- [x] `TestAfterHooksSynchronousFallback` -- hooks execute synchronously when semaphore full
- [x] All tests pass: `go test -race ./...`
- [x] Lint passes: `golangci-lint run ./...`