### PR TITLE
feat: message coalescing (#115)

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -77,6 +77,7 @@ type SSEBroker struct {
 	globMu            sync.RWMutex                     // protects globSubs
 	backend           backend.Backend                  // nil = no cross-process fan-out
 	afterHookSem      chan struct{}                     // semaphore limiting concurrent After hook goroutines
+	coalescingChans   map[chan string]*coalescingState  // channel → coalescing state (nil = normal delivery)
 }
 
 // Topic name constants are conventions for common real-time use cases.
@@ -608,6 +609,13 @@ func (b *SSEBroker) publishToChannels(topic string, channels []chan string, msg 
 			// Check filter predicate — non-matching messages are silently
 			// skipped without counting toward drops or backpressure.
 			if pred := b.filterPredicate(ch); pred != nil && !pred(msg) {
+				return
+			}
+
+			// Coalescing: store latest value atomically and signal the
+			// reader goroutine. Replaced messages do not count as drops.
+			if b.coalesceStore(ch, msg) {
+				sent++
 				return
 			}
 
@@ -1147,6 +1155,7 @@ func (b *SSEBroker) Close() {
 	b.lastHash = nil
 	b.subscriberMeta = nil
 	b.filterPredicates = nil
+	b.coalescingChans = nil
 	b.multiSubs = nil
 	b.onReplayGap = nil
 	b.replayGapStrategy = nil

--- a/coalesce.go
+++ b/coalesce.go
@@ -1,0 +1,194 @@
+package tavern
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// coalescingState holds the atomic pointer and signal channel used by a
+// coalescing subscriber. Instead of buffering every published message, only
+// the latest value is kept; the reader goroutine delivers it when signaled.
+type coalescingState struct {
+	latest atomic.Pointer[string]
+	signal chan struct{} // buffered 1
+}
+
+// SubscribeWithCoalescing registers a subscriber that automatically coalesces
+// rapid updates. When multiple messages are published before the subscriber
+// reads, only the latest value is delivered. This is ideal for high-frequency
+// data like stock tickers or sensor readings where intermediate values are
+// irrelevant.
+//
+// Replaced (coalesced) messages do not count as drops in [SSEBroker.PublishDrops].
+//
+// The returned channel receives the latest message whenever a new value is
+// available. Call the returned function to unsubscribe and close the channel.
+func (b *SSEBroker) SubscribeWithCoalescing(topic string) (msgs <-chan string, unsubscribe func()) {
+	return b.subscribeCoalescing(topic, "")
+}
+
+// SubscribeScopedWithCoalescing registers a scoped coalescing subscriber.
+// Only messages published via [SSEBroker.PublishTo] with a matching scope are
+// delivered, and rapid updates are coalesced to the latest value.
+func (b *SSEBroker) SubscribeScopedWithCoalescing(topic, scope string) (msgs <-chan string, unsubscribe func()) {
+	return b.subscribeCoalescing(topic, scope)
+}
+
+func (b *SSEBroker) subscribeCoalescing(topic, scope string) (msgs <-chan string, unsubscribe func()) {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		ch := make(chan string)
+		close(ch)
+		return ch, func() {}
+	}
+
+	// The internal channel participates in the normal fan-out path but is
+	// intercepted by publishToChannels when coalescing is enabled.
+	internalCh := make(chan string, b.bufferSize)
+	cs := &coalescingState{
+		signal: make(chan struct{}, 1),
+	}
+
+	if scope == "" {
+		if b.topics[topic] == nil {
+			b.topics[topic] = make(map[chan string]struct{})
+		}
+		b.topics[topic][internalCh] = struct{}{}
+	} else {
+		if b.scopedTopics[topic] == nil {
+			b.scopedTopics[topic] = make(map[chan string]scopedSub)
+		}
+		b.scopedTopics[topic][internalCh] = scopedSub{scope: scope}
+	}
+
+	b.subscriberMeta[internalCh] = &SubscriberInfo{Topic: topic, Scope: scope, ConnectedAt: time.Now()}
+
+	if b.coalescingChans == nil {
+		b.coalescingChans = make(map[chan string]*coalescingState)
+	}
+	b.coalescingChans[internalCh] = cs
+
+	total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+	var firstHooks []func(string)
+	if total == 1 {
+		firstHooks = b.onFirst[topic]
+	}
+	if b.metrics != nil {
+		if total > b.metrics.peakSubs[topic] {
+			b.metrics.peakSubs[topic] = total
+		}
+	}
+	hasBackend := b.backend != nil
+	delete(b.topicEmpty, topic)
+	b.mu.Unlock()
+
+	for _, fn := range firstHooks {
+		go fn(topic)
+	}
+	if hasBackend && total == 1 {
+		b.backendSubscribe(topic)
+	}
+	b.publishConnectionEvent("subscribe", topic, total)
+
+	// The public channel is fed by a goroutine that reads signals and loads
+	// the latest value from the atomic pointer.
+	out := make(chan string, 1)
+	done := make(chan struct{})
+
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case <-cs.signal:
+				ptr := cs.latest.Load()
+				if ptr == nil {
+					continue
+				}
+				select {
+				case out <- *ptr:
+				case <-done:
+					return
+				}
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	var once sync.Once
+	connectedAt := time.Now()
+
+	return out, func() {
+		once.Do(func() {
+			close(done)
+
+			b.mu.Lock()
+			var lastHooks []func(string)
+			var isLast bool
+
+			if scope == "" {
+				if _, ok := b.topics[topic][internalCh]; ok {
+					delete(b.topics[topic], internalCh)
+					total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+					if total == 0 {
+						isLast = true
+						lastHooks = b.onLast[topic]
+						b.topicEmpty[topic] = time.Now()
+					}
+				}
+			} else {
+				if _, ok := b.scopedTopics[topic][internalCh]; ok {
+					delete(b.scopedTopics[topic], internalCh)
+					total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+					if total == 0 {
+						isLast = true
+						lastHooks = b.onLast[topic]
+						b.topicEmpty[topic] = time.Now()
+					}
+				}
+			}
+			delete(b.subscriberMeta, internalCh)
+			delete(b.filterPredicates, internalCh)
+			delete(b.coalescingChans, internalCh)
+			close(internalCh)
+			b.mu.Unlock()
+
+			if b.evictThreshold > 0 || b.adaptive != nil {
+				b.dropCountsMu.Lock()
+				delete(b.dropCounts, internalCh)
+				b.dropCountsMu.Unlock()
+			}
+			if b.obs != nil {
+				b.obs.recordConnectionDuration(topic, time.Since(connectedAt))
+			}
+			for _, fn := range lastHooks {
+				go fn(topic)
+			}
+			if hasBackend && isLast {
+				b.backendUnsubscribe(topic)
+			}
+			b.publishConnectionEvent("unsubscribe", topic, -1)
+		})
+	}
+}
+
+// coalesceStore atomically stores the message for a coalescing channel and
+// signals the reader goroutine. Returns true if the channel is coalescing
+// (message was stored), false otherwise.
+func (b *SSEBroker) coalesceStore(ch chan string, msg string) bool {
+	b.mu.RLock()
+	cs, ok := b.coalescingChans[ch]
+	b.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	cs.latest.Store(&msg)
+	select {
+	case cs.signal <- struct{}{}:
+	default:
+		// Already signaled — reader will pick up the latest value.
+	}
+	return true
+}

--- a/coalesce_test.go
+++ b/coalesce_test.go
@@ -1,0 +1,194 @@
+package tavern
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubscribeWithCoalescing_BasicCoalescing(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(1))
+	defer b.Close()
+
+	ch, unsub := b.SubscribeWithCoalescing("prices")
+	defer unsub()
+
+	// Publish several messages rapidly — only the latest should be delivered.
+	for i := 0; i < 100; i++ {
+		b.Publish("prices", fmt.Sprintf("price:%d", i))
+	}
+
+	// Give the coalescing goroutine time to deliver.
+	time.Sleep(50 * time.Millisecond)
+
+	// Drain and collect what we got.
+	var received []string
+	timeout := time.After(200 * time.Millisecond)
+	for {
+		select {
+		case msg := <-ch:
+			received = append(received, msg)
+		case <-timeout:
+			goto done
+		}
+	}
+done:
+
+	// We should have received at least one message, and the last one should
+	// be from the later publishes. We should NOT have received all 100.
+	require.NotEmpty(t, received, "should receive at least one message")
+	assert.Less(t, len(received), 100, "coalescing should discard intermediate values")
+
+	// The final received message should be a high-numbered price.
+	last := received[len(received)-1]
+	assert.True(t, strings.HasPrefix(last, "price:"), "message should be a price update")
+}
+
+func TestSubscribeScopedWithCoalescing(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeScopedWithCoalescing("data", "user:1")
+	defer unsub()
+
+	// Publish to matching scope.
+	b.PublishTo("data", "user:1", "v1")
+	b.PublishTo("data", "user:1", "v2")
+	b.PublishTo("data", "user:1", "v3")
+
+	// Publish to non-matching scope — should not be delivered.
+	b.PublishTo("data", "user:2", "other")
+
+	time.Sleep(50 * time.Millisecond)
+
+	var received []string
+	timeout := time.After(200 * time.Millisecond)
+	for {
+		select {
+		case msg := <-ch:
+			received = append(received, msg)
+		case <-timeout:
+			goto done
+		}
+	}
+done:
+
+	require.NotEmpty(t, received)
+	for _, msg := range received {
+		assert.NotEqual(t, "other", msg, "should not receive messages from other scope")
+	}
+}
+
+func TestSubscribeWithCoalescing_NoDropCounting(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(1))
+	defer b.Close()
+
+	ch, unsub := b.SubscribeWithCoalescing("prices")
+	defer unsub()
+
+	// Publish many messages rapidly.
+	for i := 0; i < 50; i++ {
+		b.Publish("prices", fmt.Sprintf("msg:%d", i))
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Drain channel.
+	timeout := time.After(100 * time.Millisecond)
+	for {
+		select {
+		case <-ch:
+		case <-timeout:
+			goto done
+		}
+	}
+done:
+
+	// Coalesced messages should NOT count as drops.
+	assert.Equal(t, int64(0), b.PublishDrops(), "coalesced messages must not count as drops")
+}
+
+func TestSubscribeWithCoalescing_SSEHandler(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	handler := b.SSEHandler("prices")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// Give the SSE handler time to subscribe.
+	time.Sleep(50 * time.Millisecond)
+
+	ch, unsub := b.SubscribeWithCoalescing("prices")
+	defer unsub()
+
+	b.Publish("prices", "data: hello\n\n")
+
+	time.Sleep(50 * time.Millisecond)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "data: hello\n\n", msg)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting for coalesced message")
+	}
+
+	stats := b.Stats()
+	assert.GreaterOrEqual(t, stats.Subscribers, 1)
+}
+
+func TestSubscribeWithCoalescing_Unsubscribe(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeWithCoalescing("prices")
+	unsub()
+	unsub() // double unsubscribe should be safe
+
+	assert.Equal(t, 0, b.SubscriberCount())
+}
+
+func TestSubscribeWithCoalescing_CoexistsWithSSEHandler(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	handler := b.SSEHandler("events")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", server.URL, http.NoBody)
+	require.NoError(t, err)
+
+	go func() {
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			resp.Body.Close()
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	ch, unsub := b.SubscribeWithCoalescing("events")
+	defer unsub()
+
+	b.Publish("events", "data: test\n\n")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "data: test\n\n", msg)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting for coalesced message")
+	}
+
+	cancel()
+}


### PR DESCRIPTION
## Summary
- Add `SubscribeWithCoalescing` and `SubscribeScopedWithCoalescing` methods using atomic pointers and signal channels
- Coalesced (replaced) messages do not count as drops in `PublishDrops`
- Integrates into existing `publishToChannels` fan-out path via `coalescingChans` map on `SSEBroker`

## Test plan
- [x] Basic coalescing: stale values discarded under rapid publish
- [x] Scoped coalescing: only matching scope delivered
- [x] No drop counting for coalesced messages
- [x] Coexists with SSEHandler subscribers
- [x] Unsubscribe cleanup (including double-unsub safety)

Closes #115