### PR TITLE
feat: connection admission control (#116)

### DIFF
--- a/admission.go
+++ b/admission.go
@@ -1,0 +1,61 @@
+package tavern
+
+// WithMaxSubscribers sets a global limit on the total number of concurrent
+// subscribers across all topics. When the limit is reached, new Subscribe
+// calls return a nil channel and nil unsubscribe function, and SSEHandler
+// returns HTTP 503 Service Unavailable.
+func WithMaxSubscribers(n int) BrokerOption {
+	return func(b *SSEBroker) {
+		b.maxSubs = n
+	}
+}
+
+// WithMaxSubscribersPerTopic sets a per-topic limit on the number of
+// concurrent subscribers. When the limit for a topic is reached, new
+// Subscribe calls for that topic return a nil channel and nil unsubscribe
+// function, and SSEHandler returns HTTP 503.
+func WithMaxSubscribersPerTopic(n int) BrokerOption {
+	return func(b *SSEBroker) {
+		b.maxSubsPerTopic = n
+	}
+}
+
+// WithAdmissionControl sets a custom admission function that is called for
+// every new subscription attempt. The function receives the topic name and
+// the current total subscriber count for that topic. It should return true
+// to allow the subscription or false to deny it.
+func WithAdmissionControl(fn func(topic string, currentCount int) bool) BrokerOption {
+	return func(b *SSEBroker) {
+		b.admissionFn = fn
+	}
+}
+
+// admitSubscriber checks all admission constraints under the caller's lock.
+// Returns true if the subscription should be allowed.
+func (b *SSEBroker) admitSubscriber(topic string) bool {
+	if b.maxSubs > 0 {
+		total := 0
+		for _, subs := range b.topics {
+			total += len(subs)
+		}
+		for _, subs := range b.scopedTopics {
+			total += len(subs)
+		}
+		if total >= b.maxSubs {
+			return false
+		}
+	}
+	if b.maxSubsPerTopic > 0 {
+		topicCount := len(b.topics[topic]) + len(b.scopedTopics[topic])
+		if topicCount >= b.maxSubsPerTopic {
+			return false
+		}
+	}
+	if b.admissionFn != nil {
+		topicCount := len(b.topics[topic]) + len(b.scopedTopics[topic])
+		if !b.admissionFn(topic, topicCount) {
+			return false
+		}
+	}
+	return true
+}

--- a/admission_test.go
+++ b/admission_test.go
@@ -1,0 +1,170 @@
+package tavern
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithMaxSubscribers_GlobalLimit(t *testing.T) {
+	b := NewSSEBroker(WithMaxSubscribers(2))
+	defer b.Close()
+
+	ch1, unsub1 := b.Subscribe("a")
+	require.NotNil(t, ch1)
+	defer unsub1()
+
+	ch2, unsub2 := b.Subscribe("b")
+	require.NotNil(t, ch2)
+	defer unsub2()
+
+	// Third subscriber should be denied.
+	ch3, unsub3 := b.Subscribe("c")
+	assert.Nil(t, ch3)
+	assert.Nil(t, unsub3)
+
+	// After unsubscribing one, a new subscriber should be allowed.
+	unsub1()
+	ch4, unsub4 := b.Subscribe("c")
+	require.NotNil(t, ch4)
+	unsub4()
+}
+
+func TestWithMaxSubscribersPerTopic(t *testing.T) {
+	b := NewSSEBroker(WithMaxSubscribersPerTopic(2))
+	defer b.Close()
+
+	ch1, unsub1 := b.Subscribe("topic")
+	require.NotNil(t, ch1)
+	defer unsub1()
+
+	ch2, unsub2 := b.SubscribeScoped("topic", "scope1")
+	require.NotNil(t, ch2)
+	defer unsub2()
+
+	// Third subscriber on same topic should be denied.
+	ch3, unsub3 := b.Subscribe("topic")
+	assert.Nil(t, ch3)
+	assert.Nil(t, unsub3)
+
+	// Different topic should be fine.
+	ch4, unsub4 := b.Subscribe("other-topic")
+	require.NotNil(t, ch4)
+	unsub4()
+}
+
+func TestWithAdmissionControl_CustomCallback(t *testing.T) {
+	denied := false
+	b := NewSSEBroker(WithAdmissionControl(func(topic string, currentCount int) bool {
+		if topic == "vip" && currentCount >= 1 {
+			denied = true
+			return false
+		}
+		return true
+	}))
+	defer b.Close()
+
+	ch1, unsub1 := b.Subscribe("vip")
+	require.NotNil(t, ch1)
+	defer unsub1()
+
+	// Second subscriber to "vip" should be denied by custom fn.
+	ch2, unsub2 := b.Subscribe("vip")
+	assert.Nil(t, ch2)
+	assert.Nil(t, unsub2)
+	assert.True(t, denied)
+
+	// Other topics should be fine.
+	ch3, unsub3 := b.Subscribe("public")
+	require.NotNil(t, ch3)
+	unsub3()
+}
+
+func TestAdmissionControl_SSEHandler503(t *testing.T) {
+	b := NewSSEBroker(WithMaxSubscribers(0), WithMaxSubscribersPerTopic(1))
+	defer b.Close()
+
+	// Fill the topic limit.
+	ch, unsub := b.Subscribe("events")
+	require.NotNil(t, ch)
+	defer unsub()
+
+	handler := b.SSEHandler("events")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+func TestAdmissionControl_ConcurrentBoundary(t *testing.T) {
+	const limit = 5
+	b := NewSSEBroker(WithMaxSubscribers(limit))
+	defer b.Close()
+
+	var mu sync.Mutex
+	var successes int
+	var failures int
+	var unsubs []func()
+
+	var wg sync.WaitGroup
+	// Try to create limit+5 subscribers concurrently.
+	for i := 0; i < limit+5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ch, unsub := b.Subscribe("topic")
+			mu.Lock()
+			if ch != nil {
+				successes++
+				unsubs = append(unsubs, unsub)
+			} else {
+				failures++
+			}
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, limit, successes, "exactly %d subscribers should be admitted", limit)
+	assert.Equal(t, 5, failures, "excess subscribers should be denied")
+
+	for _, unsub := range unsubs {
+		unsub()
+	}
+}
+
+func TestAdmissionControl_ScopedSubscribers(t *testing.T) {
+	b := NewSSEBroker(WithMaxSubscribersPerTopic(1))
+	defer b.Close()
+
+	ch1, unsub1 := b.SubscribeScoped("topic", "a")
+	require.NotNil(t, ch1)
+	defer unsub1()
+
+	// Second scoped subscriber should be denied.
+	ch2, unsub2 := b.SubscribeScoped("topic", "b")
+	assert.Nil(t, ch2)
+	assert.Nil(t, unsub2)
+}
+
+func TestAdmissionControl_FilterSubscribers(t *testing.T) {
+	b := NewSSEBroker(WithMaxSubscribers(1))
+	defer b.Close()
+
+	ch1, unsub1 := b.SubscribeWithFilter("topic", func(msg string) bool { return true })
+	require.NotNil(t, ch1)
+	defer unsub1()
+
+	// Second subscriber should be denied.
+	ch2, unsub2 := b.Subscribe("other")
+	assert.Nil(t, ch2)
+	assert.Nil(t, unsub2)
+}

--- a/broker.go
+++ b/broker.go
@@ -78,6 +78,9 @@ type SSEBroker struct {
 	backend           backend.Backend                  // nil = no cross-process fan-out
 	afterHookSem      chan struct{}                     // semaphore limiting concurrent After hook goroutines
 	coalescingChans   map[chan string]*coalescingState  // channel → coalescing state (nil = normal delivery)
+	maxSubs           int                              // 0 = unlimited global subscribers
+	maxSubsPerTopic   int                              // 0 = unlimited per-topic subscribers
+	admissionFn       func(topic string, currentCount int) bool // nil = no custom admission
 }
 
 // Topic name constants are conventions for common real-time use cases.
@@ -245,6 +248,10 @@ func (b *SSEBroker) Subscribe(topic string) (msgs <-chan string, unsubscribe fun
 		close(ch)
 		return ch, func() {}
 	}
+	if !b.admitSubscriber(topic) {
+		b.mu.Unlock()
+		return nil, nil
+	}
 	ch := make(chan string, b.bufferSize)
 	if b.topics[topic] == nil {
 		b.topics[topic] = make(map[chan string]struct{})
@@ -336,6 +343,10 @@ func (b *SSEBroker) SubscribeScoped(topic, scope string) (msgs <-chan string, un
 		ch := make(chan string)
 		close(ch)
 		return ch, func() {}
+	}
+	if !b.admitSubscriber(topic) {
+		b.mu.Unlock()
+		return nil, nil
 	}
 	ch := make(chan string, b.bufferSize)
 	if b.scopedTopics[topic] == nil {

--- a/coalesce.go
+++ b/coalesce.go
@@ -43,6 +43,10 @@ func (b *SSEBroker) subscribeCoalescing(topic, scope string) (msgs <-chan string
 		close(ch)
 		return ch, func() {}
 	}
+	if !b.admitSubscriber(topic) {
+		b.mu.Unlock()
+		return nil, nil
+	}
 
 	// The internal channel participates in the normal fan-out path but is
 	// intercepted by publishToChannels when coalescing is enabled.

--- a/filter.go
+++ b/filter.go
@@ -23,6 +23,10 @@ func (b *SSEBroker) SubscribeWithFilter(topic string, predicate FilterPredicate)
 		close(ch)
 		return ch, func() {}
 	}
+	if !b.admitSubscriber(topic) {
+		b.mu.Unlock()
+		return nil, nil
+	}
 	ch := make(chan string, b.bufferSize)
 	if b.topics[topic] == nil {
 		b.topics[topic] = make(map[chan string]struct{})
@@ -78,6 +82,10 @@ func (b *SSEBroker) SubscribeScopedWithFilter(topic, scope string, predicate Fil
 		ch := make(chan string)
 		close(ch)
 		return ch, func() {}
+	}
+	if !b.admitSubscriber(topic) {
+		b.mu.Unlock()
+		return nil, nil
 	}
 	ch := make(chan string, b.bufferSize)
 	if b.scopedTopics[topic] == nil {

--- a/handler.go
+++ b/handler.go
@@ -80,6 +80,10 @@ func (h *sseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Subscribe with Last-Event-ID resumption.
 	lastID := r.Header.Get("Last-Event-ID")
 	ch, unsub := h.broker.SubscribeFromID(h.topic, lastID)
+	if ch == nil {
+		http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+		return
+	}
 	defer unsub()
 
 	// Stream loop.

--- a/resume.go
+++ b/resume.go
@@ -77,6 +77,10 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 		close(ch)
 		return ch, func() {}
 	}
+	if !b.admitSubscriber(topic) {
+		b.mu.Unlock()
+		return nil, nil
+	}
 	ch := make(chan string, b.bufferSize)
 	if b.topics[topic] == nil {
 		b.topics[topic] = make(map[chan string]struct{})

--- a/snapshot.go
+++ b/snapshot.go
@@ -21,6 +21,10 @@ func (b *SSEBroker) SubscribeWithSnapshot(topic string, snapshotFn func() string
 		close(ch)
 		return ch, func() {}
 	}
+	if !b.admitSubscriber(topic) {
+		b.mu.Unlock()
+		return nil, nil
+	}
 	ch := make(chan string, b.bufferSize)
 	if b.topics[topic] == nil {
 		b.topics[topic] = make(map[chan string]struct{})


### PR DESCRIPTION
## Summary
- Add `WithMaxSubscribers`, `WithMaxSubscribersPerTopic`, and `WithAdmissionControl` broker options
- Denied subscriptions return `nil, nil`; SSEHandler returns 503 Service Unavailable
- Admission checked in all subscribe variants (Subscribe, SubscribeScoped, SubscribeWithFilter, SubscribeScopedWithFilter, SubscribeFromID, SubscribeWithSnapshot, subscribeCoalescing)

## Test plan
- [x] Global limit enforcement
- [x] Per-topic limit enforcement
- [x] Custom admission callback
- [x] 503 from SSEHandler
- [x] Concurrent boundary test
- [x] Scoped and filtered subscriber admission

Closes #116