### PR TITLE
feat: publish-side backpressure signaling (#118)

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -82,6 +82,7 @@ type SSEBroker struct {
 	maxSubsPerTopic   int                              // 0 = unlimited per-topic subscribers
 	admissionFn       func(topic string, currentCount int) bool // nil = no custom admission
 	orderedTopics     map[string]*sync.Mutex             // topic → per-topic ordering mutex
+	onPublishDropFn   func(topic string, droppedForCount int) // nil = no drop callback
 }
 
 // Topic name constants are conventions for common real-time use cases.
@@ -681,6 +682,9 @@ func (b *SSEBroker) publishToChannels(topic string, channels []chan string, msg 
 				}
 			}
 		}()
+	}
+	if dropped > 0 && b.onPublishDropFn != nil {
+		b.onPublishDropFn(topic, dropped)
 	}
 	return
 }

--- a/publish_signal.go
+++ b/publish_signal.go
@@ -1,0 +1,104 @@
+package tavern
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrPublishTimeout is returned by [SSEBroker.PublishBlocking] and
+// [SSEBroker.PublishBlockingTo] when at least one subscriber's channel could
+// not accept the message within the configured timeout.
+var ErrPublishTimeout = errors.New("tavern: publish timeout")
+
+// OnPublishDrop registers a callback that fires each time a message is
+// dropped during fan-out because a subscriber's channel buffer is full.
+// The callback receives the topic name and the number of subscribers for
+// whom delivery failed. Only one callback is supported; subsequent calls
+// replace the previous one.
+//
+// The callback runs synchronously in the publish goroutine — keep it fast.
+func (b *SSEBroker) OnPublishDrop(fn func(topic string, droppedForCount int)) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.onPublishDropFn = fn
+}
+
+// PublishBlocking behaves like [SSEBroker.Publish] but blocks up to timeout
+// for each subscriber whose channel buffer is full. If any subscriber cannot
+// accept the message within the timeout, [ErrPublishTimeout] is returned.
+// A timeout of zero falls back to non-blocking behavior (equivalent to
+// [SSEBroker.Publish]).
+func (b *SSEBroker) PublishBlocking(topic, msg string, timeout time.Duration) error {
+	if timeout <= 0 {
+		b.Publish(topic, msg)
+		return nil
+	}
+	return b.publishBlocking(topic, "", msg, timeout)
+}
+
+// PublishBlockingTo behaves like [SSEBroker.PublishTo] but blocks up to
+// timeout for each matching scoped subscriber whose channel buffer is full.
+// Returns [ErrPublishTimeout] if any delivery times out.
+func (b *SSEBroker) PublishBlockingTo(topic, scope, msg string, timeout time.Duration) error {
+	if timeout <= 0 {
+		b.PublishTo(topic, scope, msg)
+		return nil
+	}
+	return b.publishBlocking(topic, scope, msg, timeout)
+}
+
+func (b *SSEBroker) publishBlocking(topic, scope, msg string, timeout time.Duration) error {
+	unlock := b.orderLock(topic)
+	defer unlock()
+
+	b.mu.RLock()
+	var channels []chan string
+	if scope == "" {
+		subscribers := b.topics[topic]
+		channels = make([]chan string, 0, len(subscribers))
+		for ch := range subscribers {
+			channels = append(channels, ch)
+		}
+	} else {
+		scopedSubs := b.scopedTopics[topic]
+		channels = make([]chan string, 0, len(scopedSubs))
+		for ch, sub := range scopedSubs {
+			if sub.scope == scope {
+				channels = append(channels, ch)
+			}
+		}
+	}
+	b.mu.RUnlock()
+
+	var timedOut bool
+	for _, ch := range channels {
+		func() {
+			defer func() { _ = recover() }()
+
+			// Check filter predicate.
+			if pred := b.filterPredicate(ch); pred != nil && !pred(msg) {
+				return
+			}
+
+			// Coalescing bypass.
+			if b.coalesceStore(ch, msg) {
+				return
+			}
+
+			select {
+			case ch <- msg:
+			case <-time.After(timeout):
+				timedOut = true
+			}
+		}()
+	}
+
+	b.dispatchToGlobSubscribers(topic, scope, msg)
+	b.backendPublish(topic, msg, scope)
+	b.fireAfterHooks(topic)
+
+	if timedOut {
+		return ErrPublishTimeout
+	}
+	return nil
+}

--- a/publish_signal_test.go
+++ b/publish_signal_test.go
@@ -1,0 +1,152 @@
+package tavern
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOnPublishDrop_Fires(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(1))
+	defer b.Close()
+
+	var dropTopic string
+	var dropCount atomic.Int32
+	b.OnPublishDrop(func(topic string, droppedForCount int) {
+		dropTopic = topic
+		dropCount.Add(int32(droppedForCount))
+	})
+
+	ch, unsub := b.Subscribe("events")
+	defer unsub()
+
+	// Fill the buffer.
+	b.Publish("events", "msg1")
+	// This should drop and fire the callback.
+	b.Publish("events", "msg2")
+
+	time.Sleep(50 * time.Millisecond)
+
+	assert.Equal(t, "events", dropTopic)
+	assert.GreaterOrEqual(t, dropCount.Load(), int32(1))
+
+	// Drain to verify first message arrived.
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "msg1", msg)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timeout")
+	}
+}
+
+func TestPublishBlocking_Succeeds(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(1))
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("topic")
+	defer unsub()
+
+	// Channel has buffer of 1, so first message fits.
+	err := b.PublishBlocking("topic", "hello", 100*time.Millisecond)
+	require.NoError(t, err)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "hello", msg)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout")
+	}
+}
+
+func TestPublishBlocking_TimesOut(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(1))
+	defer b.Close()
+
+	_, unsub := b.Subscribe("topic")
+	defer unsub()
+
+	// Fill the buffer.
+	err := b.PublishBlocking("topic", "msg1", 100*time.Millisecond)
+	require.NoError(t, err)
+
+	// Second publish should time out since nobody is draining.
+	err = b.PublishBlocking("topic", "msg2", 10*time.Millisecond)
+	assert.ErrorIs(t, err, ErrPublishTimeout)
+}
+
+func TestPublishBlockingTo_Scoped(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(1))
+	defer b.Close()
+
+	ch, unsub := b.SubscribeScoped("topic", "scope1")
+	defer unsub()
+
+	err := b.PublishBlockingTo("topic", "scope1", "hello", 100*time.Millisecond)
+	require.NoError(t, err)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "hello", msg)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout")
+	}
+}
+
+func TestPublishBlockingTo_TimesOut(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(1))
+	defer b.Close()
+
+	_, unsub := b.SubscribeScoped("topic", "scope1")
+	defer unsub()
+
+	// Fill buffer.
+	err := b.PublishBlockingTo("topic", "scope1", "msg1", 100*time.Millisecond)
+	require.NoError(t, err)
+
+	err = b.PublishBlockingTo("topic", "scope1", "msg2", 10*time.Millisecond)
+	assert.ErrorIs(t, err, ErrPublishTimeout)
+}
+
+func TestPublishBlocking_ZeroTimeout_NonBlocking(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(1))
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("topic")
+	defer unsub()
+
+	// Zero timeout should behave like normal Publish.
+	err := b.PublishBlocking("topic", "hello", 0)
+	require.NoError(t, err)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "hello", msg)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timeout")
+	}
+}
+
+func TestOnPublishDrop_NotCalledWhenNoDrops(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(10))
+	defer b.Close()
+
+	var called atomic.Bool
+	b.OnPublishDrop(func(_ string, _ int) {
+		called.Store(true)
+	})
+
+	ch, unsub := b.Subscribe("topic")
+	defer unsub()
+
+	b.Publish("topic", "msg1")
+
+	select {
+	case <-ch:
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	assert.False(t, called.Load(), "callback should not fire when no drops occur")
+}


### PR DESCRIPTION
## Summary
- Add `OnPublishDrop(fn)` callback fired during fan-out when messages are dropped
- Add `PublishBlocking(topic, msg, timeout)` and `PublishBlockingTo(topic, scope, msg, timeout)` with per-subscriber timeout
- Add `ErrPublishTimeout` sentinel error

## Test plan
- [x] OnPublishDrop fires on drops
- [x] OnPublishDrop not called when no drops
- [x] PublishBlocking succeeds
- [x] PublishBlocking times out
- [x] PublishBlockingTo scoped variant
- [x] Zero timeout falls back to non-blocking

Closes #118