### PR TITLE
feat: backend interface resilience (#120)

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -14,6 +14,10 @@ type MessageEnvelope struct {
 	Data string `json:"data"`
 	// Scope restricts delivery to scoped subscribers when non-empty.
 	Scope string `json:"scope,omitempty"`
+	// TTL is the message time-to-live. Zero means no expiry.
+	TTL int64 `json:"ttl,omitempty"`
+	// ID is an optional message identifier for replay/resumption.
+	ID string `json:"id,omitempty"`
 }
 
 // Backend is the interface that cross-process fan-out implementations must
@@ -38,4 +42,38 @@ type Backend interface {
 	// Close shuts down the backend and releases all resources. Any open
 	// subscription channels are closed.
 	Close() error
+}
+
+// HealthAwareBackend is an optional interface that backends may implement to
+// support health checking and reconnection notifications. When a broker
+// detects an unhealthy backend, it skips backend publishes until the
+// backend reports healthy again. On reconnect, the broker re-subscribes
+// to all active topics.
+type HealthAwareBackend interface {
+	Backend
+	// Healthy reports whether the backend is currently able to send and
+	// receive messages.
+	Healthy() bool
+	// OnReconnect registers a callback that the backend invokes when it
+	// re-establishes its connection after a failure. The broker uses this
+	// to re-subscribe to all active topics.
+	OnReconnect(fn func())
+}
+
+// BackendStats is a point-in-time snapshot of backend operational metrics.
+type BackendStats struct {
+	// Connected indicates whether the backend is currently connected.
+	Connected bool
+	// MessagesSent is the total number of envelopes published.
+	MessagesSent int64
+	// MessagesReceived is the total number of envelopes received.
+	MessagesReceived int64
+}
+
+// ObservableBackend is an optional interface that backends may implement to
+// expose operational metrics.
+type ObservableBackend interface {
+	Backend
+	// Stats returns a point-in-time snapshot of backend metrics.
+	Stats() BackendStats
 }

--- a/backend/memory/memory.go
+++ b/backend/memory/memory.go
@@ -81,18 +81,24 @@ func (b *bus) removeAll(be *Backend) {
 // shared bus. Use [New] to create one. Call [Backend.Fork] to create a linked
 // instance that shares the same bus — publishes on either instance are visible
 // to subscribers on the other.
+//
+// Backend also implements [backend.HealthAwareBackend] for health checking
+// and reconnection notifications.
 type Backend struct {
-	bus    *bus
-	mu     sync.Mutex
-	subs   map[string]chan backend.MessageEnvelope
-	closed bool
+	bus         *bus
+	mu         sync.Mutex
+	subs       map[string]chan backend.MessageEnvelope
+	closed     bool
+	healthy    bool
+	reconnectFn func()
 }
 
 // New creates a new in-process Backend with its own bus.
 func New() *Backend {
 	return &Backend{
-		bus:  newBus(),
-		subs: make(map[string]chan backend.MessageEnvelope),
+		bus:     newBus(),
+		subs:    make(map[string]chan backend.MessageEnvelope),
+		healthy: true,
 	}
 }
 
@@ -101,8 +107,9 @@ func New() *Backend {
 // all other forks (but not back to the publisher).
 func (b *Backend) Fork() *Backend {
 	return &Backend{
-		bus:  b.bus,
-		subs: make(map[string]chan backend.MessageEnvelope),
+		bus:     b.bus,
+		subs:    make(map[string]chan backend.MessageEnvelope),
+		healthy: true,
 	}
 }
 
@@ -161,6 +168,38 @@ func (b *Backend) Close() error {
 	b.bus.removeAll(b)
 	b.subs = nil
 	return nil
+}
+
+// Healthy reports whether the backend is currently healthy. Returns false
+// when the backend is closed or has been marked unhealthy via [SetHealthy].
+func (b *Backend) Healthy() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return false
+	}
+	return b.healthy
+}
+
+// OnReconnect registers a callback that fires when the backend transitions
+// from unhealthy to healthy. The callback is invoked from [SetHealthy].
+func (b *Backend) OnReconnect(fn func()) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.reconnectFn = fn
+}
+
+// SetHealthy sets the health state. When transitioning from unhealthy to
+// healthy, the registered OnReconnect callback is fired.
+func (b *Backend) SetHealthy(healthy bool) {
+	b.mu.Lock()
+	wasHealthy := b.healthy
+	b.healthy = healthy
+	fn := b.reconnectFn
+	b.mu.Unlock()
+	if healthy && !wasHealthy && fn != nil {
+		fn()
+	}
 }
 
 // ErrClosed is returned when an operation is attempted on a closed backend.

--- a/backend_integration.go
+++ b/backend_integration.go
@@ -21,12 +21,48 @@ func WithBackend(b backend.Backend) BrokerOption {
 	}
 }
 
-// initBackend is a no-op placeholder called from NewSSEBroker. The actual
-// integration happens inline: Subscribe/Unsubscribe call
-// backendSubscribe/backendUnsubscribe when the first/last subscriber
-// joins/leaves, and the Publish methods call backendPublish after local
-// fan-out.
-func (b *SSEBroker) initBackend() {}
+// initBackend sets up health-aware reconnection if the backend implements
+// [backend.HealthAwareBackend]. On reconnect, the broker re-subscribes to
+// all topics that currently have local subscribers.
+func (b *SSEBroker) initBackend() {
+	if b.backend == nil {
+		return
+	}
+	if hab, ok := b.backend.(backend.HealthAwareBackend); ok {
+		hab.OnReconnect(func() {
+			b.resubscribeAll()
+		})
+	}
+}
+
+// resubscribeAll re-subscribes to the backend for every topic that currently
+// has at least one local subscriber. This is called after a backend reconnect.
+func (b *SSEBroker) resubscribeAll() {
+	b.mu.RLock()
+	var topics []string
+	seen := make(map[string]struct{})
+	for topic, subs := range b.topics {
+		if len(subs) > 0 {
+			if _, ok := seen[topic]; !ok {
+				topics = append(topics, topic)
+				seen[topic] = struct{}{}
+			}
+		}
+	}
+	for topic, subs := range b.scopedTopics {
+		if len(subs) > 0 {
+			if _, ok := seen[topic]; !ok {
+				topics = append(topics, topic)
+				seen[topic] = struct{}{}
+			}
+		}
+	}
+	b.mu.RUnlock()
+
+	for _, topic := range topics {
+		b.backendSubscribe(topic)
+	}
+}
 
 // backendSubscribe registers the broker with the backend for the given topic
 // and starts a goroutine that forwards incoming envelopes to local
@@ -61,15 +97,42 @@ func (b *SSEBroker) backendUnsubscribe(topic string) {
 }
 
 // backendPublish forwards a message to the backend for cross-instance
-// delivery. Scoped messages include the scope in the envelope.
+// delivery. Scoped messages include the scope in the envelope. If the
+// backend implements [backend.HealthAwareBackend] and is unhealthy, the
+// publish is silently skipped.
 func (b *SSEBroker) backendPublish(topic, msg, scope string) {
 	if b.backend == nil {
+		return
+	}
+	if hab, ok := b.backend.(backend.HealthAwareBackend); ok && !hab.Healthy() {
 		return
 	}
 	env := backend.MessageEnvelope{
 		Topic: topic,
 		Data:  msg,
 		Scope: scope,
+	}
+	if err := b.backend.Publish(context.Background(), env); err != nil {
+		if b.logger != nil {
+			b.logger.Error("backend publish failed", "topic", topic, "err", err)
+		}
+	}
+}
+
+// backendPublishWithMeta forwards a message with TTL and ID metadata.
+func (b *SSEBroker) backendPublishWithMeta(topic, msg, scope string, ttlMs int64, id string) {
+	if b.backend == nil {
+		return
+	}
+	if hab, ok := b.backend.(backend.HealthAwareBackend); ok && !hab.Healthy() {
+		return
+	}
+	env := backend.MessageEnvelope{
+		Topic: topic,
+		Data:  msg,
+		Scope: scope,
+		TTL:   ttlMs,
+		ID:    id,
 	}
 	if err := b.backend.Publish(context.Background(), env); err != nil {
 		if b.logger != nil {

--- a/backend_resilience_test.go
+++ b/backend_resilience_test.go
@@ -1,0 +1,201 @@
+package tavern
+
+import (
+	"testing"
+	"time"
+
+	"github.com/catgoose/tavern/backend"
+	"github.com/catgoose/tavern/backend/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackendEnvelope_TTLAndID(t *testing.T) {
+	mem := memory.New()
+	defer mem.Close()
+
+	b1 := NewSSEBroker(WithBackend(mem))
+	fork := mem.Fork()
+	b2 := NewSSEBroker(WithBackend(fork))
+	defer b1.Close()
+	defer b2.Close()
+
+	ch, unsub := b2.Subscribe("topic")
+	defer unsub()
+
+	time.Sleep(20 * time.Millisecond)
+
+	// Publish via b1 — basic envelope should be delivered.
+	b1.Publish("topic", "hello")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "hello", msg)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting for backend message")
+	}
+}
+
+func TestBackendEnvelope_TTLFieldPopulated(t *testing.T) {
+	// Verify the envelope struct supports TTL and ID fields.
+	env := backend.MessageEnvelope{
+		Topic: "t",
+		Data:  "d",
+		TTL:   5000,
+		ID:    "msg-1",
+	}
+	assert.Equal(t, int64(5000), env.TTL)
+	assert.Equal(t, "msg-1", env.ID)
+}
+
+func TestHealthAwareBackend_SkipPublishWhenUnhealthy(t *testing.T) {
+	mem := memory.New()
+	defer mem.Close()
+
+	fork := mem.Fork()
+	b1 := NewSSEBroker(WithBackend(mem))
+	b2 := NewSSEBroker(WithBackend(fork))
+	defer b1.Close()
+	defer b2.Close()
+
+	ch, unsub := b2.Subscribe("orders")
+	defer unsub()
+
+	time.Sleep(20 * time.Millisecond)
+
+	// Mark backend as unhealthy.
+	mem.SetHealthy(false)
+
+	// Publish on b1 — should be silently skipped because backend is unhealthy.
+	b1.Publish("orders", "should-not-arrive")
+
+	select {
+	case msg := <-ch:
+		t.Fatalf("should not receive message when backend unhealthy, got: %s", msg)
+	case <-time.After(100 * time.Millisecond):
+		// Expected: no message received.
+	}
+
+	// Mark healthy again.
+	mem.SetHealthy(true)
+
+	time.Sleep(20 * time.Millisecond)
+
+	// Now publish should work.
+	b1.Publish("orders", "recovered")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "recovered", msg)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout after recovery")
+	}
+}
+
+func TestHealthAwareBackend_ReconnectResubscribes(t *testing.T) {
+	mem := memory.New()
+	defer mem.Close()
+
+	fork := mem.Fork()
+	b1 := NewSSEBroker(WithBackend(mem))
+	b2 := NewSSEBroker(WithBackend(fork))
+	defer b1.Close()
+	defer b2.Close()
+
+	// Subscribe on b2.
+	ch, unsub := b2.Subscribe("events")
+	defer unsub()
+
+	time.Sleep(20 * time.Millisecond)
+
+	// Verify initial publish works.
+	b1.Publish("events", "before")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "before", msg)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout before disconnect")
+	}
+
+	// Simulate disconnect/reconnect cycle.
+	mem.SetHealthy(false)
+	time.Sleep(20 * time.Millisecond)
+	mem.SetHealthy(true)
+
+	// Wait for reconnect handler to fire and resubscribe.
+	time.Sleep(50 * time.Millisecond)
+
+	// Publish after reconnect should be delivered.
+	b1.Publish("events", "after-reconnect")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "after-reconnect", msg)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout after reconnect")
+	}
+}
+
+func TestHealthAwareBackend_MemoryImplementsInterface(t *testing.T) {
+	mem := memory.New()
+	defer mem.Close()
+
+	var hab backend.HealthAwareBackend = mem
+	assert.True(t, hab.Healthy())
+
+	mem.SetHealthy(false)
+	assert.False(t, hab.Healthy())
+
+	mem.SetHealthy(true)
+	assert.True(t, hab.Healthy())
+}
+
+func TestHealthAwareBackend_ClosedBackendUnhealthy(t *testing.T) {
+	mem := memory.New()
+	mem.Close()
+
+	assert.False(t, mem.Healthy())
+}
+
+func TestBackendPublishWithMeta(t *testing.T) {
+	mem := memory.New()
+	defer mem.Close()
+
+	b := NewSSEBroker(WithBackend(mem))
+	defer b.Close()
+
+	// Exercise backendPublishWithMeta — it should not panic.
+	b.backendPublishWithMeta("topic", "data", "", 5000, "id-1")
+}
+
+func TestObservableBackend_Interface(t *testing.T) {
+	// Verify the ObservableBackend interface compiles and can be type-asserted.
+	var _ backend.ObservableBackend = (*observableTestBackend)(nil)
+}
+
+// observableTestBackend is a minimal implementation for compile-time checking.
+type observableTestBackend struct {
+	memory.Backend
+}
+
+func (o *observableTestBackend) Stats() backend.BackendStats {
+	return backend.BackendStats{Connected: true}
+}
+
+func TestHealthAwareBackend_OnReconnectCallback(t *testing.T) {
+	mem := memory.New()
+	defer mem.Close()
+
+	var called bool
+	mem.OnReconnect(func() {
+		called = true
+	})
+
+	// Transition: healthy → unhealthy → healthy should fire callback.
+	mem.SetHealthy(false)
+	assert.False(t, called)
+
+	mem.SetHealthy(true)
+	require.True(t, called)
+}


### PR DESCRIPTION
## Summary
- Extend `MessageEnvelope` with `TTL` and `ID` fields for cross-instance metadata
- Add `HealthAwareBackend` interface (`Healthy()`, `OnReconnect(fn)`)
- Add `ObservableBackend` interface (`Stats() BackendStats`)
- Memory backend implements `HealthAwareBackend` with `SetHealthy()` toggle
- Broker skips backend publish when unhealthy, auto-resubscribes on reconnect

## Test plan
- [x] TTL and ID fields on envelope
- [x] Health check skips publish when unhealthy
- [x] Reconnect triggers resubscribe for all active topics
- [x] Memory backend implements HealthAwareBackend
- [x] Closed backend reports unhealthy
- [x] OnReconnect callback fires on healthy transition

Closes #120