### PR TITLE
docs: polish GoDoc comments across all packages

### DIFF
--- a/admission.go
+++ b/admission.go
@@ -1,9 +1,9 @@
 package tavern
 
 // WithMaxSubscribers sets a global limit on the total number of concurrent
-// subscribers across all topics. When the limit is reached, new Subscribe
-// calls return a nil channel and nil unsubscribe function, and SSEHandler
-// returns HTTP 503 Service Unavailable.
+// subscribers across all topics. Default is 0 (unlimited). When the limit is
+// reached, new Subscribe calls return a nil channel and nil unsubscribe
+// function, and SSEHandler returns HTTP 503 Service Unavailable.
 func WithMaxSubscribers(n int) BrokerOption {
 	return func(b *SSEBroker) {
 		b.maxSubs = n
@@ -11,9 +11,9 @@ func WithMaxSubscribers(n int) BrokerOption {
 }
 
 // WithMaxSubscribersPerTopic sets a per-topic limit on the number of
-// concurrent subscribers. When the limit for a topic is reached, new
-// Subscribe calls for that topic return a nil channel and nil unsubscribe
-// function, and SSEHandler returns HTTP 503.
+// concurrent subscribers. Default is 0 (unlimited). When the limit for a
+// topic is reached, new Subscribe calls for that topic return a nil channel
+// and nil unsubscribe function, and SSEHandler returns HTTP 503.
 func WithMaxSubscribersPerTopic(n int) BrokerOption {
 	return func(b *SSEBroker) {
 		b.maxSubsPerTopic = n

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -61,6 +61,7 @@ type HealthAwareBackend interface {
 }
 
 // BackendStats is a point-in-time snapshot of backend operational metrics.
+// Obtain one via [ObservableBackend.Stats].
 type BackendStats struct {
 	// Connected indicates whether the backend is currently connected.
 	Connected bool

--- a/backend/memory/memory.go
+++ b/backend/memory/memory.go
@@ -203,6 +203,7 @@ func (b *Backend) SetHealthy(healthy bool) {
 }
 
 // ErrClosed is returned when an operation is attempted on a closed backend.
+// It is a sentinel error safe for comparison with errors.Is.
 var ErrClosed = errClosed{}
 
 type errClosed struct{}

--- a/backpressure.go
+++ b/backpressure.go
@@ -6,6 +6,7 @@ import (
 )
 
 // BackpressureTier represents the current backpressure tier of a subscriber.
+// Tiers escalate based on consecutive message drop counts.
 type BackpressureTier int
 
 const (

--- a/batch.go
+++ b/batch.go
@@ -10,10 +10,11 @@ type publishOp struct {
 	scoped    bool // true for PublishTo/PublishOOBTo
 }
 
-// PublishBatch buffers publish operations and flushes them as a single write
-// per subscriber. Create one via [SSEBroker.Batch]. Multiple goroutines may
-// call Publish/PublishTo concurrently, but Flush and Discard must be called
-// at most once and not concurrently with publishes.
+// PublishBatch buffers publish operations and flushes them as a single
+// concatenated write per subscriber channel, reducing the number of SSE
+// writes on the wire. Create one via [SSEBroker.Batch]. Multiple goroutines
+// may call Publish/PublishTo concurrently, but Flush and Discard must be
+// called at most once and not concurrently with publishes.
 type PublishBatch struct {
 	broker *SSEBroker
 	mu     sync.Mutex

--- a/broker.go
+++ b/broker.go
@@ -88,6 +88,7 @@ type SSEBroker struct {
 // Topic name constants are conventions for common real-time use cases.
 // Any string works as a topic name; these are provided for consistent naming.
 const (
+	// TopicActivityFeed is a conventional topic name for site-wide activity feeds.
 	TopicActivityFeed = "activity-feed"
 )
 

--- a/circuit.go
+++ b/circuit.go
@@ -15,6 +15,7 @@ const (
 )
 
 // CircuitBreakerConfig configures a circuit breaker for a scheduled section.
+// The circuit breaker follows the standard closed/open/half-open state machine.
 type CircuitBreakerConfig struct {
 	// FailureThreshold is the number of consecutive failures before the
 	// circuit opens. Must be at least 1.
@@ -29,7 +30,9 @@ type CircuitBreakerConfig struct {
 	FallbackRender func() string
 }
 
-// RenderError contains structured information about a render failure.
+// RenderError contains structured information about a render failure. It
+// implements the error interface and supports errors.Unwrap for the underlying
+// error.
 type RenderError struct {
 	// Topic is the broker topic or scheduled publisher event associated with the error.
 	Topic string

--- a/coalesce.go
+++ b/coalesce.go
@@ -21,9 +21,12 @@ type coalescingState struct {
 // irrelevant.
 //
 // Replaced (coalesced) messages do not count as drops in [SSEBroker.PublishDrops].
+// The coalescing channel uses an internal atomic pointer so updates are
+// lock-free in the publish path.
 //
 // The returned channel receives the latest message whenever a new value is
 // available. Call the returned function to unsubscribe and close the channel.
+// The unsubscribe function is safe to call more than once.
 func (b *SSEBroker) SubscribeWithCoalescing(topic string) (msgs <-chan string, unsubscribe func()) {
 	return b.subscribeCoalescing(topic, "")
 }

--- a/debounce.go
+++ b/debounce.go
@@ -20,7 +20,7 @@ type debounceEntry struct {
 // If called again for the same topic before the duration elapses, the timer
 // resets and only the latest message is published. This is useful for rapid
 // state changes (typing indicators, slider drags) where intermediate states
-// are noise.
+// are noise. This method is safe for concurrent use.
 func (b *SSEBroker) PublishDebounced(topic, msg string, after time.Duration) {
 	b.debounce.mu.Lock()
 	defer b.debounce.mu.Unlock()

--- a/filter.go
+++ b/filter.go
@@ -6,7 +6,10 @@ import (
 )
 
 // FilterPredicate is a function that returns true if the message should be
-// delivered to the subscriber. It runs in the publish path and must be fast.
+// delivered to the subscriber. It runs synchronously in the publish goroutine
+// for every message on the topic, so implementations must be fast and
+// non-blocking. Messages rejected by the predicate are silently skipped and
+// do not count toward drop counts or backpressure tiers.
 type FilterPredicate func(msg string) bool
 
 // SubscribeWithFilter registers a subscriber with a predicate filter for the

--- a/gap.go
+++ b/gap.go
@@ -2,7 +2,8 @@ package tavern
 
 // GapStrategy determines how the broker responds when a subscriber reconnects
 // with a Last-Event-ID that is no longer in the replay log (i.e., the log has
-// rolled over and the requested ID is gone).
+// rolled over and the requested ID is gone). Configure per-topic via
+// [SSEBroker.SetReplayGapPolicy].
 type GapStrategy int
 
 const (

--- a/group.go
+++ b/group.go
@@ -112,10 +112,13 @@ func (b *SSEBroker) DynamicGroupHandler(name string, opts ...SSEHandlerOption) h
 	return h
 }
 
+// ServeHTTP handles an incoming SSE connection for the static topic group.
 func (h *groupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	serveGroupSSE(w, r, h.broker, h.topics, h.writer)
 }
 
+// ServeHTTP handles an incoming SSE connection for the dynamic topic group,
+// resolving topics from the per-request function.
 func (h *dynamicGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	topics := h.fn(r)
 	serveGroupSSE(w, r, h.broker, topics, h.writer)

--- a/handler.go
+++ b/handler.go
@@ -71,6 +71,10 @@ func defaultSSEWriter(w http.ResponseWriter, msg string) error {
 	return nil
 }
 
+// ServeHTTP handles an incoming SSE connection by setting the appropriate
+// headers, subscribing to the handler's topic (with Last-Event-ID resumption
+// if the header is present), and streaming messages until the client
+// disconnects or the broker closes.
 func (h *sseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Set SSE headers.
 	w.Header().Set("Content-Type", "text/event-stream")

--- a/hooks.go
+++ b/hooks.go
@@ -22,7 +22,8 @@ type afterChain struct {
 
 // MutationEvent carries context about a resource mutation. It is passed to
 // handlers registered via [SSEBroker.OnMutate] when [SSEBroker.NotifyMutate]
-// is called.
+// is called. Resources are logical entities (e.g., "orders") decoupled from
+// topic names.
 type MutationEvent struct {
 	// ID identifies the specific entity that was mutated (e.g., an order ID).
 	ID string

--- a/metrics.go
+++ b/metrics.go
@@ -5,10 +5,17 @@ import (
 	"sync/atomic"
 )
 
-// TopicMetrics holds per-topic counters.
+// TopicMetrics holds per-topic counters. All fields are cumulative since the
+// broker was created (except PeakSubscribers which is a high-water mark).
 type TopicMetrics struct {
-	Published       int64
-	Dropped         int64
+	// Published is the total number of messages successfully delivered to at
+	// least one subscriber on this topic.
+	Published int64
+	// Dropped is the total number of delivery failures (subscriber buffer full)
+	// on this topic.
+	Dropped int64
+	// PeakSubscribers is the highest number of concurrent subscribers observed
+	// on this topic since the broker was created.
 	PeakSubscribers int
 }
 

--- a/multi.go
+++ b/multi.go
@@ -2,10 +2,14 @@ package tavern
 
 import "sync"
 
-// TopicMessage pairs a message with the topic it was published on.
+// TopicMessage pairs a message with the topic it was published on. It is
+// returned by multiplexed subscription methods such as [SSEBroker.SubscribeMulti]
+// and [SSEBroker.SubscribeGlob].
 type TopicMessage struct {
+	// Topic is the name of the topic the message was published to.
 	Topic string
-	Data  string
+	// Data is the published message payload.
+	Data string
 }
 
 // SubscribeMulti subscribes to multiple topics and returns a single channel

--- a/observability.go
+++ b/observability.go
@@ -18,6 +18,7 @@ const (
 
 // ObservabilityConfig controls which observability features are enabled.
 // By default all fields are false and observability has zero overhead.
+// Enable individual features selectively to minimize runtime cost.
 type ObservabilityConfig struct {
 	// PublishLatency enables per-topic publish latency histograms.
 	PublishLatency bool
@@ -29,13 +30,16 @@ type ObservabilityConfig struct {
 	TopicThroughput bool
 }
 
-// LatencyHistogram holds percentile latency data.
+// LatencyHistogram holds percentile latency data computed from a circular
+// buffer of the most recent 1024 samples.
 type LatencyHistogram struct {
 	P50, P95, P99 time.Duration
 	Count         int64
 }
 
-// TopicObservability holds observability data for a single topic.
+// TopicObservability holds observability data for a single topic. All fields
+// are populated based on the features enabled in [ObservabilityConfig]; disabled
+// features produce zero values.
 type TopicObservability struct {
 	PublishLatency      LatencyHistogram
 	SubscriberLag       map[string]int // subscriberID -> buffer depth
@@ -44,7 +48,9 @@ type TopicObservability struct {
 	EvictionCount       int64
 }
 
-// ObservabilitySnapshot is an export-friendly snapshot of all observability data.
+// ObservabilitySnapshot is a point-in-time, export-friendly snapshot of all
+// observability data across all topics. Obtain one via
+// [observabilityState.Snapshot].
 type ObservabilitySnapshot struct {
 	Topics map[string]TopicObservability
 }

--- a/oob.go
+++ b/oob.go
@@ -54,10 +54,16 @@ func escapeAttr(s string) string {
 }
 
 // Fragment describes a targeted DOM mutation for HTMX OOB swaps via SSE.
+// Use the convenience constructors [Replace], [Append], [Prepend], and
+// [Delete] instead of building Fragment values directly.
 type Fragment struct {
-	ID   string // target element ID
-	Swap string // hx-swap-oob value: outerHTML, innerHTML, delete, beforeend, afterbegin
-	HTML string // inner HTML content (empty for delete)
+	// ID is the target DOM element ID.
+	ID string
+	// Swap is the hx-swap-oob value: "outerHTML", "innerHTML", "delete",
+	// "beforeend", or "afterbegin".
+	Swap string
+	// HTML is the inner HTML content. Empty for delete operations.
+	HTML string
 }
 
 // Delete creates a fragment that removes an element from the DOM.

--- a/ordering.go
+++ b/ordering.go
@@ -5,7 +5,8 @@ import "sync"
 // SetOrdered marks or unmarks a topic as ordered. When a topic is ordered,
 // concurrent publishes are serialized through a per-topic mutex so that all
 // subscribers observe messages in the same order. Non-ordered topics (the
-// default) have zero additional synchronization overhead.
+// default) have zero additional synchronization overhead. This method is
+// safe for concurrent use.
 //
 // Call with enabled=true before publishing to guarantee ordering. Call with
 // enabled=false to remove the constraint. Toggling while publishes are

--- a/presence/presence.go
+++ b/presence/presence.go
@@ -57,7 +57,9 @@ type Config struct {
 	TargetID string
 }
 
-// Info represents a user's presence on a topic.
+// Info represents a user's presence on a topic. All fields except UserID are
+// optional. Metadata can hold arbitrary application-specific data such as
+// cursor positions, status text, or editing state.
 type Info struct {
 	UserID   string
 	Name     string
@@ -67,7 +69,9 @@ type Info struct {
 	LastSeen time.Time
 }
 
-// Tracker manages presence state for topics. It is safe for concurrent use.
+// Tracker manages presence state for topics. It is safe for concurrent use
+// by multiple goroutines. A background goroutine sweeps stale entries at half
+// the configured StaleTimeout interval.
 type Tracker struct {
 	broker *tavern.SSEBroker
 	cfg    Config

--- a/rate.go
+++ b/rate.go
@@ -5,8 +5,11 @@ import (
 	"time"
 )
 
-// Rate configures per-subscriber rate limiting. If both MaxPerSecond and
-// MinInterval are set, MinInterval takes precedence.
+// Rate configures per-subscriber rate limiting. When a subscriber is
+// rate-limited, messages published faster than the configured rate are held
+// and only the most recent held message is delivered when the interval
+// elapses (latest-wins). If both MaxPerSecond and MinInterval are set,
+// MinInterval takes precedence.
 type Rate struct {
 	// MaxPerSecond is a convenience field: converted to MinInterval internally.
 	MaxPerSecond float64

--- a/reconnect.go
+++ b/reconnect.go
@@ -2,8 +2,9 @@ package tavern
 
 import "time"
 
-// ReconnectInfo provides context about a subscriber reconnection. It is passed
-// to callbacks registered with [SSEBroker.OnReconnect].
+// ReconnectInfo provides context about a subscriber reconnection, including
+// the gap duration and number of missed messages. It is passed to callbacks
+// registered with [SSEBroker.OnReconnect].
 type ReconnectInfo struct {
 	// Topic is the topic the subscriber reconnected to.
 	Topic string

--- a/resume.go
+++ b/resume.go
@@ -6,15 +6,23 @@ import (
 	"time"
 )
 
-// ReplayEntry pairs a message with its event ID for resumption support.
-// When ExpiresAt is non-zero, the entry will be removed from the replay
-// cache after that time (see [SSEBroker.PublishWithTTL]).
+// ReplayEntry pairs a message with its event ID for Last-Event-ID resumption
+// support. When ExpiresAt is non-zero, the entry will be removed from the
+// replay cache after that time (see [SSEBroker.PublishWithTTL]).
 type ReplayEntry struct {
-	ID           string
-	Msg          string
-	ExpiresAt    time.Time // zero means no expiry
-	AutoRemoveID string    // element ID for OOB delete on expiry (empty = none)
-	PublishedAt  time.Time
+	// ID is the SSE event identifier used for Last-Event-ID resumption.
+	ID string
+	// Msg is the raw message payload stored in the replay log.
+	Msg string
+	// ExpiresAt is when this entry should be purged from the replay cache.
+	// A zero value means the entry does not expire.
+	ExpiresAt time.Time
+	// AutoRemoveID is the DOM element ID to send an OOB delete fragment for
+	// when this entry expires. Empty means no auto-removal.
+	AutoRemoveID string
+	// PublishedAt records when the entry was originally published, used to
+	// compute reconnection gap durations.
+	PublishedAt time.Time
 }
 
 // PublishWithID publishes msg to the topic with an associated event ID.

--- a/scheduled.go
+++ b/scheduled.go
@@ -9,13 +9,18 @@ import (
 	"time"
 )
 
-// RenderFunc renders content into the provided buffer.
-// It receives the context and a buffer to write into.
+// RenderFunc renders content into the provided buffer. It receives the
+// context (which is cancelled when the scheduled publisher stops) and a
+// shared buffer to write HTML into. Multiple sections write to the same
+// buffer in a single tick, so output should be self-contained fragments.
 type RenderFunc func(ctx context.Context, buf *bytes.Buffer) error
 
 // ScheduledPublisher manages multiple named sections with independent
-// update intervals. It ticks on a fast base interval, renders due sections
-// into a shared buffer, and publishes one batched message per tick.
+// update intervals. It ticks on a fast base interval (default 100ms),
+// renders due sections into a shared buffer, and publishes one batched
+// message per tick. It automatically skips rendering when no subscribers
+// are connected to the topic. ScheduledPublisher is safe for concurrent
+// use; sections can be registered while the publisher is running.
 type ScheduledPublisher struct {
 	broker   *SSEBroker
 	event    string
@@ -26,6 +31,7 @@ type ScheduledPublisher struct {
 }
 
 // SectionOptions configures optional behavior for a registered section.
+// Pass as the last argument to [ScheduledPublisher.Register].
 type SectionOptions struct {
 	// CircuitBreaker enables circuit breaker protection for the section.
 	// When nil, the section renders normally without circuit breaker logic.

--- a/subscribe_options.go
+++ b/subscribe_options.go
@@ -299,14 +299,18 @@ func (s *globRateState) allow() bool {
 	return true
 }
 
-// PublishWithTTLBatch buffers a TTL publish in the batch.
+// PublishWithTTL publishes a message with a TTL on the replay cache entry.
+// Unlike other PublishBatch methods, this executes immediately rather than
+// buffering because the TTL sweeper requires immediate processing.
 func (pb *PublishBatch) PublishWithTTL(topic, msg string, ttl time.Duration, opts ...TTLOption) {
 	// TTL publishes need immediate processing for the TTL sweeper, so we
 	// execute them directly rather than buffering.
 	pb.broker.PublishWithTTL(topic, msg, ttl, opts...)
 }
 
-// PublishWithID buffers a publish with a replay ID in the batch.
+// PublishWithID publishes a message with an associated event ID for
+// Last-Event-ID resumption. Like [PublishBatch.PublishWithTTL], this executes
+// immediately rather than buffering.
 func (pb *PublishBatch) PublishWithID(topic, id, msg string) {
 	pb.broker.PublishWithID(topic, id, msg)
 }

--- a/subscriber.go
+++ b/subscriber.go
@@ -5,7 +5,8 @@ import (
 	"time"
 )
 
-// SubscriberInfo describes an active subscriber.
+// SubscriberInfo describes an active subscriber. Retrieve a snapshot of all
+// subscribers for a topic via [SSEBroker.Subscribers].
 type SubscriberInfo struct {
 	// ID is the caller-provided identifier (empty if not set).
 	ID string
@@ -20,6 +21,8 @@ type SubscriberInfo struct {
 }
 
 // SubscribeMeta holds optional metadata for [SSEBroker.SubscribeWithMeta].
+// The ID is used for targeted operations like [SSEBroker.Disconnect] and
+// [SSEBroker.AddTopic].
 type SubscribeMeta struct {
 	// ID is an identifier for this subscriber (e.g., session ID, user ID).
 	ID string

--- a/taverntest/capture.go
+++ b/taverntest/capture.go
@@ -10,7 +10,8 @@ import (
 
 // Capture subscribes to a real broker and collects messages for assertion.
 // Unlike [Recorder], Capture provides assertion methods that accept expected
-// messages directly, making tests more declarative.
+// messages directly, making tests more declarative. Capture is safe for
+// concurrent use by multiple goroutines.
 type Capture struct {
 	msgs  []string
 	mu    sync.Mutex

--- a/taverntest/mock_broker.go
+++ b/taverntest/mock_broker.go
@@ -1,3 +1,9 @@
+// Package taverntest provides test helpers for tavern-based applications.
+// It includes a mock broker for verifying publish calls without running a
+// real broker, recorders and captures for collecting live messages during
+// integration tests, a slow subscriber simulator for backpressure testing,
+// a simulated connection for reconnect/resumption testing, and an SSE
+// recorder for HTTP handler testing.
 package taverntest
 
 import (
@@ -19,6 +25,7 @@ type publishedCall struct {
 // MockBroker records publish calls for test assertions. It does not deliver
 // messages to any subscribers; use it when you want to verify that application
 // code publishes the right messages without running a real broker.
+// MockBroker is safe for concurrent use by multiple goroutines.
 type MockBroker struct {
 	mu   sync.Mutex
 	calls []publishedCall

--- a/taverntest/recorder.go
+++ b/taverntest/recorder.go
@@ -10,7 +10,8 @@ import (
 
 // Recorder captures messages published to a topic for test assertions.
 // It subscribes to the topic on creation and collects messages in a
-// goroutine. Use [NewRecorder] or [NewScopedRecorder] to create one.
+// background goroutine. Use [NewRecorder] or [NewScopedRecorder] to create
+// one. Recorder is safe for concurrent use by multiple goroutines.
 type Recorder struct {
 	msgs   []string
 	mu     sync.Mutex

--- a/taverntest/simulated_connection.go
+++ b/taverntest/simulated_connection.go
@@ -11,7 +11,8 @@ import (
 // SimulatedConnection models a client that can disconnect and reconnect to a
 // broker, collecting messages across connection cycles. This is useful for
 // testing Last-Event-ID resumption, reconnect behavior, and message
-// continuity across disconnects.
+// continuity across disconnects. SimulatedConnection is safe for concurrent
+// use by multiple goroutines.
 type SimulatedConnection struct {
 	broker *tavern.SSEBroker
 	topic  string

--- a/taverntest/slow_subscriber.go
+++ b/taverntest/slow_subscriber.go
@@ -17,7 +17,8 @@ type SlowSubscriberConfig struct {
 
 // SlowSubscriber simulates a subscriber that reads messages slowly, useful
 // for testing backpressure, drop-oldest behavior, and slow subscriber
-// eviction scenarios.
+// eviction scenarios. SlowSubscriber is safe for concurrent use by multiple
+// goroutines.
 type SlowSubscriber struct {
 	msgs   []string
 	mu     sync.Mutex

--- a/taverntest/sse_recorder.go
+++ b/taverntest/sse_recorder.go
@@ -25,7 +25,8 @@ type SSEEvent struct {
 // into structured [SSEEvent] values for easy assertion.
 //
 // Use it like [net/http/httptest.ResponseRecorder] but with SSE-aware
-// assertion methods.
+// assertion methods. SSERecorder is safe for concurrent use by multiple
+// goroutines.
 type SSERecorder struct {
 	mu      sync.Mutex
 	header  http.Header

--- a/throttle.go
+++ b/throttle.go
@@ -20,8 +20,9 @@ type throttleEntry struct {
 // PublishThrottled publishes msg to the topic at most once per interval.
 // The first call publishes immediately. Subsequent calls within the interval
 // are held; when the interval elapses, the most recent held message is
-// published. This guarantees bounded latency for the first message while
-// rate-limiting subsequent ones.
+// published (latest-wins). This guarantees bounded latency for the first
+// message while rate-limiting subsequent ones. This method is safe for
+// concurrent use.
 func (b *SSEBroker) PublishThrottled(topic, msg string, interval time.Duration) {
 	now := time.Now()
 	b.throttle.mu.Lock()

--- a/ttl.go
+++ b/ttl.go
@@ -2,7 +2,8 @@ package tavern
 
 import "time"
 
-// TTLOption configures optional behavior for TTL-based publish methods.
+// TTLOption configures optional behavior for TTL-based publish methods such
+// as [SSEBroker.PublishWithTTL] and [SSEBroker.PublishToWithTTL].
 type TTLOption func(*ttlConfig)
 
 type ttlConfig struct {


### PR DESCRIPTION
## Summary
- Adds or improves GoDoc comments on all exported types, methods, functions, and constants across 34 files in root package, backend/, presence/, and taverntest/
- Adds missing doc comments (ServeHTTP methods, taverntest package doc, TopicActivityFeed constant)
- Documents thread safety, default values, and cross-references between related types
- Fixes misleading doc comments on PublishBatch TTL/ID methods

Closes #130