### PR TITLE
feat: max connection duration handler option

### DIFF
--- a/group.go
+++ b/group.go
@@ -2,8 +2,10 @@ package tavern
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"net/http"
 	"sync"
+	"time"
 )
 
 // groupDef is a static topic group definition.
@@ -18,16 +20,18 @@ type dynamicGroupDef struct {
 
 // groupHandler serves a multiplexed SSE stream for a set of topics.
 type groupHandler struct {
-	broker *SSEBroker
-	topics []string
-	writer SSEWriterFunc
+	broker          *SSEBroker
+	topics          []string
+	writer          SSEWriterFunc
+	maxConnDuration time.Duration
 }
 
 // dynamicGroupHandler serves a multiplexed SSE stream for topics resolved per-request.
 type dynamicGroupHandler struct {
-	broker *SSEBroker
-	fn     func(r *http.Request) []string
-	writer SSEWriterFunc
+	broker          *SSEBroker
+	fn              func(r *http.Request) []string
+	writer          SSEWriterFunc
+	maxConnDuration time.Duration
 }
 
 // DefineGroup registers a named static topic group. The group can later be
@@ -66,6 +70,9 @@ func (b *SSEBroker) GroupHandler(name string, opts ...SSEHandlerOption) http.Han
 		opt(adapter)
 		if adapter.writer != nil {
 			h.writer = adapter.writer
+		}
+		if adapter.maxConnDuration > 0 {
+			h.maxConnDuration = adapter.maxConnDuration
 		}
 	}
 	return h
@@ -108,20 +115,23 @@ func (b *SSEBroker) DynamicGroupHandler(name string, opts ...SSEHandlerOption) h
 		if adapter.writer != nil {
 			h.writer = adapter.writer
 		}
+		if adapter.maxConnDuration > 0 {
+			h.maxConnDuration = adapter.maxConnDuration
+		}
 	}
 	return h
 }
 
 // ServeHTTP handles an incoming SSE connection for the static topic group.
 func (h *groupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	serveGroupSSE(w, r, h.broker, h.topics, h.writer)
+	serveGroupSSE(w, r, h.broker, h.topics, h.writer, h.maxConnDuration)
 }
 
 // ServeHTTP handles an incoming SSE connection for the dynamic topic group,
 // resolving topics from the per-request function.
 func (h *dynamicGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	topics := h.fn(r)
-	serveGroupSSE(w, r, h.broker, topics, h.writer)
+	serveGroupSSE(w, r, h.broker, topics, h.writer, h.maxConnDuration)
 }
 
 // serveGroupSSE is the shared streaming loop for static and dynamic group
@@ -129,7 +139,7 @@ func (h *dynamicGroupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 // message as an SSE event with the topic as the event type. When the request
 // includes a Last-Event-ID header, cached messages after that ID are replayed
 // for each topic before the live stream begins.
-func serveGroupSSE(w http.ResponseWriter, r *http.Request, broker *SSEBroker, topics []string, writer SSEWriterFunc) {
+func serveGroupSSE(w http.ResponseWriter, r *http.Request, broker *SSEBroker, topics []string, writer SSEWriterFunc, maxConnDuration time.Duration) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
@@ -151,6 +161,12 @@ func serveGroupSSE(w http.ResponseWriter, r *http.Request, broker *SSEBroker, to
 	}
 	defer unsub()
 
+	var maxDurC <-chan time.Time
+	if maxConnDuration > 0 {
+		actual := maxConnDuration + time.Duration(rand.Int64N(int64(maxConnDuration/10)))
+		maxDurC = time.After(actual)
+	}
+
 	for {
 		select {
 		case msg, ok := <-ch:
@@ -163,6 +179,9 @@ func serveGroupSSE(w http.ResponseWriter, r *http.Request, broker *SSEBroker, to
 			}
 		case <-r.Context().Done():
 			return // client disconnected
+		case <-maxDurC:
+			writeMaxDurationClose(w)
+			return
 		}
 	}
 }

--- a/handler.go
+++ b/handler.go
@@ -2,7 +2,9 @@ package tavern
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"net/http"
+	"time"
 )
 
 // SSEWriterFunc writes a message to the HTTP response. It is called for each
@@ -24,10 +26,24 @@ func WithSSEWriter(fn SSEWriterFunc) SSEHandlerOption {
 	}
 }
 
+// WithMaxConnectionDuration sets a maximum lifetime for SSE connections. After
+// the configured duration (plus 0-10% random jitter to prevent thundering herd),
+// the handler sends a retry: directive and an SSE comment, then closes the
+// connection. The browser's EventSource will automatically reconnect with
+// Last-Event-ID, providing seamless resumption.
+//
+// A zero or negative duration disables the limit.
+func WithMaxConnectionDuration(d time.Duration) SSEHandlerOption {
+	return func(h *sseHandler) {
+		h.maxConnDuration = d
+	}
+}
+
 type sseHandler struct {
-	broker *SSEBroker
-	topic  string
-	writer SSEWriterFunc
+	broker          *SSEBroker
+	topic           string
+	writer          SSEWriterFunc
+	maxConnDuration time.Duration
 }
 
 // SSEHandler returns an [http.Handler] that streams SSE messages for the
@@ -91,6 +107,12 @@ func (h *sseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer unsub()
 
 	// Stream loop.
+	var maxDurC <-chan time.Time
+	if h.maxConnDuration > 0 {
+		actual := h.maxConnDuration + time.Duration(rand.Int64N(int64(h.maxConnDuration/10)))
+		maxDurC = time.After(actual)
+	}
+
 	for {
 		select {
 		case msg, ok := <-ch:
@@ -102,6 +124,19 @@ func (h *sseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		case <-r.Context().Done():
 			return // client disconnected
+		case <-maxDurC:
+			writeMaxDurationClose(w)
+			return
 		}
+	}
+}
+
+// writeMaxDurationClose writes the retry hint and comment before closing a
+// connection that has reached its maximum duration.
+func writeMaxDurationClose(w http.ResponseWriter) {
+	fmt.Fprint(w, "retry: 1000\n\n")
+	fmt.Fprint(w, ": max connection duration reached\n\n")
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
 	}
 }

--- a/max_conn_duration_test.go
+++ b/max_conn_duration_test.go
@@ -1,0 +1,273 @@
+package tavern
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaxConnectionDuration_Basic(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	handler := b.SSEHandler("events", WithMaxConnectionDuration(100*time.Millisecond))
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse", http.NoBody)
+
+	start := time.Now()
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not return after max connection duration")
+	}
+
+	elapsed := time.Since(start)
+	// Should close between 100ms and 110ms + some tolerance for scheduling.
+	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond, "closed too early")
+	assert.Less(t, elapsed, 200*time.Millisecond, "closed too late (jitter should be at most 10%)")
+}
+
+func TestMaxConnectionDuration_Jitter(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	const n = 10
+	durations := make([]time.Duration, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+
+	for i := range n {
+		go func(idx int) {
+			defer wg.Done()
+			handler := b.SSEHandler("events", WithMaxConnectionDuration(100*time.Millisecond))
+			rec := newFlushRecorder()
+			req := httptest.NewRequest("GET", "/sse", http.NoBody)
+			start := time.Now()
+			handler.ServeHTTP(rec, req)
+			durations[idx] = time.Since(start)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Check that not all durations are identical — at least two differ by > 1ms.
+	allSame := true
+	for i := 1; i < n; i++ {
+		diff := durations[i] - durations[0]
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > time.Millisecond {
+			allSame = false
+			break
+		}
+	}
+	assert.False(t, allSame, "expected jitter to produce varying durations, got: %v", durations)
+}
+
+func TestMaxConnectionDuration_RetryDirective(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	handler := b.SSEHandler("events", WithMaxConnectionDuration(50*time.Millisecond))
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse", http.NoBody)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not return")
+	}
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "retry: 1000\n\n", "should contain retry directive")
+	assert.Contains(t, body, ": max connection duration reached\n\n", "should contain close comment")
+
+	// Retry should come before the comment.
+	retryIdx := strings.Index(body, "retry: 1000")
+	commentIdx := strings.Index(body, ": max connection duration reached")
+	assert.Less(t, retryIdx, commentIdx, "retry directive should precede close comment")
+}
+
+func TestMaxConnectionDuration_LastEventIDReplay(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	b.PublishWithID("events", "1", "msg-1")
+	b.PublishWithID("events", "2", "msg-2")
+	b.PublishWithID("events", "3", "msg-3")
+
+	// First connection: short max duration, no Last-Event-ID.
+	handler := b.SSEHandler("events", WithMaxConnectionDuration(50*time.Millisecond))
+
+	rec1 := newFlushRecorder()
+	req1 := httptest.NewRequest("GET", "/sse", http.NoBody)
+
+	done1 := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec1, req1)
+		close(done1)
+	}()
+
+	select {
+	case <-done1:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first connection did not close")
+	}
+
+	// Second connection: reconnect with Last-Event-ID "1", should replay 2 and 3.
+	rec2 := newFlushRecorder()
+	req2 := httptest.NewRequest("GET", "/sse", http.NoBody)
+	req2.Header.Set("Last-Event-ID", "1")
+	ctx2, cancel2 := contextWithCancel(req2)
+	req2 = req2.WithContext(ctx2)
+
+	handler2 := b.SSEHandler("events", WithMaxConnectionDuration(200*time.Millisecond))
+	done2 := make(chan struct{})
+	go func() {
+		handler2.ServeHTTP(rec2, req2)
+		close(done2)
+	}()
+
+	// Give time for replay.
+	time.Sleep(50 * time.Millisecond)
+	cancel2()
+	<-done2
+
+	body := rec2.Body.String()
+	assert.Contains(t, body, "msg-2")
+	assert.Contains(t, body, "msg-3")
+	assert.NotContains(t, body, "msg-1")
+}
+
+func TestMaxConnectionDuration_GroupHandler(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.DefineGroup("dash", []string{"metrics", "alerts"})
+	handler := b.GroupHandler("dash", WithMaxConnectionDuration(100*time.Millisecond))
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/dash", http.NoBody)
+
+	// Publish some data so we can verify messages flow before close.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		b.Publish("metrics", "cpu=42")
+	}()
+
+	start := time.Now()
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not return after max connection duration")
+	}
+
+	elapsed := time.Since(start)
+	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond)
+	assert.Less(t, elapsed, 200*time.Millisecond)
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "retry: 1000")
+	assert.Contains(t, body, ": max connection duration reached")
+	assert.Contains(t, body, "cpu=42")
+}
+
+func TestMaxConnectionDuration_DynamicGroupHandler(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.DynamicGroup("dyn", func(_ *http.Request) []string {
+		return []string{"a", "b"}
+	})
+	handler := b.DynamicGroupHandler("dyn", WithMaxConnectionDuration(100*time.Millisecond))
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/dyn", http.NoBody)
+
+	start := time.Now()
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not return after max connection duration")
+	}
+
+	elapsed := time.Since(start)
+	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond)
+	assert.Less(t, elapsed, 200*time.Millisecond)
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "retry: 1000")
+	assert.Contains(t, body, ": max connection duration reached")
+}
+
+func TestMaxConnectionDuration_Zero_Disabled(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	// WithMaxConnectionDuration(0) should be a no-op.
+	handler := b.SSEHandler("events", WithMaxConnectionDuration(0))
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse", http.NoBody)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	// Should not close on its own within 150ms.
+	time.Sleep(150 * time.Millisecond)
+	select {
+	case <-done:
+		t.Fatal("handler should not have returned with zero duration")
+	default:
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not return after context cancel")
+	}
+
+	// Body should not contain the close comment.
+	require.NotContains(t, rec.Body.String(), ": max connection duration reached")
+}


### PR DESCRIPTION
## Summary

- Add `WithMaxConnectionDuration(d time.Duration)` handler option that forces periodic reconnects after a configurable duration
- Jitter of 0-10% prevents thundering herd when many connections share the same duration
- Before closing, sends `retry: 1000` directive and SSE comment for graceful shutdown; browser EventSource auto-reconnects with `Last-Event-ID`
- Works with `SSEHandler`, `GroupHandler`, and `DynamicGroupHandler`

## Test plan

- [x] Basic: connection closes after duration
- [x] Jitter: multiple connections don't all close at exactly the same time
- [x] Retry hint: verify the `retry:` directive is sent before close
- [x] Integration with Last-Event-ID: publish with IDs, let connection close, reconnect with Last-Event-ID, verify replay works
- [x] GroupHandler variant works
- [x] DynamicGroupHandler variant works
- [x] Zero duration disables the feature
- [x] All tests pass with `-race`
- [x] Lint passes

Closes #135