### PR TITLE
fix: use jsdelivr CDN for tavern-js references

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ and translates them into declarative UI behaviors — reconnection overlays,
 gap recovery, and topic change notifications — with zero custom JavaScript:
 
 ```html
-<script src="https://unpkg.com/tavern-sse/dist/tavern.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/catgoose/tavern-js@latest/dist/tavern.min.js"></script>
 <div sse-connect="/sse/notifications"
      sse-swap="message"
      data-tavern-reconnecting-class="opacity-50"

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -1498,7 +1498,7 @@ mux.Handle("/sse/dashboard", broker.SSEHandler("dashboard",
 ### Client (HTML + tavern.js)
 
 ```html
-<script src="https://unpkg.com/tavern-sse/dist/tavern.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/catgoose/tavern-js@latest/dist/tavern.min.js"></script>
 
 <div id="dashboard"
      sse-connect="/sse/dashboard"


### PR DESCRIPTION
Updates tavern-js CDN URLs from unpkg to jsdelivr — npm publishing was removed in favor of GitHub Releases + jsdelivr.