### PR TITLE
fix: route Batch.Flush() through normal publish pipeline

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -59,9 +59,16 @@ func (pb *PublishBatch) Discard() {
 	pb.mu.Unlock()
 }
 
-// Flush sends all buffered messages. For each subscriber, messages are
-// concatenated into a single channel send to minimise SSE writes. Flush
-// should be called at most once; the batch is empty afterwards.
+// Flush sends all buffered messages. For each unique (topic, scope)
+// combination the individual messages are concatenated, then routed through
+// the same publish pipeline as [SSEBroker.Publish] / [SSEBroker.PublishTo]
+// — middleware, rate limiting, filters, adaptive backpressure, glob
+// subscribers, backend publish, observability, and after-hooks all execute
+// exactly as they would for a regular publish. The concatenation preserves
+// the batch's value proposition: each subscriber receives a single channel
+// write containing all messages for that topic.
+//
+// Flush should be called at most once; the batch is empty afterwards.
 func (pb *PublishBatch) Flush() {
 	pb.mu.Lock()
 	ops := pb.ops
@@ -72,87 +79,39 @@ func (pb *PublishBatch) Flush() {
 		return
 	}
 
+	// Group messages by (topic, scope, scoped) and concatenate in order.
+	type groupKey struct {
+		topic  string
+		scope  string
+		scoped bool
+	}
+	type group struct {
+		key groupKey
+		msg string
+	}
+	seen := make(map[groupKey]int) // key → index in groups slice
+	var groups []group
+
+	for _, op := range ops {
+		k := groupKey{topic: op.topic, scope: op.scope, scoped: op.scoped}
+		if idx, ok := seen[k]; ok {
+			groups[idx].msg += op.msg
+		} else {
+			seen[k] = len(groups)
+			groups = append(groups, group{key: k, msg: op.msg})
+		}
+	}
+
 	b := pb.broker
 
-	// Build a map of channel → concatenated message.
-	// We need to resolve each op to its target channels.
-	chanMsgs := make(map[chan string]string)
-
-	// Track topics touched for metrics.
-	type metricsAcc struct {
-		sent    int
-		dropped int
-	}
-	topicMetrics := make(map[string]*metricsAcc)
-
-	b.mu.RLock()
-	for _, op := range ops {
-		if op.scoped {
-			scopedSubs := b.scopedTopics[op.topic]
-			for ch, sub := range scopedSubs {
-				if sub.scope == op.scope {
-					chanMsgs[ch] += op.msg
-				}
-			}
+	// Dispatch each group through the normal publish path. The middleware,
+	// publishToChannels, glob dispatch, backend publish, observability, and
+	// after-hooks all fire exactly as they do for Publish/PublishTo.
+	for _, g := range groups {
+		if g.key.scoped {
+			b.PublishTo(g.key.topic, g.key.scope, g.msg)
 		} else {
-			for ch := range b.topics[op.topic] {
-				chanMsgs[ch] += op.msg
-			}
-		}
-	}
-	b.mu.RUnlock()
-
-	// Now send one concatenated message per channel.
-	for ch, msg := range chanMsgs {
-		// Determine topic for metrics/eviction by looking up subscriber info.
-		topic := ""
-		if b.metrics != nil || b.evictThreshold > 0 {
-			b.mu.RLock()
-			if info, ok := b.subscriberMeta[ch]; ok {
-				topic = info.Topic
-			}
-			b.mu.RUnlock()
-		}
-
-		func() {
-			defer func() { _ = recover() }()
-			if b.send(ch, msg) {
-				if b.evictThreshold > 0 {
-					b.resetDropCount(ch)
-				}
-				if b.metrics != nil && topic != "" {
-					acc := topicMetrics[topic]
-					if acc == nil {
-						acc = &metricsAcc{}
-						topicMetrics[topic] = acc
-					}
-					acc.sent++
-				}
-			} else {
-				b.drops.Add(1)
-				if b.evictThreshold > 0 && topic != "" {
-					if b.incrementDropCount(ch) >= int64(b.evictThreshold) {
-						b.evictSubscriber(topic, ch)
-					}
-				}
-				if b.metrics != nil && topic != "" {
-					acc := topicMetrics[topic]
-					if acc == nil {
-						acc = &metricsAcc{}
-						topicMetrics[topic] = acc
-					}
-					acc.dropped++
-				}
-			}
-		}()
-	}
-
-	// Update metrics.
-	if b.metrics != nil {
-		for topic, acc := range topicMetrics {
-			tc := b.metrics.counter(topic)
-			tc.published.Add(int64(acc.sent))
-			tc.dropped.Add(int64(acc.dropped))
+			b.Publish(g.key.topic, g.msg)
 		}
 	}
 }

--- a/batch_test.go
+++ b/batch_test.go
@@ -397,3 +397,91 @@ func TestBatchMultipleScopedSubscribersSameScope(t *testing.T) {
 	sort.Strings(msgs)
 	assert.Equal(t, []string{"msg", "msg"}, msgs)
 }
+
+func TestBatchFlushFiresAfterHooks(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	var hookCalled int32
+	done := make(chan struct{}, 2)
+	b.After("t", func() {
+		hookCalled++
+		done <- struct{}{}
+	})
+
+	batch := b.Batch()
+	batch.Publish("t", "one")
+	batch.Publish("t", "two")
+	batch.Flush()
+
+	// Drain the message.
+	_, ok := recv(ch, time.Second)
+	require.True(t, ok)
+
+	// Wait for the after hook to fire.
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("after hook was not called")
+	}
+	assert.Equal(t, int32(1), hookCalled)
+}
+
+func TestBatchFlushDispatchesToGlobSubscribers(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	// Regular subscriber.
+	ch, unsub := b.Subscribe("events/click")
+	defer unsub()
+
+	// Glob subscriber matching the topic.
+	globCh, globUnsub := b.SubscribeGlob("events/*")
+	defer globUnsub()
+
+	batch := b.Batch()
+	batch.Publish("events/click", "a")
+	batch.Publish("events/click", "b")
+	batch.Flush()
+
+	// Regular subscriber gets concatenated message.
+	msg, ok := recv(ch, time.Second)
+	require.True(t, ok)
+	assert.Equal(t, "ab", msg)
+
+	// Glob subscriber should also receive the message.
+	select {
+	case tm := <-globCh:
+		assert.Equal(t, "events/click", tm.Topic)
+		assert.Equal(t, "ab", tm.Data)
+	case <-time.After(time.Second):
+		t.Fatal("glob subscriber did not receive batch message")
+	}
+}
+
+func TestBatchFlushRunsMiddleware(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	var middlewareCalled int32
+	b.Use(func(next PublishFunc) PublishFunc {
+		return func(topic, msg string) {
+			middlewareCalled++
+			next(topic, msg)
+		}
+	})
+
+	ch, unsub := b.Subscribe("t")
+	defer unsub()
+
+	batch := b.Batch()
+	batch.Publish("t", "hello")
+	batch.Flush()
+
+	_, ok := recv(ch, time.Second)
+	require.True(t, ok)
+	assert.Equal(t, int32(1), middlewareCalled)
+}


### PR DESCRIPTION
## Summary

- `Batch.Flush()` was bypassing the normal publish pipeline by writing directly to subscriber channels via `b.send()`, skipping middleware, after hooks, glob subscriber dispatch, rate limiting, filters, coalescing, adaptive backpressure, backend publish, and observability
- Reworked `Flush()` to group buffered ops by (topic, scope), concatenate messages per group, then dispatch each group through `Publish()` / `PublishTo()` — preserving atomic single-write-per-subscriber semantics while using the full delivery path
- Added tests verifying after hooks fire, glob subscribers receive messages, and middleware executes for batch-published messages

Fixes #141

## Test plan

- [x] All existing batch tests pass (atomicity, concatenation, scoped isolation, drop counting)
- [x] New test: after hooks fire for batch-published messages
- [x] New test: glob subscribers receive batch-published messages
- [x] New test: middleware runs for batch-published messages
- [x] Full test suite passes (`go test ./...`)