### PR TITLE
fix: emit SSE id fields on the wire for PublishWithID

### DIFF
--- a/gap_test.go
+++ b/gap_test.go
@@ -44,7 +44,8 @@ func TestSubscribeFromID_GapSilentDefault(t *testing.T) {
 	b.PublishWithID("events", "6", "live")
 	select {
 	case msg := <-ch:
-		assert.Equal(t, "live", msg)
+		assert.Contains(t, msg, "live")
+		assert.Contains(t, msg, "id: 6")
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for live message")
 	}
@@ -329,7 +330,8 @@ func TestSubscribeFromID_GapWithLiveMessages(t *testing.T) {
 	b.PublishWithID("events", "4", "live")
 	select {
 	case msg := <-ch:
-		assert.Equal(t, "live", msg)
+		assert.Contains(t, msg, "live")
+		assert.Contains(t, msg, "id: 4")
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for live message")
 	}

--- a/handler_test.go
+++ b/handler_test.go
@@ -212,6 +212,106 @@ func TestSSEHandler_GapDetection(t *testing.T) {
 	assert.NotContains(t, body, "msg-1")
 }
 
+func TestSSEHandler_PublishWithID_EmitsIDField(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+
+	handler := b.SSEHandler("events")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse", http.NoBody)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	// Wait for subscription to establish, then publish.
+	time.Sleep(20 * time.Millisecond)
+	b.PublishWithID("events", "evt-42", NewSSEMessage("update", "hello").String())
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "event: update")
+	assert.Contains(t, body, "data: hello")
+	assert.Contains(t, body, "id: evt-42")
+}
+
+func TestSSEHandler_PublishWithID_ReplayContainsIDField(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	b.PublishWithID("events", "1", NewSSEMessage("update", "first").String())
+	b.PublishWithID("events", "2", NewSSEMessage("update", "second").String())
+	b.PublishWithID("events", "3", NewSSEMessage("update", "third").String())
+
+	handler := b.SSEHandler("events")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse", http.NoBody)
+	req.Header.Set("Last-Event-ID", "1")
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+	// Replayed messages should contain id fields.
+	assert.Contains(t, body, "id: 2")
+	assert.Contains(t, body, "id: 3")
+	assert.Contains(t, body, "data: second")
+	assert.Contains(t, body, "data: third")
+	// ID 1 should not be replayed.
+	assert.NotContains(t, body, "data: first")
+}
+
+func TestSSEHandler_RegularPublish_NoIDField(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	handler := b.SSEHandler("events")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse", http.NoBody)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	b.Publish("events", NewSSEMessage("update", "no-id").String())
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "event: update")
+	assert.Contains(t, body, "data: no-id")
+	assert.NotContains(t, body, "id:")
+}
+
 // contextWithCancel creates a cancellable context from a request.
 func contextWithCancel(r *http.Request) (context.Context, context.CancelFunc) {
 	return context.WithCancel(r.Context())

--- a/message.go
+++ b/message.go
@@ -60,3 +60,49 @@ func (m SSEMessage) WithRetry(ms int) SSEMessage {
 	m.Retry = ms
 	return m
 }
+
+// injectSSEID injects an "id: <id>" field into an SSE message string. If the
+// message already contains an id: field, it is replaced. If the message is a
+// properly terminated SSE frame (ending with \n\n), the id field is inserted
+// before the final blank line. Otherwise it is prepended.
+func injectSSEID(msg, id string) string {
+	if id == "" {
+		return msg
+	}
+
+	idLine := fmt.Sprintf("id: %s", id)
+
+	// Remove any existing id: field to avoid duplicates.
+	lines := strings.Split(msg, "\n")
+	var filtered []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "id:") {
+			continue
+		}
+		filtered = append(filtered, line)
+	}
+
+	// Rebuild the message. If it ended with \n\n (SSE frame terminator),
+	// the split produces trailing empty strings. Insert id before those.
+	// Find the last non-empty line index.
+	lastNonEmpty := -1
+	for i := len(filtered) - 1; i >= 0; i-- {
+		if filtered[i] != "" {
+			lastNonEmpty = i
+			break
+		}
+	}
+
+	if lastNonEmpty < 0 {
+		// Message was empty or all blank lines; just return id field as SSE frame.
+		return idLine + "\n\n"
+	}
+
+	// Insert id line after the last non-empty line, before trailing empty lines.
+	var result []string
+	result = append(result, filtered[:lastNonEmpty+1]...)
+	result = append(result, idLine)
+	result = append(result, filtered[lastNonEmpty+1:]...)
+	return strings.Join(result, "\n")
+}

--- a/message_test.go
+++ b/message_test.go
@@ -119,3 +119,42 @@ func TestSSEMessage_SingleLineData(t *testing.T) {
 	assert.Equal(t, 1, count)
 	assert.Contains(t, got, "data: hello\n")
 }
+
+func TestInjectSSEID_RawString(t *testing.T) {
+	got := injectSSEID("hello", "42")
+	assert.Contains(t, got, "hello")
+	assert.Contains(t, got, "id: 42")
+}
+
+func TestInjectSSEID_EmptyID(t *testing.T) {
+	msg := "hello"
+	got := injectSSEID(msg, "")
+	assert.Equal(t, msg, got)
+}
+
+func TestInjectSSEID_FormattedSSE(t *testing.T) {
+	msg := "event: update\ndata: payload\n\n"
+	got := injectSSEID(msg, "evt-1")
+	assert.Contains(t, got, "event: update")
+	assert.Contains(t, got, "data: payload")
+	assert.Contains(t, got, "id: evt-1")
+	assert.True(t, strings.HasSuffix(got, "\n\n"), "must preserve SSE frame terminator")
+}
+
+func TestInjectSSEID_ReplacesExistingID(t *testing.T) {
+	msg := "event: update\ndata: payload\nid: old-id\n\n"
+	got := injectSSEID(msg, "new-id")
+	assert.Contains(t, got, "id: new-id")
+	assert.NotContains(t, got, "old-id")
+	// Only one id: field.
+	assert.Equal(t, 1, strings.Count(got, "id:"))
+}
+
+func TestInjectSSEID_MultilineData(t *testing.T) {
+	msg := "event: update\ndata: line1\ndata: line2\n\n"
+	got := injectSSEID(msg, "ml-1")
+	assert.Contains(t, got, "data: line1")
+	assert.Contains(t, got, "data: line2")
+	assert.Contains(t, got, "id: ml-1")
+	assert.True(t, strings.HasSuffix(got, "\n\n"))
+}

--- a/reconnect_test.go
+++ b/reconnect_test.go
@@ -257,10 +257,11 @@ func TestReconnectedControlEvent(t *testing.T) {
 		t.Fatal("no control event received")
 	}
 
-	// Then the replayed message.
+	// Then the replayed message (with id field injected).
 	select {
 	case msg := <-ch:
-		assert.Equal(t, "msg-2", msg)
+		assert.Contains(t, msg, "msg-2")
+		assert.Contains(t, msg, "id: 2")
 	case <-time.After(time.Second):
 		t.Fatal("no replay message received")
 	}
@@ -323,16 +324,18 @@ func TestBundleOnReconnect_Disabled(t *testing.T) {
 	// Skip control event.
 	<-ch
 
-	// Should receive individual messages.
+	// Should receive individual messages (with id fields injected).
 	select {
 	case msg := <-ch:
-		assert.Equal(t, "msg-2", msg)
+		assert.Contains(t, msg, "msg-2")
+		assert.Contains(t, msg, "id: 2")
 	case <-time.After(time.Second):
 		t.Fatal("no first replay")
 	}
 	select {
 	case msg := <-ch:
-		assert.Equal(t, "msg-3", msg)
+		assert.Contains(t, msg, "msg-3")
+		assert.Contains(t, msg, "id: 3")
 	case <-time.After(time.Second):
 		t.Fatal("no second replay")
 	}
@@ -370,18 +373,21 @@ func TestBundleOnReconnect_NoLastEventID(t *testing.T) {
 	b.PublishWithID("events", "2", "msg-2")
 
 	// Subscribe without Last-Event-ID: should get individual replays, no bundling.
+	// Messages include id fields since they come from the replayLog.
 	ch, unsub := b.SubscribeFromID("events", "")
 	defer unsub()
 
 	select {
 	case msg := <-ch:
-		assert.Equal(t, "msg-1", msg)
+		assert.Contains(t, msg, "msg-1")
+		assert.Contains(t, msg, "id: 1")
 	case <-time.After(time.Second):
 		t.Fatal("no first replay")
 	}
 	select {
 	case msg := <-ch:
-		assert.Equal(t, "msg-2", msg)
+		assert.Contains(t, msg, "msg-2")
+		assert.Contains(t, msg, "id: 2")
 	case <-time.After(time.Second):
 		t.Fatal("no second replay")
 	}
@@ -643,10 +649,11 @@ func TestBundleOnReconnect_SingleMessage(t *testing.T) {
 	// Skip control event.
 	<-ch
 
-	// Single bundled message containing only msg-2.
+	// Single bundled message containing only msg-2 (with id field).
 	select {
 	case msg := <-ch:
-		assert.Equal(t, "msg-2", msg)
+		assert.Contains(t, msg, "msg-2")
+		assert.Contains(t, msg, "id: 2")
 	case <-time.After(time.Second):
 		t.Fatal("no bundled replay received")
 	}

--- a/resume.go
+++ b/resume.go
@@ -60,7 +60,8 @@ func (b *SSEBroker) PublishWithID(topic, id, msg string) {
 	}
 	b.mu.Unlock()
 
-	sent, dropped := b.publishToChannels(topic, channels, msg)
+	wireMsg := injectSSEID(msg, id)
+	sent, dropped := b.publishToChannels(topic, channels, wireMsg)
 	if b.metrics != nil {
 		tc := b.metrics.counter(topic)
 		tc.published.Add(int64(sent))
@@ -118,7 +119,7 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 				if !e.ExpiresAt.IsZero() && now.After(e.ExpiresAt) {
 					continue
 				}
-				replayMsgs = append(replayMsgs, e.Msg)
+				replayMsgs = append(replayMsgs, injectSSEID(e.Msg, e.ID))
 			}
 		} else {
 			replayMsgs = append([]string(nil), b.replayCache[topic]...)
@@ -134,7 +135,7 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 					if !e.ExpiresAt.IsZero() && now.After(e.ExpiresAt) {
 						continue
 					}
-					replayMsgs = append(replayMsgs, e.Msg)
+					replayMsgs = append(replayMsgs, injectSSEID(e.Msg, e.ID))
 				}
 				break
 			}

--- a/resume_test.go
+++ b/resume_test.go
@@ -21,7 +21,8 @@ func TestPublishWithID_BasicDelivery(t *testing.T) {
 
 	select {
 	case msg := <-ch:
-		assert.Equal(t, "hello", msg)
+		assert.Contains(t, msg, "hello")
+		assert.Contains(t, msg, "id: id-1")
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for message")
 	}
@@ -56,7 +57,11 @@ func TestSubscribeFromID_ReplaysAfterID(t *testing.T) {
 			t.Fatal("timed out waiting for replay message")
 		}
 	}
-	assert.Equal(t, []string{"msg-4", "msg-5"}, got)
+	require.Len(t, got, 2)
+	assert.Contains(t, got[0], "msg-4")
+	assert.Contains(t, got[0], "id: 4")
+	assert.Contains(t, got[1], "msg-5")
+	assert.Contains(t, got[1], "id: 5")
 
 	// Verify no more replay messages are buffered.
 	select {
@@ -87,7 +92,11 @@ func TestSubscribeFromID_EmptyID(t *testing.T) {
 			t.Fatal("timed out waiting for replay message")
 		}
 	}
-	assert.Equal(t, []string{"msg-1", "msg-2", "msg-3"}, got)
+	require.Len(t, got, 3)
+	for i, msg := range got {
+		assert.Contains(t, msg, fmt.Sprintf("msg-%d", i+1))
+		assert.Contains(t, msg, fmt.Sprintf("id: %d", i+1))
+	}
 }
 
 func TestSubscribeFromID_UnknownID(t *testing.T) {
@@ -121,7 +130,8 @@ func TestSubscribeFromID_UnknownID(t *testing.T) {
 	b.PublishWithID("events", "4", "live-msg")
 	select {
 	case msg := <-ch:
-		assert.Equal(t, "live-msg", msg)
+		assert.Contains(t, msg, "live-msg")
+		assert.Contains(t, msg, "id: 4")
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for live message")
 	}
@@ -178,7 +188,13 @@ func TestPublishWithID_RespectsReplayPolicy(t *testing.T) {
 			t.Fatal("timed out waiting for replay message")
 		}
 	}
-	assert.Equal(t, []string{"msg-3", "msg-4", "msg-5"}, got)
+	require.Len(t, got, 3)
+	assert.Contains(t, got[0], "msg-3")
+	assert.Contains(t, got[0], "id: 3")
+	assert.Contains(t, got[1], "msg-4")
+	assert.Contains(t, got[1], "id: 4")
+	assert.Contains(t, got[2], "msg-5")
+	assert.Contains(t, got[2], "id: 5")
 }
 
 func TestPublishWithID_AfterClose(t *testing.T) {
@@ -223,6 +239,9 @@ func TestPublishWithID_UpdatesRegularReplayCache(t *testing.T) {
 	}
 
 	// Regular Subscribe should also get the replay from PublishWithID.
+	// Note: replayCache stores raw messages without IDs, so regular Subscribe
+	// gets raw messages on replay (IDs are only injected for live delivery
+	// and SubscribeFromID replay).
 	ch, unsub := b.Subscribe("events")
 	defer unsub()
 
@@ -236,4 +255,108 @@ func TestPublishWithID_UpdatesRegularReplayCache(t *testing.T) {
 		}
 	}
 	assert.Equal(t, []string{"msg-1", "msg-2", "msg-3"}, got)
+}
+
+func TestPublishWithID_SSEFormattedMessage(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("events")
+	defer unsub()
+
+	// Publish a pre-formatted SSE message with PublishWithID.
+	sseMsg := NewSSEMessage("update", "payload").String()
+	b.PublishWithID("events", "evt-42", sseMsg)
+
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: update")
+		assert.Contains(t, msg, "data: payload")
+		assert.Contains(t, msg, "id: evt-42")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+}
+
+func TestPublishWithID_SSEMessageWithExistingID(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("events")
+	defer unsub()
+
+	// Publish a pre-formatted SSE message that already has an id field.
+	// PublishWithID should replace it with the new id.
+	sseMsg := NewSSEMessage("update", "payload").WithID("old-id").String()
+	b.PublishWithID("events", "new-id", sseMsg)
+
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: update")
+		assert.Contains(t, msg, "data: payload")
+		assert.Contains(t, msg, "id: new-id")
+		assert.NotContains(t, msg, "old-id")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+}
+
+func TestPublishWithID_RegularPublishNoID(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.Subscribe("events")
+	defer unsub()
+
+	// Regular Publish should not add any id field.
+	b.Publish("events", "plain-message")
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "plain-message", msg)
+		assert.NotContains(t, msg, "id:")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+}
+
+func TestPublishWithID_RoundTrip(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+
+	// Publish with IDs.
+	b.PublishWithID("events", "evt-1", NewSSEMessage("update", "first").String())
+	b.PublishWithID("events", "evt-2", NewSSEMessage("update", "second").String())
+	b.PublishWithID("events", "evt-3", NewSSEMessage("update", "third").String())
+
+	// Simulate reconnect from evt-1: should replay evt-2 and evt-3 with id fields.
+	ch, unsub := b.SubscribeFromID("events", "evt-1")
+	defer unsub()
+
+	// Drain reconnected control event.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reconnected control event")
+	}
+
+	// Replayed messages should contain id fields.
+	for _, expected := range []struct {
+		data string
+		id   string
+	}{
+		{"second", "evt-2"},
+		{"third", "evt-3"},
+	} {
+		select {
+		case msg := <-ch:
+			assert.Contains(t, msg, "data: "+expected.data)
+			assert.Contains(t, msg, "id: "+expected.id)
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for replay of %s", expected.id)
+		}
+	}
 }

--- a/subscribe_options_test.go
+++ b/subscribe_options_test.go
@@ -253,7 +253,8 @@ func TestPublishBatch_PublishWithID(t *testing.T) {
 
 	select {
 	case msg := <-ch:
-		assert.Equal(t, "id-msg", msg)
+		assert.Contains(t, msg, "id-msg")
+		assert.Contains(t, msg, "id: id-1")
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("timeout")
 	}

--- a/taverntest/simulated_connection.go
+++ b/taverntest/simulated_connection.go
@@ -1,6 +1,7 @@
 package taverntest
 
 import (
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -172,13 +173,13 @@ func (sc *SimulatedConnection) AssertReceivedAfterReconnect(t testing.TB, expect
 	for _, exp := range expected {
 		found := false
 		for _, msg := range sc.reconnectMsgs {
-			if msg == exp {
+			if msg == exp || strings.Contains(msg, exp) {
 				found = true
 				break
 			}
 		}
 		if !found {
-			t.Errorf("expected message %q not found in reconnect messages", exp)
+			t.Errorf("expected message %q not found in reconnect messages: %v", exp, sc.reconnectMsgs)
 		}
 	}
 }

--- a/ttl_test.go
+++ b/ttl_test.go
@@ -308,7 +308,9 @@ func TestPublishWithTTL_SubscribeFromID_FiltersExpired(t *testing.T) {
 			t.Fatal("timed out")
 		}
 	}
-	assert.Equal(t, []string{"msg-2"}, got)
+	require.Len(t, got, 1)
+	assert.Contains(t, got[0], "msg-2")
+	assert.Contains(t, got[0], "id: 2")
 
 	// No more messages.
 	select {
@@ -346,7 +348,11 @@ func TestPublishWithTTL_SubscribeFromID_EmptyID_FiltersExpired(t *testing.T) {
 			t.Fatal("timed out")
 		}
 	}
-	assert.Equal(t, []string{"alive", "also-alive"}, got)
+	require.Len(t, got, 2)
+	assert.Contains(t, got[0], "alive")
+	assert.Contains(t, got[0], "id: 1")
+	assert.Contains(t, got[1], "also-alive")
+	assert.Contains(t, got[1], "id: 3")
 }
 
 func TestPublishWithTTL_MultipleAutoRemove(t *testing.T) {


### PR DESCRIPTION
## Summary
- `PublishWithID` was storing the event ID in the replay log but sending the raw message to subscribers without the `id:` field, so browsers never received SSE `id:` and could not send `Last-Event-ID` on reconnect
- Added `injectSSEID` helper in `message.go` that inserts or replaces an `id:` field in an SSE message string
- Applied the helper in `PublishWithID` for live delivery and in `SubscribeFromID` for replay delivery

## Test plan
- [x] All existing tests updated and passing
- [x] New test: `TestSSEHandler_PublishWithID_EmitsIDField` — verifies handler output contains `id:` for live messages
- [x] New test: `TestSSEHandler_PublishWithID_ReplayContainsIDField` — verifies replayed messages contain `id:` fields
- [x] New test: `TestSSEHandler_RegularPublish_NoIDField` — verifies regular Publish does not add `id:`
- [x] New test: `TestPublishWithID_RoundTrip` — full round-trip: publish with ID, reconnect with Last-Event-ID, verify replay with `id:` fields
- [x] New test: `TestPublishWithID_SSEFormattedMessage` — pre-formatted SSE messages get `id:` injected
- [x] New test: `TestPublishWithID_SSEMessageWithExistingID` — existing `id:` field is replaced, not duplicated
- [x] Unit tests for `injectSSEID` helper covering raw strings, formatted SSE, existing ID replacement, multiline data

Fixes #143