### PR TITLE
fix: grouped SSE resumption double-wraps and loses IDs

### DIFF
--- a/group.go
+++ b/group.go
@@ -173,7 +173,7 @@ func serveGroupSSE(w http.ResponseWriter, r *http.Request, broker *SSEBroker, to
 			if !ok {
 				return // broker closed
 			}
-			sseMsg := NewSSEMessage(msg.Topic, msg.Data).String()
+			sseMsg := wrapForGroup(msg.Topic, msg.Data)
 			if err := writer(w, sseMsg); err != nil {
 				return // client disconnected
 			}
@@ -217,7 +217,7 @@ func (b *SSEBroker) subscribeMultiFromID(topics []string, lastEventID string, wr
 				if !ok {
 					break drainTopic
 				}
-				sseMsg := NewSSEMessage(topic, msg).String()
+				sseMsg := wrapForGroup(topic, msg)
 				if err := writer(w, sseMsg); err != nil {
 					// Clean up on write error.
 					for _, unsub := range unsubs {

--- a/group_test.go
+++ b/group_test.go
@@ -573,6 +573,160 @@ func TestDynamicGroupHandlerLastEventID(t *testing.T) {
 	assert.NotContains(t, body, "data: y1\n")
 }
 
+func TestGroupHandler_ReplayPreservesControlEvents(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("metrics", 10)
+	b.PublishWithID("metrics", "1", "m1")
+	b.PublishWithID("metrics", "2", "m2")
+
+	b.DefineGroup("dash", []string{"metrics"})
+	handler := b.GroupHandler("dash")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/dash", http.NoBody)
+	req.Header.Set("Last-Event-ID", "1")
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+
+	// The tavern-reconnected control event should appear as its own event type,
+	// NOT wrapped inside another event type (no double-wrapping).
+	assert.Contains(t, body, "event: tavern-reconnected\n",
+		"control event should appear with its own event type")
+	assert.NotContains(t, body, "data: event: tavern-reconnected",
+		"control event must not be nested inside a data field")
+}
+
+func TestGroupHandler_ReplayPreservesEventIDs(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("metrics", 10)
+	b.PublishWithID("metrics", "1", "m1")
+	b.PublishWithID("metrics", "2", "m2")
+	b.PublishWithID("metrics", "3", "m3")
+
+	b.DefineGroup("dash", []string{"metrics"})
+	handler := b.GroupHandler("dash")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/dash", http.NoBody)
+	req.Header.Set("Last-Event-ID", "1")
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+
+	// Replayed messages should preserve their event IDs.
+	assert.Contains(t, body, "id: 2\n", "event ID 2 should be preserved in replay")
+	assert.Contains(t, body, "id: 3\n", "event ID 3 should be preserved in replay")
+	// And the topic should be used as the event type.
+	assert.Contains(t, body, "event: metrics\n", "topic should be used as event type")
+}
+
+func TestGroupHandler_LiveMessagesPreserveIDs(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("alerts", 10)
+	b.DefineGroup("dash", []string{"alerts"})
+	handler := b.GroupHandler("dash")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/dash", http.NoBody)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	b.PublishWithID("alerts", "evt-42", "disk-full")
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "event: alerts\n", "topic should be event type")
+	assert.Contains(t, body, "data: disk-full\n", "payload should be in data field")
+	assert.Contains(t, body, "id: evt-42\n", "event ID should be preserved for live messages")
+}
+
+func TestGroupHandler_NoNestedControlEventsInReplay(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	// Set up two topics to exercise the multi-topic replay path.
+	b.SetReplayPolicy("t1", 10)
+	b.SetReplayPolicy("t2", 10)
+	b.PublishWithID("t1", "1", "msg-t1")
+	b.PublishWithID("t2", "1", "msg-t2")
+	b.PublishWithID("t1", "2", "msg-t1-2")
+	b.PublishWithID("t2", "2", "msg-t2-2")
+
+	b.DefineGroup("g", []string{"t1", "t2"})
+	handler := b.GroupHandler("g")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/g", http.NoBody)
+	req.Header.Set("Last-Event-ID", "1")
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+
+	// Verify no control event content appears nested inside data fields.
+	assert.NotContains(t, body, "data: event: tavern-",
+		"control events must not appear as data payloads")
+	assert.NotContains(t, body, "data: event: tavern-reconnected",
+		"tavern-reconnected must not be nested")
+
+	// Verify control events appear correctly.
+	assert.Contains(t, body, "event: tavern-reconnected\n",
+		"reconnected control event should be present")
+
+	// Verify replay payloads appear with correct topic event types and IDs.
+	assert.Contains(t, body, "event: t1\n")
+	assert.Contains(t, body, "event: t2\n")
+	assert.Contains(t, body, "id: 2\n")
+}
+
 // collectTopics drains n topic names from ch within the given timeout.
 func collectTopics(t *testing.T, ch <-chan string, n int, timeout time.Duration) []string {
 	t.Helper()

--- a/message.go
+++ b/message.go
@@ -61,6 +61,48 @@ func (m SSEMessage) WithRetry(ms int) SSEMessage {
 	return m
 }
 
+// isControlEvent reports whether msg is a tavern control event (e.g.,
+// tavern-reconnected, tavern-replay-gap). Control events are already
+// fully-formatted SSE frames and must not be re-wrapped.
+func isControlEvent(msg string) bool {
+	return strings.HasPrefix(msg, "event: tavern-")
+}
+
+// extractSSEID extracts the id field value from an SSE message string and
+// returns the message with the id field removed. If no id field is present, the
+// original message is returned unchanged with an empty id.
+func extractSSEID(msg string) (cleaned, id string) {
+	lines := strings.Split(msg, "\n")
+	var filtered []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "id:") {
+			id = strings.TrimSpace(strings.TrimPrefix(trimmed, "id:"))
+			continue
+		}
+		filtered = append(filtered, line)
+	}
+	if id == "" {
+		return msg, ""
+	}
+	return strings.Join(filtered, "\n"), id
+}
+
+// wrapForGroup formats a raw subscriber message for grouped SSE output. Control
+// events are forwarded as-is. Payload messages are wrapped with the topic as the
+// SSE event type, preserving any id field injected by PublishWithID.
+func wrapForGroup(topic, msg string) string {
+	if isControlEvent(msg) {
+		return msg
+	}
+	cleaned, id := extractSSEID(msg)
+	m := NewSSEMessage(topic, cleaned)
+	if id != "" {
+		m = m.WithID(id)
+	}
+	return m.String()
+}
+
 // injectSSEID injects an "id: <id>" field into an SSE message string. If the
 // message already contains an id: field, it is replaced. If the message is a
 // properly terminated SSE frame (ending with \n\n), the id field is inserted

--- a/message_test.go
+++ b/message_test.go
@@ -120,6 +120,67 @@ func TestSSEMessage_SingleLineData(t *testing.T) {
 	assert.Contains(t, got, "data: hello\n")
 }
 
+func TestIsControlEvent(t *testing.T) {
+	assert.True(t, isControlEvent("event: tavern-reconnected\ndata: \n\n"))
+	assert.True(t, isControlEvent("event: tavern-replay-gap\ndata: old-id\n\n"))
+	assert.False(t, isControlEvent("event: metrics\ndata: cpu=42\n\n"))
+	assert.False(t, isControlEvent("just raw text"))
+	assert.False(t, isControlEvent(""))
+}
+
+func TestExtractSSEID(t *testing.T) {
+	t.Run("no id", func(t *testing.T) {
+		msg := "hello"
+		cleaned, id := extractSSEID(msg)
+		assert.Equal(t, msg, cleaned)
+		assert.Empty(t, id)
+	})
+
+	t.Run("with id", func(t *testing.T) {
+		msg := "id: 42\nhello"
+		cleaned, id := extractSSEID(msg)
+		assert.Equal(t, "42", id)
+		assert.NotContains(t, cleaned, "id:")
+		assert.Contains(t, cleaned, "hello")
+	})
+
+	t.Run("id in SSE frame", func(t *testing.T) {
+		msg := "event: update\ndata: payload\nid: evt-7\n\n"
+		cleaned, id := extractSSEID(msg)
+		assert.Equal(t, "evt-7", id)
+		assert.NotContains(t, cleaned, "id:")
+		assert.Contains(t, cleaned, "event: update")
+		assert.Contains(t, cleaned, "data: payload")
+	})
+}
+
+func TestWrapForGroup(t *testing.T) {
+	t.Run("control event passed through", func(t *testing.T) {
+		ctrl := "event: tavern-reconnected\ndata: \n\n"
+		got := wrapForGroup("metrics", ctrl)
+		assert.Equal(t, ctrl, got, "control events should pass through unchanged")
+	})
+
+	t.Run("payload wrapped with topic", func(t *testing.T) {
+		got := wrapForGroup("metrics", "cpu=42")
+		assert.Contains(t, got, "event: metrics\n")
+		assert.Contains(t, got, "data: cpu=42\n")
+	})
+
+	t.Run("payload with id preserved", func(t *testing.T) {
+		got := wrapForGroup("alerts", "id: 7\ndisk-full")
+		assert.Contains(t, got, "event: alerts\n")
+		assert.Contains(t, got, "data: disk-full\n")
+		assert.Contains(t, got, "id: 7\n")
+	})
+
+	t.Run("gap control event passed through", func(t *testing.T) {
+		ctrl := replayGapControlEvent("old-id")
+		got := wrapForGroup("t1", ctrl)
+		assert.Equal(t, ctrl, got)
+	})
+}
+
 func TestInjectSSEID_RawString(t *testing.T) {
 	got := injectSSEID("hello", "42")
 	assert.Contains(t, got, "hello")


### PR DESCRIPTION
## Summary
- Fix `subscribeMultiFromID` replay drain and `serveGroupSSE` live loop to stop wrapping all messages from `SubscribeFromID` with `NewSSEMessage`, which corrupted control events and discarded event IDs
- Add `wrapForGroup()` helper that detects control events (already fully-formatted SSE frames) and passes them through unchanged, while extracting and re-attaching `id:` fields for payload messages
- Add tests verifying control events are not double-wrapped, event IDs are preserved in both replay and live paths, and no nested `tavern-reconnected` payloads appear in grouped output

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] New tests verify control events pass through without double-wrapping
- [x] New tests verify event IDs are preserved in grouped replay
- [x] New tests verify event IDs are preserved in live grouped messages
- [x] New tests verify no nested `tavern-reconnected` in multi-topic replay

Fixes #144