### PR TITLE
fix: detect and unwrap pre-formatted SSE in GroupHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,34 @@ broker.DynamicGroup("user-dashboard", func(r *http.Request) []string {
 mux.Handle("/sse/user", broker.DynamicGroupHandler("user-dashboard"))
 ```
 
+### SSEHandler vs GroupHandler message format
+
+`SSEHandler` and `GroupHandler` expect different message formats:
+
+- **SSEHandler** writes messages verbatim — callers pre-format with `NewSSEMessage(event, data).String()`.
+- **GroupHandler** wraps messages automatically, using the topic name as the SSE event type.
+
+GroupHandler detects pre-formatted SSE messages (those starting with `event:` or
+`data:`) and extracts the data payload before re-wrapping with the topic. This
+prevents double-wrapping when migrating from SSEHandler to GroupHandler, or when
+the same publish call serves both handler types.
+
+```go
+// Both of these produce correct output through a GroupHandler:
+broker.Publish("alerts", "disk-full")                              // raw string
+broker.Publish("alerts", NewSSEMessage("alert", "disk-full").String()) // pre-formatted
+
+// GroupHandler output in both cases:
+//   event: alerts
+//   data: disk-full
+```
+
+Control events (`tavern-reconnected`, `tavern-replay-gap`, etc.) always pass
+through unchanged regardless of format.
+
+When using HTMX with GroupHandler, set `sse-swap` attributes to match **topic
+names** (the SSE event type), not the original event names from `NewSSEMessage`.
+
 ### Snapshot + delta (SubscribeWithSnapshot)
 
 Send a computed snapshot as the first message, then live updates. Eliminates

--- a/group_test.go
+++ b/group_test.go
@@ -727,6 +727,107 @@ func TestGroupHandler_NoNestedControlEventsInReplay(t *testing.T) {
 	assert.Contains(t, body, "id: 2\n")
 }
 
+func TestGroupHandler_PreformattedSSENoDoubleWrap(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.DefineGroup("g", []string{"doc/content"})
+	handler := b.GroupHandler("g")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/g", http.NoBody)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Publish a pre-formatted SSE message (simulating what SSEHandler callers do)
+	preformatted := NewSSEMessage("content", "<div>hello</div>").String()
+	b.Publish("doc/content", preformatted)
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+	// Should use topic as event type, not the original event name
+	assert.Contains(t, body, "event: doc/content\n")
+	assert.Contains(t, body, "data: <div>hello</div>\n")
+	// Must NOT double-wrap
+	assert.NotContains(t, body, "data: event:")
+	assert.NotContains(t, body, "data: data:")
+}
+
+func TestGroupHandler_PreformattedSSEWithIDPreserved(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.DefineGroup("g", []string{"topic1"})
+	handler := b.GroupHandler("g")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/g", http.NoBody)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Publish a pre-formatted SSE message with an id field
+	preformatted := NewSSEMessage("update", "payload").WithID("evt-99").String()
+	b.Publish("topic1", preformatted)
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "event: topic1\n")
+	assert.Contains(t, body, "data: payload\n")
+	assert.Contains(t, body, "id: evt-99\n")
+	assert.NotContains(t, body, "data: event:")
+}
+
+func TestGroupHandler_RawStringStillWorks(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.DefineGroup("g", []string{"metrics"})
+	handler := b.GroupHandler("g")
+
+	rec := newFlushRecorder()
+	req := httptest.NewRequest("GET", "/sse/g", http.NoBody)
+	ctx, cancel := contextWithCancel(req)
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	b.Publish("metrics", "cpu=42")
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "event: metrics\n")
+	assert.Contains(t, body, "data: cpu=42\n")
+}
+
 // collectTopics drains n topic names from ch within the given timeout.
 func collectTopics(t *testing.T, ch <-chan string, n int, timeout time.Duration) []string {
 	t.Helper()

--- a/message.go
+++ b/message.go
@@ -68,6 +68,36 @@ func isControlEvent(msg string) bool {
 	return strings.HasPrefix(msg, "event: tavern-")
 }
 
+// isSSEFormatted reports whether msg is already a formatted SSE frame. A
+// message is considered SSE-formatted if its first line starts with "event:"
+// or "data:" — the primary SSE field prefixes produced by [SSEMessage.String].
+// Messages that only start with "id:" or "retry:" are not considered
+// pre-formatted because those prefixes can appear in raw payloads with
+// injected IDs (e.g., from PublishWithID).
+func isSSEFormatted(msg string) bool {
+	return strings.HasPrefix(msg, "event:") ||
+		strings.HasPrefix(msg, "data:")
+}
+
+// extractSSEData extracts the data payload from an already-formatted SSE
+// message by collecting all "data:" lines and joining them with newlines.
+func extractSSEData(msg string) string {
+	var dataLines []string
+	for _, line := range strings.Split(msg, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "data:") {
+			dataLines = append(dataLines, strings.TrimPrefix(trimmed, "data:"))
+		}
+	}
+	// Trim the leading space that SSE format adds after "data:"
+	for i, line := range dataLines {
+		if len(line) > 0 && line[0] == ' ' {
+			dataLines[i] = line[1:]
+		}
+	}
+	return strings.Join(dataLines, "\n")
+}
+
 // extractSSEID extracts the id field value from an SSE message string and
 // returns the message with the id field removed. If no id field is present, the
 // original message is returned unchanged with an empty id.
@@ -89,11 +119,23 @@ func extractSSEID(msg string) (cleaned, id string) {
 }
 
 // wrapForGroup formats a raw subscriber message for grouped SSE output. Control
-// events are forwarded as-is. Payload messages are wrapped with the topic as the
-// SSE event type, preserving any id field injected by PublishWithID.
+// events are forwarded as-is. Pre-formatted SSE messages have their data
+// extracted and re-wrapped with the topic as the event type to avoid
+// double-wrapping. Raw strings are wrapped with [NewSSEMessage] as before.
 func wrapForGroup(topic, msg string) string {
 	if isControlEvent(msg) {
 		return msg
+	}
+	if isSSEFormatted(msg) {
+		// Already an SSE frame — extract the data payload and id, then
+		// re-wrap with the topic as the event type.
+		data := extractSSEData(msg)
+		_, id := extractSSEID(msg)
+		m := NewSSEMessage(topic, data)
+		if id != "" {
+			m = m.WithID(id)
+		}
+		return m.String()
 	}
 	cleaned, id := extractSSEID(msg)
 	m := NewSSEMessage(topic, cleaned)

--- a/message_test.go
+++ b/message_test.go
@@ -181,6 +181,82 @@ func TestWrapForGroup(t *testing.T) {
 	})
 }
 
+func TestIsSSEFormatted(t *testing.T) {
+	assert.True(t, isSSEFormatted("event: update\ndata: hello\n\n"))
+	assert.True(t, isSSEFormatted("data: hello\n\n"))
+	assert.True(t, isSSEFormatted("event: tavern-reconnected\ndata: \n\n"))
+	// id: and retry: alone are NOT considered pre-formatted SSE
+	assert.False(t, isSSEFormatted("id: 42\ndata: hello\n\n"))
+	assert.False(t, isSSEFormatted("retry: 3000\n\n"))
+	assert.False(t, isSSEFormatted("just raw text"))
+	assert.False(t, isSSEFormatted("cpu=42"))
+	assert.False(t, isSSEFormatted(""))
+}
+
+func TestExtractSSEData(t *testing.T) {
+	t.Run("single data line", func(t *testing.T) {
+		msg := "event: update\ndata: hello\n\n"
+		assert.Equal(t, "hello", extractSSEData(msg))
+	})
+
+	t.Run("multiple data lines", func(t *testing.T) {
+		msg := "event: update\ndata: line1\ndata: line2\n\n"
+		assert.Equal(t, "line1\nline2", extractSSEData(msg))
+	})
+
+	t.Run("no data lines", func(t *testing.T) {
+		msg := "event: ping\n\n"
+		assert.Equal(t, "", extractSSEData(msg))
+	})
+
+	t.Run("data with id and retry", func(t *testing.T) {
+		msg := "event: update\ndata: payload\nid: 42\nretry: 3000\n\n"
+		assert.Equal(t, "payload", extractSSEData(msg))
+	})
+}
+
+func TestWrapForGroup_PreformattedSSE(t *testing.T) {
+	t.Run("pre-formatted SSE message unwrapped and re-wrapped", func(t *testing.T) {
+		preformatted := NewSSEMessage("content", "<div>hello</div>").String()
+		got := wrapForGroup("doc/content", preformatted)
+		assert.Contains(t, got, "event: doc/content\n")
+		assert.Contains(t, got, "data: <div>hello</div>\n")
+		// Must NOT contain double-wrapped data
+		assert.NotContains(t, got, "data: event:")
+		assert.NotContains(t, got, "data: data:")
+	})
+
+	t.Run("pre-formatted SSE with id preserved", func(t *testing.T) {
+		preformatted := NewSSEMessage("content", "payload").WithID("evt-5").String()
+		got := wrapForGroup("doc/content", preformatted)
+		assert.Contains(t, got, "event: doc/content\n")
+		assert.Contains(t, got, "data: payload\n")
+		assert.Contains(t, got, "id: evt-5\n")
+		assert.NotContains(t, got, "data: event:")
+	})
+
+	t.Run("pre-formatted SSE with multiline data", func(t *testing.T) {
+		preformatted := NewSSEMessage("update", "line1\nline2").String()
+		got := wrapForGroup("topic", preformatted)
+		assert.Contains(t, got, "event: topic\n")
+		assert.Contains(t, got, "data: line1\n")
+		assert.Contains(t, got, "data: line2\n")
+		assert.NotContains(t, got, "data: event:")
+	})
+
+	t.Run("raw string still works", func(t *testing.T) {
+		got := wrapForGroup("metrics", "cpu=42")
+		assert.Contains(t, got, "event: metrics\n")
+		assert.Contains(t, got, "data: cpu=42\n")
+	})
+
+	t.Run("control event still passes through", func(t *testing.T) {
+		ctrl := "event: tavern-reconnected\ndata: \n\n"
+		got := wrapForGroup("metrics", ctrl)
+		assert.Equal(t, ctrl, got)
+	})
+}
+
 func TestInjectSSEID_RawString(t *testing.T) {
 	got := injectSSEID("hello", "42")
 	assert.Contains(t, got, "hello")


### PR DESCRIPTION
## Summary
- `wrapForGroup()` now detects already-formatted SSE messages (starting with `event:` or `data:`) and extracts their data payload before re-wrapping with the topic name, preventing double-wrapping
- Control events (`tavern-*`) continue to pass through unchanged
- Added README section documenting SSEHandler vs GroupHandler message format differences

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] New unit tests for `isSSEFormatted()` and `extractSSEData()`
- [x] New unit tests for `wrapForGroup()` with pre-formatted SSE input
- [x] New integration tests verifying GroupHandler correctly unwraps pre-formatted messages
- [x] Verified control events still pass through unchanged
- [x] Verified raw string payloads still work as before
- [x] Verified pre-formatted messages with `id:` fields are preserved

Closes #140