### PR TITLE
feat: add ReplayStore interface for pluggable replay

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -83,6 +83,7 @@ type SSEBroker struct {
 	admissionFn       func(topic string, currentCount int) bool // nil = no custom admission
 	orderedTopics     map[string]*sync.Mutex             // topic → per-topic ordering mutex
 	onPublishDropFn   func(topic string, droppedForCount int) // nil = no drop callback
+	replayStore       ReplayStore                        // nil = use internal maps
 }
 
 // Topic name constants are conventions for common real-time use cases.
@@ -176,6 +177,19 @@ func WithSlowSubscriberCallback(fn func(topic string)) BrokerOption {
 func WithMessageTTLSweep(interval time.Duration) BrokerOption {
 	return func(b *SSEBroker) {
 		b.msgTTLSweep = interval
+	}
+}
+
+// WithReplayStore sets an external [ReplayStore] for persisting replay entries.
+// When configured, the broker delegates all replay read/write operations to the
+// store instead of using its internal in-memory maps. This enables durable replay
+// across process restarts or shared replay across multiple broker instances.
+//
+// When no store is configured (the default), the broker uses its built-in
+// in-memory replay, preserving existing behavior.
+func WithReplayStore(store ReplayStore) BrokerOption {
+	return func(b *SSEBroker) {
+		b.replayStore = store
 	}
 }
 
@@ -279,10 +293,20 @@ func (b *SSEBroker) Subscribe(topic string) (msgs <-chan string, unsubscribe fun
 	if b.adaptive != nil {
 		b.adaptive.getState(ch) // pre-create state
 	}
-	replayMsgs := append([]string(nil), b.replayCache[topic]...)
+	store := b.replayStore
+	var replayMsgs []string
+	if store == nil {
+		replayMsgs = append([]string(nil), b.replayCache[topic]...)
+	}
 	delete(b.topicEmpty, topic)
 	hasBackend := b.backend != nil
 	b.mu.Unlock()
+	if store != nil {
+		entries, _ := store.Latest(context.Background(), topic, b.replayStoreLimit(topic))
+		for _, e := range entries {
+			replayMsgs = append(replayMsgs, e.Msg)
+		}
+	}
 	for _, fn := range firstHooks {
 		go fn(topic)
 	}
@@ -375,10 +399,20 @@ func (b *SSEBroker) SubscribeScoped(topic, scope string) (msgs <-chan string, un
 	if b.adaptive != nil {
 		b.adaptive.getState(ch) // pre-create state
 	}
-	replayMsgs := append([]string(nil), b.replayCache[topic]...)
+	storeScoped := b.replayStore
+	var replayMsgs []string
+	if storeScoped == nil {
+		replayMsgs = append([]string(nil), b.replayCache[topic]...)
+	}
 	hasBackendScoped := b.backend != nil
 	delete(b.topicEmpty, topic)
 	b.mu.Unlock()
+	if storeScoped != nil {
+		entries, _ := storeScoped.Latest(context.Background(), topic, b.replayStoreLimit(topic))
+		for _, e := range entries {
+			replayMsgs = append(replayMsgs, e.Msg)
+		}
+	}
 	for _, fn := range firstHooks {
 		go fn(topic)
 	}
@@ -853,22 +887,29 @@ func (b *SSEBroker) publishWithReplayDirect(topic, msg string) {
 		b.mu.Unlock()
 		return
 	}
-	maxSize := 1
-	if n, ok := b.replaySize[topic]; ok {
-		maxSize = n
+	store := b.replayStore
+	if store == nil {
+		maxSize := 1
+		if n, ok := b.replaySize[topic]; ok {
+			maxSize = n
+		}
+		msgs := b.replayCache[topic]
+		msgs = append(msgs, msg)
+		if len(msgs) > maxSize {
+			msgs = msgs[len(msgs)-maxSize:]
+		}
+		b.replayCache[topic] = msgs
 	}
-	msgs := b.replayCache[topic]
-	msgs = append(msgs, msg)
-	if len(msgs) > maxSize {
-		msgs = msgs[len(msgs)-maxSize:]
-	}
-	b.replayCache[topic] = msgs
 	subscribers := b.topics[topic]
 	channels := make([]chan string, 0, len(subscribers))
 	for ch := range subscribers {
 		channels = append(channels, ch)
 	}
 	b.mu.Unlock()
+
+	if store != nil {
+		_ = store.Append(context.Background(), topic, ReplayEntry{Msg: msg, PublishedAt: time.Now()})
+	}
 
 	if len(channels) > 0 {
 		sent, dropped := b.publishToChannels(topic, channels, msg)
@@ -893,7 +934,7 @@ func (b *SSEBroker) publishWithReplayDirect(topic, msg string) {
 // live messages. Use n=0 to disable replay for the topic.
 func (b *SSEBroker) SetReplayPolicy(topic string, n int) {
 	b.mu.Lock()
-	defer b.mu.Unlock()
+	store := b.replayStore
 	if n <= 0 {
 		delete(b.replaySize, topic)
 		delete(b.replayCache, topic)
@@ -901,14 +942,24 @@ func (b *SSEBroker) SetReplayPolicy(topic string, n int) {
 		delete(b.replayGapStrategy, topic)
 		delete(b.replayGapSnapshot, topic)
 		delete(b.bundleOnReconnect, topic)
+		b.mu.Unlock()
+		if store != nil {
+			_ = store.DeleteTopic(context.Background(), topic)
+		}
 		return
 	}
 	b.replaySize[topic] = n
-	if msgs := b.replayCache[topic]; len(msgs) > n {
-		b.replayCache[topic] = msgs[len(msgs)-n:]
+	if store == nil {
+		if msgs := b.replayCache[topic]; len(msgs) > n {
+			b.replayCache[topic] = msgs[len(msgs)-n:]
+		}
+		if logs := b.replayLog[topic]; len(logs) > n {
+			b.replayLog[topic] = logs[len(logs)-n:]
+		}
 	}
-	if logs := b.replayLog[topic]; len(logs) > n {
-		b.replayLog[topic] = logs[len(logs)-n:]
+	b.mu.Unlock()
+	if store != nil {
+		_ = store.SetMaxEntries(context.Background(), topic, n)
 	}
 }
 
@@ -916,6 +967,7 @@ func (b *SSEBroker) SetReplayPolicy(topic string, n int) {
 // subscribers will no longer receive a replayed message on connect.
 func (b *SSEBroker) ClearReplay(topic string) {
 	b.mu.Lock()
+	store := b.replayStore
 	delete(b.replayCache, topic)
 	delete(b.replaySize, topic)
 	delete(b.replayLog, topic)
@@ -923,6 +975,20 @@ func (b *SSEBroker) ClearReplay(topic string) {
 	delete(b.replayGapSnapshot, topic)
 	delete(b.bundleOnReconnect, topic)
 	b.mu.Unlock()
+	if store != nil {
+		_ = store.DeleteTopic(context.Background(), topic)
+	}
+}
+
+// replayStoreLimit returns the configured replay size for a topic, defaulting
+// to 1. It must be called without holding b.mu when used outside the lock.
+func (b *SSEBroker) replayStoreLimit(topic string) int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	if n, ok := b.replaySize[topic]; ok {
+		return n
+	}
+	return 1
 }
 
 // PublishTo fans out msg only to scoped subscribers of the given topic whose

--- a/replay_store.go
+++ b/replay_store.go
@@ -1,0 +1,158 @@
+package tavern
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// ReplayStore is an abstraction for storing and retrieving replay entries.
+// Implementations must be safe for concurrent use by multiple goroutines.
+// The default in-memory implementation is [MemoryReplayStore].
+//
+// IDs are topic-scoped (not global). TTL filtering happens at read time:
+// stores must not return expired entries from [ReplayStore.AfterID] or
+// [ReplayStore.Latest].
+type ReplayStore interface {
+	// Append stores a replay entry for a topic.
+	Append(ctx context.Context, topic string, entry ReplayEntry) error
+
+	// AfterID returns entries published after the given ID.
+	// found indicates whether lastID exists in the store.
+	// If found=false, the broker treats this as a gap.
+	// Must not return expired entries (TTL filtering at read time).
+	AfterID(ctx context.Context, topic, lastID string, limit int) (entries []ReplayEntry, found bool, err error)
+
+	// Latest returns the most recent entries for a topic (for initial
+	// subscribe replay). Must not return expired entries.
+	Latest(ctx context.Context, topic string, limit int) ([]ReplayEntry, error)
+
+	// DeleteTopic removes all replay entries for a topic.
+	DeleteTopic(ctx context.Context, topic string) error
+
+	// SetMaxEntries configures the maximum number of entries to retain for a
+	// topic. When the limit is exceeded, the oldest entries are discarded.
+	// A value of 0 or less removes all entries and the limit for the topic.
+	SetMaxEntries(ctx context.Context, topic string, n int) error
+}
+
+// MemoryReplayStore is an in-memory implementation of [ReplayStore]. It stores
+// entries in ordered slices per topic with a configurable maximum size.
+// All methods are safe for concurrent use.
+type MemoryReplayStore struct {
+	mu       sync.Mutex
+	entries  map[string][]ReplayEntry
+	maxSize  map[string]int
+}
+
+// NewMemoryReplayStore creates a ready-to-use in-memory replay store.
+func NewMemoryReplayStore() *MemoryReplayStore {
+	return &MemoryReplayStore{
+		entries: make(map[string][]ReplayEntry),
+		maxSize: make(map[string]int),
+	}
+}
+
+// Append stores a replay entry for a topic. If the number of entries exceeds
+// the configured maximum for the topic, the oldest entries are discarded.
+// The default maximum is 1 if not explicitly configured via [MemoryReplayStore.SetMaxEntries].
+func (m *MemoryReplayStore) Append(_ context.Context, topic string, entry ReplayEntry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	maxSize := 1
+	if n, ok := m.maxSize[topic]; ok {
+		maxSize = n
+	}
+
+	log := m.entries[topic]
+	log = append(log, entry)
+	if len(log) > maxSize {
+		log = log[len(log)-maxSize:]
+	}
+	m.entries[topic] = log
+	return nil
+}
+
+// AfterID returns entries published after the given ID. If lastID is not found
+// in the store, found is false and entries is nil (indicating a gap). Expired
+// entries are filtered out.
+func (m *MemoryReplayStore) AfterID(_ context.Context, topic, lastID string, _ int) ([]ReplayEntry, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	log := m.entries[topic]
+	now := time.Now()
+
+	for i, entry := range log {
+		if entry.ID == lastID {
+			var result []ReplayEntry
+			for _, e := range log[i+1:] {
+				if !e.ExpiresAt.IsZero() && now.After(e.ExpiresAt) {
+					continue
+				}
+				result = append(result, e)
+			}
+			return result, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+// Latest returns the most recent entries for a topic, up to limit. Expired
+// entries are filtered out.
+func (m *MemoryReplayStore) Latest(_ context.Context, topic string, limit int) ([]ReplayEntry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	log := m.entries[topic]
+	if len(log) == 0 {
+		return nil, nil
+	}
+
+	now := time.Now()
+	var result []ReplayEntry
+	// Walk from newest to oldest, collecting up to limit non-expired entries.
+	for i := len(log) - 1; i >= 0 && len(result) < limit; i-- {
+		e := log[i]
+		if !e.ExpiresAt.IsZero() && now.After(e.ExpiresAt) {
+			continue
+		}
+		result = append(result, e)
+	}
+	// Reverse to restore chronological order.
+	for i, j := 0, len(result)-1; i < j; i, j = i+1, j-1 {
+		result[i], result[j] = result[j], result[i]
+	}
+	return result, nil
+}
+
+// DeleteTopic removes all replay entries for a topic and its max-size config.
+func (m *MemoryReplayStore) DeleteTopic(_ context.Context, topic string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.entries, topic)
+	delete(m.maxSize, topic)
+	return nil
+}
+
+// SetMaxEntries configures the maximum number of entries to retain for a topic.
+// If n <= 0, all entries and the limit are removed (equivalent to DeleteTopic).
+// If the current number of entries exceeds n, the oldest are discarded.
+func (m *MemoryReplayStore) SetMaxEntries(_ context.Context, topic string, n int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if n <= 0 {
+		delete(m.entries, topic)
+		delete(m.maxSize, topic)
+		return nil
+	}
+
+	m.maxSize[topic] = n
+	if log := m.entries[topic]; len(log) > n {
+		m.entries[topic] = log[len(log)-n:]
+	}
+	return nil
+}

--- a/replay_store_test.go
+++ b/replay_store_test.go
@@ -1,0 +1,382 @@
+package tavern
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// MemoryReplayStore unit tests
+// ---------------------------------------------------------------------------
+
+func TestMemoryReplayStore_AppendAndLatest(t *testing.T) {
+	s := NewMemoryReplayStore()
+	ctx := context.Background()
+
+	require.NoError(t, s.SetMaxEntries(ctx, "t", 5))
+	for i := 1; i <= 3; i++ {
+		require.NoError(t, s.Append(ctx, "t", ReplayEntry{
+			ID:  fmt.Sprintf("%d", i),
+			Msg: fmt.Sprintf("msg-%d", i),
+		}))
+	}
+
+	entries, err := s.Latest(ctx, "t", 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 3)
+	assert.Equal(t, "msg-1", entries[0].Msg)
+	assert.Equal(t, "msg-3", entries[2].Msg)
+}
+
+func TestMemoryReplayStore_LatestRespectsLimit(t *testing.T) {
+	s := NewMemoryReplayStore()
+	ctx := context.Background()
+
+	require.NoError(t, s.SetMaxEntries(ctx, "t", 10))
+	for i := 1; i <= 5; i++ {
+		require.NoError(t, s.Append(ctx, "t", ReplayEntry{
+			ID:  fmt.Sprintf("%d", i),
+			Msg: fmt.Sprintf("msg-%d", i),
+		}))
+	}
+
+	entries, err := s.Latest(ctx, "t", 2)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "msg-4", entries[0].Msg)
+	assert.Equal(t, "msg-5", entries[1].Msg)
+}
+
+func TestMemoryReplayStore_AfterID_Found(t *testing.T) {
+	s := NewMemoryReplayStore()
+	ctx := context.Background()
+
+	require.NoError(t, s.SetMaxEntries(ctx, "t", 10))
+	for i := 1; i <= 5; i++ {
+		require.NoError(t, s.Append(ctx, "t", ReplayEntry{
+			ID:  fmt.Sprintf("%d", i),
+			Msg: fmt.Sprintf("msg-%d", i),
+		}))
+	}
+
+	entries, found, err := s.AfterID(ctx, "t", "3", 0)
+	require.NoError(t, err)
+	assert.True(t, found)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "msg-4", entries[0].Msg)
+	assert.Equal(t, "msg-5", entries[1].Msg)
+}
+
+func TestMemoryReplayStore_AfterID_NotFound(t *testing.T) {
+	s := NewMemoryReplayStore()
+	ctx := context.Background()
+
+	require.NoError(t, s.SetMaxEntries(ctx, "t", 10))
+	require.NoError(t, s.Append(ctx, "t", ReplayEntry{ID: "1", Msg: "m1"}))
+
+	entries, found, err := s.AfterID(ctx, "t", "unknown", 0)
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Nil(t, entries)
+}
+
+func TestMemoryReplayStore_AfterID_AllCaughtUp(t *testing.T) {
+	s := NewMemoryReplayStore()
+	ctx := context.Background()
+
+	require.NoError(t, s.SetMaxEntries(ctx, "t", 10))
+	require.NoError(t, s.Append(ctx, "t", ReplayEntry{ID: "1", Msg: "m1"}))
+
+	entries, found, err := s.AfterID(ctx, "t", "1", 0)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Empty(t, entries)
+}
+
+func TestMemoryReplayStore_TTLFiltering(t *testing.T) {
+	s := NewMemoryReplayStore()
+	ctx := context.Background()
+
+	require.NoError(t, s.SetMaxEntries(ctx, "t", 10))
+	// One expired entry, one live entry.
+	require.NoError(t, s.Append(ctx, "t", ReplayEntry{
+		ID:        "1",
+		Msg:       "expired",
+		ExpiresAt: time.Now().Add(-time.Second),
+	}))
+	require.NoError(t, s.Append(ctx, "t", ReplayEntry{
+		ID:  "2",
+		Msg: "live",
+	}))
+
+	entries, err := s.Latest(ctx, "t", 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "live", entries[0].Msg)
+
+	// AfterID should also filter expired.
+	entries, found, err := s.AfterID(ctx, "t", "1", 0)
+	require.NoError(t, err)
+	assert.True(t, found)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "live", entries[0].Msg)
+}
+
+func TestMemoryReplayStore_DeleteTopic(t *testing.T) {
+	s := NewMemoryReplayStore()
+	ctx := context.Background()
+
+	require.NoError(t, s.SetMaxEntries(ctx, "t", 10))
+	require.NoError(t, s.Append(ctx, "t", ReplayEntry{ID: "1", Msg: "m1"}))
+
+	require.NoError(t, s.DeleteTopic(ctx, "t"))
+
+	entries, err := s.Latest(ctx, "t", 10)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestMemoryReplayStore_MaxSizeTruncation(t *testing.T) {
+	s := NewMemoryReplayStore()
+	ctx := context.Background()
+
+	require.NoError(t, s.SetMaxEntries(ctx, "t", 3))
+	for i := 1; i <= 5; i++ {
+		require.NoError(t, s.Append(ctx, "t", ReplayEntry{
+			ID:  fmt.Sprintf("%d", i),
+			Msg: fmt.Sprintf("msg-%d", i),
+		}))
+	}
+
+	entries, err := s.Latest(ctx, "t", 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 3)
+	assert.Equal(t, "msg-3", entries[0].Msg)
+	assert.Equal(t, "msg-5", entries[2].Msg)
+}
+
+func TestMemoryReplayStore_SetMaxEntries_Shrinks(t *testing.T) {
+	s := NewMemoryReplayStore()
+	ctx := context.Background()
+
+	require.NoError(t, s.SetMaxEntries(ctx, "t", 10))
+	for i := 1; i <= 5; i++ {
+		require.NoError(t, s.Append(ctx, "t", ReplayEntry{
+			ID:  fmt.Sprintf("%d", i),
+			Msg: fmt.Sprintf("msg-%d", i),
+		}))
+	}
+	// Shrink to 2.
+	require.NoError(t, s.SetMaxEntries(ctx, "t", 2))
+
+	entries, err := s.Latest(ctx, "t", 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "msg-4", entries[0].Msg)
+	assert.Equal(t, "msg-5", entries[1].Msg)
+}
+
+func TestMemoryReplayStore_DefaultMaxSizeIsOne(t *testing.T) {
+	s := NewMemoryReplayStore()
+	ctx := context.Background()
+
+	// Don't call SetMaxEntries — default should be 1.
+	require.NoError(t, s.Append(ctx, "t", ReplayEntry{ID: "1", Msg: "first"}))
+	require.NoError(t, s.Append(ctx, "t", ReplayEntry{ID: "2", Msg: "second"}))
+
+	entries, err := s.Latest(ctx, "t", 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "second", entries[0].Msg)
+}
+
+// ---------------------------------------------------------------------------
+// Broker + ReplayStore integration tests
+// ---------------------------------------------------------------------------
+
+func TestBrokerWithReplayStore_PublishWithID_SubscribeFromID(t *testing.T) {
+	store := NewMemoryReplayStore()
+	b := NewSSEBroker(WithReplayStore(store))
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	for i := 1; i <= 5; i++ {
+		b.PublishWithID("events", fmt.Sprintf("%d", i), fmt.Sprintf("msg-%d", i))
+	}
+
+	ch, unsub := b.SubscribeFromID("events", "3")
+	defer unsub()
+
+	// Drain reconnected control event.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reconnected control event")
+	}
+
+	var got []string
+	for range 2 {
+		select {
+		case msg := <-ch:
+			got = append(got, msg)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for replay message")
+		}
+	}
+	require.Len(t, got, 2)
+	assert.Contains(t, got[0], "msg-4")
+	assert.Contains(t, got[0], "id: 4")
+	assert.Contains(t, got[1], "msg-5")
+	assert.Contains(t, got[1], "id: 5")
+}
+
+func TestBrokerWithReplayStore_GapDetection(t *testing.T) {
+	store := NewMemoryReplayStore()
+	b := NewSSEBroker(WithReplayStore(store))
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 3)
+	// Use GapFallbackToSnapshot so we get a control event to verify gap detection.
+	b.SetReplayGapPolicy("events", GapFallbackToSnapshot, nil)
+	for i := 1; i <= 3; i++ {
+		b.PublishWithID("events", fmt.Sprintf("%d", i), fmt.Sprintf("msg-%d", i))
+	}
+
+	// Subscribe with an ID that doesn't exist (gap).
+	ch, unsub := b.SubscribeFromID("events", "unknown-id")
+	defer unsub()
+
+	// Reconnected control event.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+
+	// Gap control event.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-replay-gap")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for gap control event")
+	}
+
+	// No replay messages.
+	select {
+	case msg := <-ch:
+		t.Fatalf("expected no replay, got: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestBrokerWithReplayStore_SubscribeReplay(t *testing.T) {
+	store := NewMemoryReplayStore()
+	b := NewSSEBroker(WithReplayStore(store))
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 5)
+	b.PublishWithReplay("events", "hello")
+	b.PublishWithReplay("events", "world")
+
+	ch, unsub := b.Subscribe("events")
+	defer unsub()
+
+	var got []string
+	for range 2 {
+		select {
+		case msg := <-ch:
+			got = append(got, msg)
+		case <-time.After(time.Second):
+			t.Fatal("timed out")
+		}
+	}
+	assert.Equal(t, []string{"hello", "world"}, got)
+}
+
+func TestBrokerWithReplayStore_SetReplayPolicyZero_DeletesTopic(t *testing.T) {
+	store := NewMemoryReplayStore()
+	b := NewSSEBroker(WithReplayStore(store))
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	b.PublishWithReplay("events", "hello")
+
+	// Verify it's in the store.
+	entries, err := store.Latest(context.Background(), "events", 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	// Setting policy to 0 should delete from store.
+	b.SetReplayPolicy("events", 0)
+
+	entries, err = store.Latest(context.Background(), "events", 10)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestBrokerWithReplayStore_SubscribeFromID_EmptyID(t *testing.T) {
+	store := NewMemoryReplayStore()
+	b := NewSSEBroker(WithReplayStore(store))
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	for i := 1; i <= 3; i++ {
+		b.PublishWithID("events", fmt.Sprintf("%d", i), fmt.Sprintf("msg-%d", i))
+	}
+
+	// Empty ID replays all via Latest().
+	ch, unsub := b.SubscribeFromID("events", "")
+	defer unsub()
+
+	var got []string
+	for range 3 {
+		select {
+		case msg := <-ch:
+			got = append(got, msg)
+		case <-time.After(time.Second):
+			t.Fatal("timed out")
+		}
+	}
+	require.Len(t, got, 3)
+	for i, msg := range got {
+		assert.Contains(t, msg, fmt.Sprintf("msg-%d", i+1))
+		assert.Contains(t, msg, fmt.Sprintf("id: %d", i+1))
+	}
+}
+
+func TestBrokerWithReplayStore_ClearReplay(t *testing.T) {
+	store := NewMemoryReplayStore()
+	b := NewSSEBroker(WithReplayStore(store))
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	b.PublishWithReplay("events", "hello")
+
+	b.ClearReplay("events")
+
+	entries, err := store.Latest(context.Background(), "events", 10)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestBrokerWithReplayStore_PublishWithTTL(t *testing.T) {
+	store := NewMemoryReplayStore()
+	b := NewSSEBroker(WithReplayStore(store))
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	b.PublishWithTTL("events", "ttl-msg", time.Hour)
+
+	entries, err := store.Latest(context.Background(), "events", 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "ttl-msg", entries[0].Msg)
+	assert.False(t, entries[0].ExpiresAt.IsZero())
+}

--- a/resume.go
+++ b/resume.go
@@ -1,6 +1,7 @@
 package tavern
 
 import (
+	"context"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -34,24 +35,27 @@ func (b *SSEBroker) PublishWithID(topic, id, msg string) {
 		b.mu.Unlock()
 		return
 	}
-	maxSize := 1
-	if n, ok := b.replaySize[topic]; ok {
-		maxSize = n
-	}
-	log := b.replayLog[topic]
-	log = append(log, ReplayEntry{ID: id, Msg: msg, PublishedAt: time.Now()})
-	if len(log) > maxSize {
-		log = log[len(log)-maxSize:]
-	}
-	b.replayLog[topic] = log
+	store := b.replayStore
+	if store == nil {
+		maxSize := 1
+		if n, ok := b.replaySize[topic]; ok {
+			maxSize = n
+		}
+		log := b.replayLog[topic]
+		log = append(log, ReplayEntry{ID: id, Msg: msg, PublishedAt: time.Now()})
+		if len(log) > maxSize {
+			log = log[len(log)-maxSize:]
+		}
+		b.replayLog[topic] = log
 
-	// Also update replayCache for regular Subscribe replay compatibility.
-	msgs := b.replayCache[topic]
-	msgs = append(msgs, msg)
-	if len(msgs) > maxSize {
-		msgs = msgs[len(msgs)-maxSize:]
+		// Also update replayCache for regular Subscribe replay compatibility.
+		msgs := b.replayCache[topic]
+		msgs = append(msgs, msg)
+		if len(msgs) > maxSize {
+			msgs = msgs[len(msgs)-maxSize:]
+		}
+		b.replayCache[topic] = msgs
 	}
-	b.replayCache[topic] = msgs
 
 	subscribers := b.topics[topic]
 	channels := make([]chan string, 0, len(subscribers))
@@ -59,6 +63,10 @@ func (b *SSEBroker) PublishWithID(topic, id, msg string) {
 		channels = append(channels, ch)
 	}
 	b.mu.Unlock()
+
+	if store != nil {
+		_ = store.Append(context.Background(), topic, ReplayEntry{ID: id, Msg: msg, PublishedAt: time.Now()})
+	}
 
 	wireMsg := injectSSEID(msg, id)
 	sent, dropped := b.publishToChannels(topic, channels, wireMsg)
@@ -108,40 +116,43 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 	}
 
 	// Find messages after lastEventID, skipping expired TTL entries.
-	now := time.Now()
+	store := b.replayStore
 	var replayMsgs []string
 	var gapDetected bool
-	if lastEventID == "" {
-		// No Last-Event-ID: replay all cached (same as regular Subscribe).
-		// Filter out expired entries from the replay log if present.
-		if log := b.replayLog[topic]; len(log) > 0 {
-			for _, e := range log {
-				if !e.ExpiresAt.IsZero() && now.After(e.ExpiresAt) {
-					continue
-				}
-				replayMsgs = append(replayMsgs, injectSSEID(e.Msg, e.ID))
-			}
-		} else {
-			replayMsgs = append([]string(nil), b.replayCache[topic]...)
-		}
-	} else {
-		log := b.replayLog[topic]
-		found := false
-		for i, entry := range log {
-			if entry.ID == lastEventID {
-				found = true
-				// Replay everything after this entry, skipping expired.
-				for _, e := range log[i+1:] {
+	if store == nil {
+		now := time.Now()
+		if lastEventID == "" {
+			// No Last-Event-ID: replay all cached (same as regular Subscribe).
+			// Filter out expired entries from the replay log if present.
+			if log := b.replayLog[topic]; len(log) > 0 {
+				for _, e := range log {
 					if !e.ExpiresAt.IsZero() && now.After(e.ExpiresAt) {
 						continue
 					}
 					replayMsgs = append(replayMsgs, injectSSEID(e.Msg, e.ID))
 				}
-				break
+			} else {
+				replayMsgs = append([]string(nil), b.replayCache[topic]...)
 			}
-		}
-		if !found {
-			gapDetected = true
+		} else {
+			log := b.replayLog[topic]
+			found := false
+			for i, entry := range log {
+				if entry.ID == lastEventID {
+					found = true
+					// Replay everything after this entry, skipping expired.
+					for _, e := range log[i+1:] {
+						if !e.ExpiresAt.IsZero() && now.After(e.ExpiresAt) {
+							continue
+						}
+						replayMsgs = append(replayMsgs, injectSSEID(e.Msg, e.ID))
+					}
+					break
+				}
+			}
+			if !found {
+				gapDetected = true
+			}
 		}
 	}
 
@@ -179,6 +190,34 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 		go fn(topic)
 	}
 	b.publishConnectionEvent("subscribe", topic, total)
+
+	// When an external ReplayStore is configured, query it outside the lock.
+	if store != nil {
+		if lastEventID == "" {
+			entries, _ := store.Latest(context.Background(), topic, b.replayStoreLimit(topic))
+			for _, e := range entries {
+				if e.ID != "" {
+					replayMsgs = append(replayMsgs, injectSSEID(e.Msg, e.ID))
+				} else {
+					replayMsgs = append(replayMsgs, e.Msg)
+				}
+			}
+		} else {
+			entries, found, _ := store.AfterID(context.Background(), topic, lastEventID, 0)
+			if !found {
+				gapDetected = true
+				// Re-read gap callbacks under the lock.
+				b.mu.RLock()
+				gapCallbacks = b.onReplayGap[topic]
+				gapStrategy = b.replayGapStrategy[topic]
+				gapSnapshotFn = b.replayGapSnapshot[topic]
+				b.mu.RUnlock()
+			}
+			for _, e := range entries {
+				replayMsgs = append(replayMsgs, injectSSEID(e.Msg, e.ID))
+			}
+		}
+	}
 
 	// Send reconnected control event when Last-Event-ID is present.
 	if isReconnect {

--- a/ttl.go
+++ b/ttl.go
@@ -1,6 +1,9 @@
 package tavern
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // TTLOption configures optional behavior for TTL-based publish methods such
 // as [SSEBroker.PublishWithTTL] and [SSEBroker.PublishToWithTTL].
@@ -33,7 +36,8 @@ func (b *SSEBroker) PublishWithTTL(topic, msg string, ttl time.Duration, opts ..
 		b.mu.Unlock()
 		return
 	}
-	b.storeReplayWithTTL(topic, msg, now, ttl, cfg)
+	entry := b.storeReplayWithTTL(topic, msg, now, ttl, cfg)
+	store := b.replayStore
 
 	subscribers := b.topics[topic]
 	channels := make([]chan string, 0, len(subscribers))
@@ -41,6 +45,10 @@ func (b *SSEBroker) PublishWithTTL(topic, msg string, ttl time.Duration, opts ..
 		channels = append(channels, ch)
 	}
 	b.mu.Unlock()
+
+	if store != nil {
+		_ = store.Append(context.Background(), topic, entry)
+	}
 
 	b.ensureTTLSweeper()
 
@@ -69,7 +77,8 @@ func (b *SSEBroker) PublishToWithTTL(topic, scope, msg string, ttl time.Duration
 		b.mu.Unlock()
 		return
 	}
-	b.storeReplayWithTTL(topic, msg, now, ttl, cfg)
+	entry := b.storeReplayWithTTL(topic, msg, now, ttl, cfg)
+	store := b.replayStore
 
 	scopedSubs, exists := b.scopedTopics[topic]
 	var channels []chan string
@@ -82,6 +91,10 @@ func (b *SSEBroker) PublishToWithTTL(topic, scope, msg string, ttl time.Duration
 		}
 	}
 	b.mu.Unlock()
+
+	if store != nil {
+		_ = store.Append(context.Background(), topic, entry)
+	}
 
 	b.ensureTTLSweeper()
 
@@ -112,7 +125,8 @@ func (b *SSEBroker) PublishIfChangedWithTTL(topic, msg string, ttl time.Duration
 		return false
 	}
 	b.lastHash[topic] = h
-	b.storeReplayWithTTL(topic, msg, now, ttl, cfg)
+	entry := b.storeReplayWithTTL(topic, msg, now, ttl, cfg)
+	store := b.replayStore
 
 	subscribers := b.topics[topic]
 	channels := make([]chan string, 0, len(subscribers))
@@ -120,6 +134,10 @@ func (b *SSEBroker) PublishIfChangedWithTTL(topic, msg string, ttl time.Duration
 		channels = append(channels, ch)
 	}
 	b.mu.Unlock()
+
+	if store != nil {
+		_ = store.Append(context.Background(), topic, entry)
+	}
 
 	b.ensureTTLSweeper()
 
@@ -133,8 +151,23 @@ func (b *SSEBroker) PublishIfChangedWithTTL(topic, msg string, ttl time.Duration
 }
 
 // storeReplayWithTTL adds a message to both the replay cache and replay log
-// with TTL metadata. Must be called with b.mu held.
-func (b *SSEBroker) storeReplayWithTTL(topic, msg string, now time.Time, ttl time.Duration, cfg ttlConfig) {
+// with TTL metadata. Must be called with b.mu held. When an external
+// ReplayStore is configured, this only builds and returns the entry; the
+// caller is responsible for appending it to the store after releasing the lock.
+func (b *SSEBroker) storeReplayWithTTL(topic, msg string, now time.Time, ttl time.Duration, cfg ttlConfig) ReplayEntry {
+	entry := ReplayEntry{
+		Msg:         msg,
+		ExpiresAt:   now.Add(ttl),
+		PublishedAt: now,
+	}
+	if cfg.autoRemoveID != "" {
+		entry.AutoRemoveID = cfg.autoRemoveID
+	}
+
+	if b.replayStore != nil {
+		return entry
+	}
+
 	maxSize := 1
 	if n, ok := b.replaySize[topic]; ok {
 		maxSize = n
@@ -149,19 +182,13 @@ func (b *SSEBroker) storeReplayWithTTL(topic, msg string, now time.Time, ttl tim
 	b.replayCache[topic] = msgs
 
 	// Update replay log with TTL metadata.
-	entry := ReplayEntry{
-		Msg:       msg,
-		ExpiresAt: now.Add(ttl),
-	}
-	if cfg.autoRemoveID != "" {
-		entry.AutoRemoveID = cfg.autoRemoveID
-	}
 	log := b.replayLog[topic]
 	log = append(log, entry)
 	if len(log) > maxSize {
 		log = log[len(log)-maxSize:]
 	}
 	b.replayLog[topic] = log
+	return entry
 }
 
 // ensureTTLSweeper starts the background TTL sweeper goroutine if it has not


### PR DESCRIPTION
## Summary
- Adds a `ReplayStore` interface abstracting replay entry storage, enabling durable/shared replay across instances
- Implements `MemoryReplayStore` as the default in-memory store with per-topic max size and TTL filtering
- Adds `WithReplayStore()` broker option; when not set, existing in-memory behavior is preserved unchanged
- Wires all broker publish/subscribe/policy paths to delegate to the store when configured
- Store methods are called outside the broker lock to avoid holding it during potential I/O

## Test plan
- [x] All existing tests pass unchanged (default no-store path)
- [x] MemoryReplayStore unit tests: append/retrieve, AfterID found/not-found, TTL filtering, Latest limit, DeleteTopic, max size truncation
- [x] Broker integration tests with WithReplayStore: PublishWithID + SubscribeFromID round-trip, gap detection, Subscribe replay via Latest, SetReplayPolicy(0) calls DeleteTopic, ClearReplay, PublishWithTTL

Closes #150