### PR TITLE
fix: honor scope/snapshot in SubscribeMultiWith and fix snapshot ordering

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -14,6 +14,9 @@ import (
 // This eliminates the dual-render pattern where page handlers and publishers
 // independently render the same initial state.
 func (b *SSEBroker) SubscribeWithSnapshot(topic string, snapshotFn func() string) (msgs <-chan string, unsubscribe func()) {
+	// Compute snapshot outside lock to avoid deadlock if snapshotFn accesses broker.
+	snap := snapshotFn()
+
 	b.mu.Lock()
 	if b.closed {
 		b.mu.Unlock()
@@ -26,6 +29,15 @@ func (b *SSEBroker) SubscribeWithSnapshot(topic string, snapshotFn func() string
 		return nil, nil
 	}
 	ch := make(chan string, b.bufferSize)
+
+	// Inject snapshot BEFORE registering — no live message can arrive first.
+	if snap != "" {
+		select {
+		case ch <- snap:
+		default:
+		}
+	}
+
 	if b.topics[topic] == nil {
 		b.topics[topic] = make(map[chan string]struct{})
 	}
@@ -52,14 +64,6 @@ func (b *SSEBroker) SubscribeWithSnapshot(topic string, snapshotFn func() string
 		go fn(topic)
 	}
 
-	// Send snapshot as first message
-	if snap := snapshotFn(); snap != "" {
-		select {
-		case ch <- snap:
-		default:
-		}
-	}
-
 	return ch, func() {
 		b.mu.Lock()
 		var lastHooks []func(string)
@@ -82,4 +86,189 @@ func (b *SSEBroker) SubscribeWithSnapshot(topic string, snapshotFn func() string
 			go fn(topic)
 		}
 	}
+}
+
+// subscribeScopedWithSnapshot creates a scoped subscription with an atomic
+// pre-registration snapshot.
+func (b *SSEBroker) subscribeScopedWithSnapshot(topic, scope, snap string) (<-chan string, func()) {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		ch := make(chan string)
+		close(ch)
+		return ch, func() {}
+	}
+	if !b.admitSubscriber(topic) {
+		b.mu.Unlock()
+		return nil, nil
+	}
+	ch := make(chan string, b.bufferSize)
+	if snap != "" {
+		select {
+		case ch <- snap:
+		default:
+		}
+	}
+	if b.scopedTopics[topic] == nil {
+		b.scopedTopics[topic] = make(map[chan string]scopedSub)
+	}
+	b.scopedTopics[topic][ch] = scopedSub{scope: scope}
+	b.subscriberMeta[ch] = &SubscriberInfo{Topic: topic, Scope: scope, ConnectedAt: time.Now()}
+	total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+	var firstHooks []func(string)
+	if total == 1 {
+		firstHooks = b.onFirst[topic]
+	}
+	if b.metrics != nil {
+		if total > b.metrics.peakSubs[topic] {
+			b.metrics.peakSubs[topic] = total
+		}
+	}
+	if b.evictThreshold > 0 || b.adaptive != nil {
+		b.dropCountsMu.Lock()
+		b.dropCounts[ch] = &atomic.Int64{}
+		b.dropCountsMu.Unlock()
+	}
+	if b.adaptive != nil {
+		b.adaptive.getState(ch)
+	}
+	delete(b.topicEmpty, topic)
+	hasBackend := b.backend != nil
+	b.mu.Unlock()
+	for _, fn := range firstHooks {
+		go fn(topic)
+	}
+	if hasBackend && total == 1 {
+		b.backendSubscribe(topic)
+	}
+	b.publishConnectionEvent("subscribe", topic, total)
+	return ch, b.makeScopedUnsubscribe(topic, ch)
+}
+
+// subscribeWithFilterAndSnapshot creates a filtered subscription with an
+// atomic pre-registration snapshot.
+func (b *SSEBroker) subscribeWithFilterAndSnapshot(topic string, predicate FilterPredicate, snap string) (<-chan string, func()) {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		ch := make(chan string)
+		close(ch)
+		return ch, func() {}
+	}
+	if !b.admitSubscriber(topic) {
+		b.mu.Unlock()
+		return nil, nil
+	}
+	ch := make(chan string, b.bufferSize)
+	if snap != "" {
+		select {
+		case ch <- snap:
+		default:
+		}
+	}
+	if b.topics[topic] == nil {
+		b.topics[topic] = make(map[chan string]struct{})
+	}
+	b.topics[topic][ch] = struct{}{}
+	b.subscriberMeta[ch] = &SubscriberInfo{Topic: topic, ConnectedAt: time.Now()}
+	if b.filterPredicates == nil {
+		b.filterPredicates = make(map[chan string]FilterPredicate)
+	}
+	b.filterPredicates[ch] = predicate
+	total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+	var firstHooks []func(string)
+	if total == 1 {
+		firstHooks = b.onFirst[topic]
+	}
+	if b.metrics != nil {
+		if total > b.metrics.peakSubs[topic] {
+			b.metrics.peakSubs[topic] = total
+		}
+	}
+	if b.evictThreshold > 0 {
+		b.dropCountsMu.Lock()
+		b.dropCounts[ch] = &atomic.Int64{}
+		b.dropCountsMu.Unlock()
+	}
+	replayMsgs := append([]string(nil), b.replayCache[topic]...)
+	delete(b.topicEmpty, topic)
+	b.mu.Unlock()
+	for _, fn := range firstHooks {
+		go fn(topic)
+	}
+	b.publishConnectionEvent("subscribe", topic, total)
+	for _, msg := range replayMsgs {
+		if predicate != nil && !predicate(msg) {
+			continue
+		}
+		select {
+		case ch <- msg:
+		default:
+		}
+	}
+	return ch, b.makeUnsubscribe(topic, ch)
+}
+
+// subscribeScopedWithFilterAndSnapshot creates a scoped+filtered subscription
+// with an atomic pre-registration snapshot.
+func (b *SSEBroker) subscribeScopedWithFilterAndSnapshot(topic, scope string, predicate FilterPredicate, snap string) (<-chan string, func()) {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		ch := make(chan string)
+		close(ch)
+		return ch, func() {}
+	}
+	if !b.admitSubscriber(topic) {
+		b.mu.Unlock()
+		return nil, nil
+	}
+	ch := make(chan string, b.bufferSize)
+	if snap != "" {
+		select {
+		case ch <- snap:
+		default:
+		}
+	}
+	if b.scopedTopics[topic] == nil {
+		b.scopedTopics[topic] = make(map[chan string]scopedSub)
+	}
+	b.scopedTopics[topic][ch] = scopedSub{scope: scope}
+	b.subscriberMeta[ch] = &SubscriberInfo{Topic: topic, Scope: scope, ConnectedAt: time.Now()}
+	if b.filterPredicates == nil {
+		b.filterPredicates = make(map[chan string]FilterPredicate)
+	}
+	b.filterPredicates[ch] = predicate
+	total := len(b.topics[topic]) + len(b.scopedTopics[topic])
+	var firstHooks []func(string)
+	if total == 1 {
+		firstHooks = b.onFirst[topic]
+	}
+	if b.metrics != nil {
+		if total > b.metrics.peakSubs[topic] {
+			b.metrics.peakSubs[topic] = total
+		}
+	}
+	if b.evictThreshold > 0 {
+		b.dropCountsMu.Lock()
+		b.dropCounts[ch] = &atomic.Int64{}
+		b.dropCountsMu.Unlock()
+	}
+	replayMsgs := append([]string(nil), b.replayCache[topic]...)
+	delete(b.topicEmpty, topic)
+	b.mu.Unlock()
+	for _, fn := range firstHooks {
+		go fn(topic)
+	}
+	b.publishConnectionEvent("subscribe", topic, total)
+	for _, msg := range replayMsgs {
+		if predicate != nil && !predicate(msg) {
+			continue
+		}
+		select {
+		case ch <- msg:
+		default:
+		}
+	}
+	return ch, b.makeScopedUnsubscribe(topic, ch)
 }

--- a/subscribe_options.go
+++ b/subscribe_options.go
@@ -73,17 +73,26 @@ func buildSubscribeConfig(opts []SubscribeOption) subscribeConfig {
 func (b *SSEBroker) SubscribeWith(topic string, opts ...SubscribeOption) (msgs <-chan string, unsubscribe func()) {
 	cfg := buildSubscribeConfig(opts)
 
+	// Pre-compute snapshot outside lock when needed for atomic ordering.
+	var preSnap string
+	if cfg.snapshotFn != nil {
+		preSnap = cfg.snapshotFn()
+	}
+
 	var ch <-chan string
 	var unsub func()
 
 	switch {
+	case cfg.scope != "" && cfg.filter != nil && cfg.snapshotFn != nil:
+		ch, unsub = b.subscribeScopedWithFilterAndSnapshot(topic, cfg.scope, cfg.filter, preSnap)
 	case cfg.scope != "" && cfg.filter != nil:
 		ch, unsub = b.SubscribeScopedWithFilter(topic, cfg.scope, cfg.filter)
+	case cfg.scope != "" && cfg.snapshotFn != nil:
+		ch, unsub = b.subscribeScopedWithSnapshot(topic, cfg.scope, preSnap)
 	case cfg.scope != "":
 		ch, unsub = b.SubscribeScoped(topic, cfg.scope)
 	case cfg.filter != nil && cfg.snapshotFn != nil:
-		// Filter + snapshot: use filter subscribe, then inject snapshot.
-		ch, unsub = b.SubscribeWithFilter(topic, cfg.filter)
+		ch, unsub = b.subscribeWithFilterAndSnapshot(topic, cfg.filter, preSnap)
 	case cfg.filter != nil:
 		ch, unsub = b.SubscribeWithFilter(topic, cfg.filter)
 	case cfg.snapshotFn != nil:
@@ -94,19 +103,6 @@ func (b *SSEBroker) SubscribeWith(topic string, opts ...SubscribeOption) (msgs <
 
 	if ch == nil {
 		return nil, nil
-	}
-
-	// Inject snapshot for combos that didn't use SubscribeWithSnapshot.
-	if cfg.snapshotFn != nil && (cfg.filter != nil || cfg.scope != "") {
-		if snap := cfg.snapshotFn(); snap != "" {
-			biCh := b.findBiChanAny(topic, ch)
-			if biCh != nil {
-				select {
-				case biCh <- snap:
-				default:
-				}
-			}
-		}
 	}
 
 	// Apply meta.
@@ -162,6 +158,9 @@ func (b *SSEBroker) SubscribeMultiWith(topics []string, opts ...SubscribeOption)
 
 	for _, topic := range topics {
 		var innerOpts []SubscribeOption
+		if cfg.scope != "" {
+			innerOpts = append(innerOpts, SubWithScope(cfg.scope))
+		}
 		if cfg.filter != nil {
 			innerOpts = append(innerOpts, SubWithFilter(cfg.filter))
 		}
@@ -170,6 +169,9 @@ func (b *SSEBroker) SubscribeMultiWith(topics []string, opts ...SubscribeOption)
 		}
 		if cfg.meta != nil {
 			innerOpts = append(innerOpts, SubWithMeta(*cfg.meta))
+		}
+		if cfg.snapshotFn != nil {
+			innerOpts = append(innerOpts, SubWithSnapshot(cfg.snapshotFn))
 		}
 
 		ch, unsub := b.SubscribeWith(topic, innerOpts...)

--- a/subscribe_options_test.go
+++ b/subscribe_options_test.go
@@ -260,6 +260,138 @@ func TestPublishBatch_PublishWithID(t *testing.T) {
 	}
 }
 
+func TestSubscribeMultiWith_Scope(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(10))
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMultiWith(
+		[]string{"orders", "inventory"},
+		SubWithScope("tenant-a"),
+	)
+	defer unsub()
+
+	b.PublishTo("orders", "tenant-a", "order-1")
+	b.PublishTo("inventory", "tenant-a", "inv-1")
+	b.PublishTo("orders", "tenant-b", "order-2") // should NOT arrive
+
+	var received []TopicMessage
+	timeout := time.After(200 * time.Millisecond)
+	for {
+		select {
+		case msg := <-ch:
+			received = append(received, msg)
+			if len(received) >= 2 {
+				goto done
+			}
+		case <-timeout:
+			goto done
+		}
+	}
+done:
+	assert.Len(t, received, 2)
+	var datas []string
+	for _, tm := range received {
+		datas = append(datas, tm.Data)
+	}
+	assert.Contains(t, datas, "order-1")
+	assert.Contains(t, datas, "inv-1")
+	assert.NotContains(t, datas, "order-2")
+}
+
+func TestSubscribeMultiWith_Snapshot(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(10))
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMultiWith(
+		[]string{"a", "b"},
+		SubWithSnapshot(func() string { return "snap" }),
+	)
+	defer unsub()
+
+	var received []TopicMessage
+	timeout := time.After(200 * time.Millisecond)
+	for {
+		select {
+		case msg := <-ch:
+			received = append(received, msg)
+			if len(received) >= 2 {
+				goto done
+			}
+		case <-timeout:
+			goto done
+		}
+	}
+done:
+	assert.Len(t, received, 2)
+	for _, msg := range received {
+		assert.Equal(t, "snap", msg.Data)
+	}
+}
+
+func TestSubscribeWith_ScopeAndSnapshot_OrderingGuarantee(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(10))
+	defer b.Close()
+
+	ch, unsub := b.SubscribeWith("topic",
+		SubWithScope("user:1"),
+		SubWithSnapshot(func() string { return "snapshot-data" }),
+	)
+	defer unsub()
+
+	// Publish a live message immediately.
+	b.PublishTo("topic", "user:1", "live-1")
+
+	var received []string
+	timeout := time.After(200 * time.Millisecond)
+	for {
+		select {
+		case msg := <-ch:
+			received = append(received, msg)
+			if len(received) >= 2 {
+				goto done
+			}
+		case <-timeout:
+			goto done
+		}
+	}
+done:
+	require.Len(t, received, 2)
+	assert.Equal(t, "snapshot-data", received[0], "snapshot should be first")
+	assert.Equal(t, "live-1", received[1], "live message should be second")
+}
+
+func TestSubscribeWith_FilterAndSnapshot_OrderingGuarantee(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(10))
+	defer b.Close()
+
+	ch, unsub := b.SubscribeWith("topic",
+		SubWithFilter(func(msg string) bool { return true }),
+		SubWithSnapshot(func() string { return "snapshot-data" }),
+	)
+	defer unsub()
+
+	// Publish a live message immediately.
+	b.Publish("topic", "live-1")
+
+	var received []string
+	timeout := time.After(200 * time.Millisecond)
+	for {
+		select {
+		case msg := <-ch:
+			received = append(received, msg)
+			if len(received) >= 2 {
+				goto done
+			}
+		case <-timeout:
+			goto done
+		}
+	}
+done:
+	require.Len(t, received, 2)
+	assert.Equal(t, "snapshot-data", received[0], "snapshot should be first")
+	assert.Equal(t, "live-1", received[1], "live message should be second")
+}
+
 func TestSubscribeWith_AdmissionDenied(t *testing.T) {
 	b := NewSSEBroker(WithMaxSubscribers(0), WithMaxSubscribersPerTopic(1))
 	defer b.Close()


### PR DESCRIPTION
## Summary
- `SubscribeMultiWith` now forwards `SubWithScope` and `SubWithSnapshot` options instead of silently ignoring them
- `SubscribeWithSnapshot` injects snapshot into the channel buffer before registering in the topics map, eliminating the race where a concurrent `Publish` could deliver a live message before the snapshot
- New unexported helpers for scope+snapshot, filter+snapshot, and scope+filter+snapshot combos follow the same atomic pattern
- `SubscribeWith` pre-computes snapshots and routes to the correct helper, removing post-hoc injection

## Test plan
- [x] `TestSubscribeMultiWith_Scope` — scoped messages filtered across multiple topics
- [x] `TestSubscribeMultiWith_Snapshot` — snapshots delivered for each topic
- [x] `TestSubscribeWith_ScopeAndSnapshot_OrderingGuarantee` — snapshot before live with scope
- [x] `TestSubscribeWith_FilterAndSnapshot_OrderingGuarantee` — snapshot before live with filter
- [x] All tests pass with `-race`

Closes #158, closes #160