### PR TITLE
fix: warn on SetReplayGapPolicy without ID-backed replay state

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,9 +701,15 @@ has been evicted; the broker treats this as a gap.
 ### Replay gap detection (OnReplayGap / SetReplayGapPolicy)
 
 Handle reconnections where the client's Last-Event-ID has rolled out of the
-replay log:
+replay log. Gap detection requires ID-backed replay — the topic must receive
+messages via `PublishWithID` (or `PublishWithTTL`) so that event IDs exist in
+the replay log. Without ID-backed publishes, `SetReplayGapPolicy` has no
+effect.
 
 ```go
+// Enable ID-backed replay so gap detection is meaningful.
+broker.SetReplayPolicy("dashboard", 100)
+
 broker.OnReplayGap("dashboard", func(sub *tavern.SubscriberInfo, lastID string) {
     slog.Warn("replay gap", "subscriber", sub.ID, "lastID", lastID)
 })

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -779,6 +779,12 @@ func sseHandler(broker *tavern.SSEBroker) echo.HandlerFunc {
 > than the buffer covers, it gets only live messages -- which is usually the
 > right trade-off.
 
+> **Note:** `SetReplayGapPolicy` and `OnReplayGap` only take effect when the
+> topic uses ID-backed replay (`PublishWithID` or `PublishWithTTL`). Calling
+> `SetReplayGapPolicy` on a topic that only uses plain `Publish` has no
+> effect — the stream never emits event IDs, so `Last-Event-ID` reconnection
+> is not meaningful.
+
 ---
 
 ## 12. Live dashboard with linkwell navigation

--- a/gap.go
+++ b/gap.go
@@ -28,6 +28,8 @@ type ReplayGapCallback func(sub *SubscriberInfo, lastEventID string)
 // with a Last-Event-ID that is no longer present in the replay log for the
 // given topic. The callback runs in its own goroutine and does not block the
 // subscription. Multiple callbacks per topic are allowed and all will fire.
+// Like [SSEBroker.SetReplayGapPolicy], gap callbacks are only meaningful
+// when the topic uses ID-backed replay (see SetReplayGapPolicy for details).
 // Calling this on a closed broker is a no-op.
 func (b *SSEBroker) OnReplayGap(topic string, fn ReplayGapCallback) {
 	b.mu.Lock()
@@ -49,11 +51,29 @@ func (b *SSEBroker) OnReplayGap(topic string, fn ReplayGapCallback) {
 //
 // The snapshotFn parameter is only used with [GapFallbackToSnapshot] and
 // may be nil for other strategies.
+//
+// Gap detection requires ID-backed replay state: the topic must receive
+// messages via [SSEBroker.PublishWithID] (or variants like PublishWithTTL)
+// so that a replay log with event IDs exists. Without ID-backed publishes,
+// subscribers never receive event IDs and Last-Event-ID reconnection is
+// not meaningful. Calling SetReplayGapPolicy on a topic that only uses
+// plain [SSEBroker.Publish] has no effect at runtime.
+//
+// If a [*slog.Logger] is configured via [WithLogger], a warning is logged
+// when this method is called for a topic that has no replay log entries
+// and no external [ReplayStore].
 func (b *SSEBroker) SetReplayGapPolicy(topic string, strategy GapStrategy, snapshotFn func() string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.closed {
 		return
+	}
+	if b.logger != nil && b.replayStore == nil && len(b.replayLog[topic]) == 0 {
+		if _, hasSize := b.replaySize[topic]; !hasSize {
+			b.logger.Warn("SetReplayGapPolicy called on topic with no ID-backed replay state; gap detection requires PublishWithID",
+				"topic", topic,
+			)
+		}
 	}
 	b.replayGapStrategy[topic] = strategy
 	if snapshotFn != nil {

--- a/gap_test.go
+++ b/gap_test.go
@@ -1,7 +1,9 @@
 package tavern
 
 import (
+	"bytes"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"testing"
@@ -443,4 +445,32 @@ func TestSubscribeFromID_GapSilentNoControlEvent(t *testing.T) {
 		t.Fatalf("expected no gap control event with GapSilent, got: %s", msg)
 	case <-time.After(50 * time.Millisecond):
 	}
+}
+
+func TestSetReplayGapPolicy_WarnsWithoutReplayState(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	b := NewSSEBroker(WithLogger(logger))
+	defer b.Close()
+
+	b.SetReplayGapPolicy("feed", GapFallbackToSnapshot, func() string {
+		return "<div>snapshot</div>"
+	})
+
+	assert.Contains(t, buf.String(), "no ID-backed replay state")
+}
+
+func TestSetReplayGapPolicy_NoWarnWithReplayState(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	b := NewSSEBroker(WithLogger(logger))
+	defer b.Close()
+
+	b.SetReplayPolicy("feed", 10)
+	b.PublishWithID("feed", "evt-1", "data: hello\n\n")
+	b.SetReplayGapPolicy("feed", GapFallbackToSnapshot, func() string {
+		return "<div>snapshot</div>"
+	})
+
+	assert.NotContains(t, buf.String(), "no ID-backed replay state")
 }


### PR DESCRIPTION
## Summary

Closes #170.

- Updated godoc on `SetReplayGapPolicy` and `OnReplayGap` to document the dependency on ID-backed replay state (`PublishWithID` / `PublishWithTTL`)
- Added a runtime `slog.Warn` when `SetReplayGapPolicy` is called on a topic with no replay log entries, no explicit replay size, and no external `ReplayStore` (only fires when a logger is configured via `WithLogger`)
- Updated README and RECIPES examples to show `SetReplayPolicy` before gap configuration and clarify the requirement

## Test plan

- [x] `TestSetReplayGapPolicy_WarnsWithoutReplayState` — warning fires on misconfigured topic
- [x] `TestSetReplayGapPolicy_NoWarnWithReplayState` — no warning when replay is properly configured
- [x] Full test suite passes (`go test ./...`)