### PR TITLE
fix: replay accounting overstates delivered events on buffer truncation

### DIFF
--- a/reconnect.go
+++ b/reconnect.go
@@ -1,6 +1,9 @@
 package tavern
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // ReconnectInfo provides context about a subscriber reconnection, including
 // the gap duration and number of missed messages. It is passed to callbacks
@@ -18,6 +21,13 @@ type ReconnectInfo struct {
 	// MissedCount is the number of messages published after LastEventID that
 	// the subscriber missed. Zero if the ID was not found in the replay log.
 	MissedCount int
+	// ReplayDelivered is the number of replay messages successfully enqueued
+	// to the subscriber channel. This may be less than MissedCount if the
+	// subscriber buffer was too small to hold all replay messages.
+	ReplayDelivered int
+	// ReplayDropped is the number of replay messages that could not be
+	// enqueued because the subscriber buffer was full.
+	ReplayDropped int
 	// SendToSubscriber sends a message directly to this subscriber's channel.
 	// The message is delivered as-is (raw SSE text). If the subscriber's buffer
 	// is full the message is dropped silently.
@@ -65,6 +75,13 @@ func (b *SSEBroker) SetBundleOnReconnect(topic string, bundle bool) {
 // notifies clients a reconnection was detected.
 func reconnectedControlEvent() string {
 	return NewSSEMessage("tavern-reconnected", "").String()
+}
+
+// replayTruncatedControlEvent returns an SSE control event indicating that
+// some replay messages were dropped due to subscriber buffer limits.
+func replayTruncatedControlEvent(delivered, dropped int) string {
+	return NewSSEMessage("tavern-replay-truncated",
+		fmt.Sprintf("delivered:%d dropped:%d", delivered, dropped)).String()
 }
 
 // buildReconnectInfo constructs a ReconnectInfo from the replay log state.

--- a/reconnect_test.go
+++ b/reconnect_test.go
@@ -48,6 +48,8 @@ func TestOnReconnect_FiresOnReconnection(t *testing.T) {
 	assert.Equal(t, "events", captured.Topic)
 	assert.Equal(t, "1", captured.LastEventID)
 	assert.Equal(t, 2, captured.MissedCount)
+	assert.Equal(t, 2, captured.ReplayDelivered)
+	assert.Equal(t, 0, captured.ReplayDropped)
 	assert.Greater(t, captured.Gap, time.Duration(0))
 
 	// Drain channel.
@@ -147,6 +149,8 @@ func TestOnReconnect_GapDurationAndMissedCount(t *testing.T) {
 	}
 
 	assert.Equal(t, 3, captured.MissedCount)
+	assert.Equal(t, 3, captured.ReplayDelivered)
+	assert.Equal(t, 0, captured.ReplayDropped)
 	assert.Greater(t, captured.Gap, 10*time.Millisecond)
 
 	drainCh(ch)
@@ -630,6 +634,8 @@ func TestOnReconnect_MissedCountAtEndOfLog(t *testing.T) {
 	}
 
 	assert.Equal(t, 0, captured.MissedCount)
+	assert.Equal(t, 0, captured.ReplayDelivered)
+	assert.Equal(t, 0, captured.ReplayDropped)
 	drainCh(ch)
 }
 
@@ -697,6 +703,113 @@ func TestOnReconnect_TopicIsolation(t *testing.T) {
 	}
 
 	drainCh(ch)
+}
+
+func TestOnReconnect_ReplayTruncation(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(3))
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 50)
+	// Publish enough messages to exceed the buffer.
+	for i := 1; i <= 20; i++ {
+		b.PublishWithID("events", fmt.Sprintf("%d", i), fmt.Sprintf("msg-%d", i))
+	}
+
+	var captured ReconnectInfo
+	done := make(chan struct{}, 1)
+
+	b.OnReconnect("events", func(info ReconnectInfo) {
+		captured = info
+		done <- struct{}{}
+	})
+
+	ch, unsub := b.SubscribeFromID("events", "1")
+	defer unsub()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("callback not fired")
+	}
+
+	assert.Equal(t, 19, captured.MissedCount)
+	assert.Equal(t, 19, captured.ReplayDelivered+captured.ReplayDropped)
+	assert.Greater(t, captured.ReplayDropped, 0, "expected some replay messages to be dropped")
+	assert.Greater(t, captured.ReplayDelivered, 0, "expected some replay messages to be delivered")
+
+	drainCh(ch)
+}
+
+func TestOnReconnect_NoTruncationEventWhenAllDelivered(t *testing.T) {
+	// When all replay messages fit in the buffer, no truncation event is sent.
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 50)
+	for i := 1; i <= 5; i++ {
+		b.PublishWithID("events", fmt.Sprintf("%d", i), fmt.Sprintf("msg-%d", i))
+	}
+
+	ch, unsub := b.SubscribeFromID("events", "1")
+	defer unsub()
+
+	var msgs []string
+	timeout := time.After(200 * time.Millisecond)
+	for {
+		select {
+		case msg := <-ch:
+			msgs = append(msgs, msg)
+		case <-timeout:
+			goto done
+		}
+	}
+done:
+	for _, m := range msgs {
+		assert.NotContains(t, m, "event: tavern-replay-truncated",
+			"no truncation event expected when all replay messages were delivered")
+	}
+}
+
+func TestBundleOnReconnect_TruncationAccounting(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(2))
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 50)
+	b.SetBundleOnReconnect("events", true)
+
+	for i := 1; i <= 20; i++ {
+		b.PublishWithID("events", fmt.Sprintf("%d", i), fmt.Sprintf("msg-%d", i))
+	}
+
+	var captured ReconnectInfo
+	done := make(chan struct{}, 1)
+
+	b.OnReconnect("events", func(info ReconnectInfo) {
+		captured = info
+		done <- struct{}{}
+	})
+
+	ch, unsub := b.SubscribeFromID("events", "1")
+	defer unsub()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("callback not fired")
+	}
+
+	// Bundled: either all delivered or all dropped.
+	assert.Equal(t, 19, captured.MissedCount)
+	assert.Equal(t, 19, captured.ReplayDelivered+captured.ReplayDropped)
+
+	drainCh(ch)
+}
+
+func TestReplayTruncatedControlEvent_Format(t *testing.T) {
+	msg := replayTruncatedControlEvent(5, 3)
+	assert.Contains(t, msg, "event: tavern-replay-truncated")
+	assert.Contains(t, msg, "delivered:5 dropped:3")
+	assert.True(t, strings.HasSuffix(msg, "\n\n"), "SSE message must end with double newline")
 }
 
 func TestOnReconnect_ConcurrentSafety(t *testing.T) {

--- a/resume.go
+++ b/resume.go
@@ -227,10 +227,6 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 		case ch <- controlMsg:
 		default:
 		}
-		// Fire reconnect callbacks in their own goroutines.
-		for _, fn := range reconnectCallbacks {
-			go fn(reconnectInfo)
-		}
 	}
 
 	// Handle replay gap: fire callbacks, optionally send control event and snapshot.
@@ -258,6 +254,7 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 	}
 
 	// Deliver replay messages, optionally bundled into a single write.
+	var replayDelivered, replayDropped int
 	if bundle && len(replayMsgs) > 0 {
 		var bundled strings.Builder
 		for _, msg := range replayMsgs {
@@ -265,12 +262,32 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 		}
 		select {
 		case ch <- bundled.String():
+			replayDelivered = len(replayMsgs)
 		default:
+			replayDropped = len(replayMsgs)
 		}
 	} else {
 		for _, msg := range replayMsgs {
 			select {
 			case ch <- msg:
+				replayDelivered++
+			default:
+				replayDropped++
+			}
+		}
+	}
+
+	// Populate replay delivery stats and fire reconnect callbacks.
+	if isReconnect {
+		reconnectInfo.ReplayDelivered = replayDelivered
+		reconnectInfo.ReplayDropped = replayDropped
+		for _, fn := range reconnectCallbacks {
+			go fn(reconnectInfo)
+		}
+		// Emit truncation control event when replay messages were dropped.
+		if replayDropped > 0 {
+			select {
+			case ch <- replayTruncatedControlEvent(replayDelivered, replayDropped):
 			default:
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes #175

- Added `ReplayDelivered` and `ReplayDropped` fields to `ReconnectInfo` so callers get accurate counts of how many replay messages were actually enqueued vs silently dropped due to buffer pressure
- Moved reconnect callback firing to after replay delivery so callbacks receive populated delivery stats
- Added best-effort `tavern-replay-truncated` SSE control event emitted when replay drops occur
- Added tests for truncation accounting (non-bundled and bundled), format verification, and updated existing tests to assert on the new fields

## Test plan

- [x] Existing tests updated with `ReplayDelivered`/`ReplayDropped` assertions
- [x] `TestOnReconnect_ReplayTruncation` — verifies dropped > 0 with small buffer
- [x] `TestBundleOnReconnect_TruncationAccounting` — verifies bundled mode accounting
- [x] `TestReplayTruncatedControlEvent_Format` — verifies SSE wire format
- [x] `TestOnReconnect_NoTruncationEventWhenAllDelivered` — no false positives
- [x] `go test ./...` passes