### PR TITLE
docs: document buffer size impact on reconnect replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,43 @@ broker.OnReconnect("dashboard", func(info tavern.ReconnectInfo) {
 broker.SetBundleOnReconnect("dashboard", true)
 ```
 
+### Buffer sizing for replay
+
+The subscriber buffer (`WithBufferSize`) and the replay window (`SetReplayPolicy`)
+serve different purposes:
+
+- **Replay window** determines how many past messages Tavern *retains* for
+  Last-Event-ID resumption.
+- **Buffer size** determines how many messages can be *queued* to a subscriber
+  channel at once — including replay messages delivered on reconnect.
+
+During reconnect, Tavern enqueues all eligible replay messages into the
+subscriber channel using non-blocking sends. If the replay burst exceeds the
+available buffer capacity, excess messages are dropped and a
+`tavern-replay-truncated` control event is emitted with the delivery counts.
+
+**Rule of thumb:** if you expect reconnect bursts of up to *N* missed messages,
+set the buffer size to at least *N* plus headroom for control events and
+concurrent live publishes:
+
+```go
+broker := tavern.NewSSEBroker(
+    tavern.WithBufferSize(64), // enough for reconnect bursts up to ~60 messages
+)
+broker.SetReplayPolicy("dashboard", 50)
+```
+
+| Scenario | Suggested buffer size |
+|----------|----------------------|
+| Small replay windows (≤ 10 messages) | Default (`10`) is fine |
+| Demo / test with intentional reconnect gaps | `64`–`128` |
+| Production with large replay windows | At least replay window size + 10–20 headroom |
+
+> **Note:** `SetBundleOnReconnect` combines all replay messages into a single
+> channel write, which avoids per-message buffer pressure. When bundling is
+> enabled, buffer size only needs to accommodate the single bundled write plus
+> control events.
+
 ### Adaptive backpressure
 
 Tiered response to slow subscribers -- throttle, simplify, then disconnect:
@@ -1023,7 +1060,7 @@ broker2 := tavern.NewSSEBroker(tavern.WithBackend(fork))
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `WithBufferSize(n)` | 10 | Subscriber channel buffer capacity |
+| `WithBufferSize(n)` | 10 | Subscriber channel buffer capacity. Also limits how many replay messages can be queued during reconnect — see [Buffer sizing for replay](#buffer-sizing-for-replay) |
 | `WithDropOldest()` | drop newest | Discard oldest queued message when buffer full |
 | `WithKeepalive(d)` | disabled | Send SSE comment keepalives at interval |
 | `WithTopicTTL(d)` | disabled | Auto-remove topics with no subscribers after TTL |

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -779,6 +779,12 @@ func sseHandler(broker *tavern.SSEBroker) echo.HandlerFunc {
 > than the buffer covers, it gets only live messages -- which is usually the
 > right trade-off.
 
+> **Tip:** The subscriber buffer size (`WithBufferSize`) limits how many replay
+> messages can be queued during reconnect. If you set a large replay policy,
+> make sure the buffer is large enough to hold the replay burst — otherwise
+> some replayed messages will be dropped silently. For example, with a replay
+> policy of 50, use `WithBufferSize(64)` or larger.
+
 > **Note:** `SetReplayGapPolicy` and `OnReplayGap` only take effect when the
 > topic uses ID-backed replay (`PublishWithID` or `PublishWithTTL`). Calling
 > `SetReplayGapPolicy` on a topic that only uses plain `Publish` has no


### PR DESCRIPTION
## Summary

- Added a "Buffer sizing for replay" section to README.md explaining how `WithBufferSize` interacts with reconnect replay delivery
- Enhanced the `WithBufferSize` row in the configuration table to cross-reference the new section
- Added a tip to RECIPES.md warning users to size the buffer to match their replay policy

Closes #176