### PR TITLE
fix: race in StreamSSE tests under -race

### DIFF
--- a/stream_test.go
+++ b/stream_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -30,18 +29,16 @@ func (n *nonFlushResponseWriter) Header() http.Header         { return n.header 
 func (n *nonFlushResponseWriter) Write(b []byte) (int, error) { return n.body.Write(b) }
 func (n *nonFlushResponseWriter) WriteHeader(code int)        { n.code = code }
 
-// waitFor polls cond every 2ms until it returns true or timeout elapses.
-func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if cond() {
-			return
-		}
-		time.Sleep(2 * time.Millisecond)
-	}
-	t.Fatalf("waitFor: condition not met within %s", timeout)
-}
+// The tests in this file deliberately avoid concurrent access to the
+// flushRecorder. StreamSSE writes to rec.Header() and rec.Body; reading
+// those from the main goroutine while StreamSSE runs in a background
+// goroutine would race under -race. The pattern used here is:
+//
+//   - Pre-fill and close the channel, then call StreamSSE synchronously.
+//     The loop drains the buffered values and returns on the channel close.
+//   - Only tests that genuinely need mid-stream timing (Heartbeat,
+//     ContextCancellation) spawn a goroutine, and they read rec only
+//     after receiving from the done channel.
 
 func TestStreamSSE_StreamsString(t *testing.T) {
 	t.Parallel()
@@ -50,21 +47,11 @@ func TestStreamSSE_StreamsString(t *testing.T) {
 	ch <- NewSSEMessage("ping", "one").String()
 	ch <- NewSSEMessage("ping", "two").String()
 	ch <- NewSSEMessage("ping", "three").String()
+	close(ch)
 
 	rec := newFlushRecorder()
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- StreamSSE(ctx, rec, ch, func(s string) string { return s })
-	}()
-
-	waitFor(t, time.Second, func() bool {
-		return strings.Count(rec.Body.String(), "data: three") == 1
-	})
-	cancel()
-	require.NoError(t, <-done)
+	err := StreamSSE(t.Context(), rec, ch, func(s string) string { return s })
+	require.NoError(t, err)
 
 	body := rec.Body.String()
 	assert.Contains(t, body, "data: one")
@@ -78,23 +65,13 @@ func TestStreamSSE_StreamsTopicMessage(t *testing.T) {
 	ch := make(chan TopicMessage, 2)
 	ch <- TopicMessage{Topic: "orders", Data: "created"}
 	ch <- TopicMessage{Topic: "invoices", Data: "paid"}
+	close(ch)
 
 	rec := newFlushRecorder()
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- StreamSSE(ctx, rec, ch, func(tm TopicMessage) string {
-			return NewSSEMessage(tm.Topic, tm.Data).String()
-		})
-	}()
-
-	waitFor(t, time.Second, func() bool {
-		return strings.Contains(rec.Body.String(), "event: invoices")
+	err := StreamSSE(t.Context(), rec, ch, func(tm TopicMessage) string {
+		return NewSSEMessage(tm.Topic, tm.Data).String()
 	})
-	cancel()
-	require.NoError(t, <-done)
+	require.NoError(t, err)
 
 	body := rec.Body.String()
 	assert.Contains(t, body, "event: orders\ndata: created")
@@ -127,21 +104,11 @@ func TestStreamSSE_ChannelClose(t *testing.T) {
 	t.Parallel()
 
 	ch := make(chan string)
-	rec := newFlushRecorder()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- StreamSSE(t.Context(), rec, ch, func(s string) string { return s })
-	}()
-
 	close(ch)
 
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		t.Fatal("StreamSSE did not return after channel close")
-	}
+	rec := newFlushRecorder()
+	err := StreamSSE(t.Context(), rec, ch, func(s string) string { return s })
+	require.NoError(t, err)
 }
 
 func TestStreamSSE_MissingFlusher(t *testing.T) {
@@ -165,25 +132,19 @@ func TestStreamSSE_MissingFlusher(t *testing.T) {
 func TestStreamSSE_HeadersSet(t *testing.T) {
 	t.Parallel()
 
-	rec := newFlushRecorder()
+	// Pre-closed channel: StreamSSE sets headers, enters the select loop,
+	// immediately receives the !ok from the closed channel, and returns.
+	// This gives us synchronous access to rec.Header() with no race.
 	ch := make(chan string)
-	ctx, cancel := context.WithCancel(t.Context())
+	close(ch)
 
-	done := make(chan error, 1)
-	go func() {
-		done <- StreamSSE(ctx, rec, ch, func(s string) string { return s })
-	}()
-
-	waitFor(t, time.Second, func() bool {
-		return rec.Header().Get("Content-Type") == "text/event-stream"
-	})
+	rec := newFlushRecorder()
+	err := StreamSSE(t.Context(), rec, ch, func(s string) string { return s })
+	require.NoError(t, err)
 
 	assert.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"))
 	assert.Equal(t, "no-cache", rec.Header().Get("Cache-Control"))
 	assert.Equal(t, "keep-alive", rec.Header().Get("Connection"))
-
-	cancel()
-	<-done
 }
 
 func TestStreamSSE_Snapshot(t *testing.T) {
@@ -191,24 +152,15 @@ func TestStreamSSE_Snapshot(t *testing.T) {
 
 	ch := make(chan string, 1)
 	ch <- NewSSEMessage("update", "live").String()
-
-	rec := newFlushRecorder()
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
+	close(ch)
 
 	snapshot := NewSSEMessage("snapshot", "initial").String()
-	done := make(chan error, 1)
-	go func() {
-		done <- StreamSSE(ctx, rec, ch, func(s string) string { return s },
-			WithStreamSnapshot(func() string { return snapshot }),
-		)
-	}()
 
-	waitFor(t, time.Second, func() bool {
-		return strings.Contains(rec.Body.String(), "data: live")
-	})
-	cancel()
-	require.NoError(t, <-done)
+	rec := newFlushRecorder()
+	err := StreamSSE(t.Context(), rec, ch, func(s string) string { return s },
+		WithStreamSnapshot(func() string { return snapshot }),
+	)
+	require.NoError(t, err)
 
 	body := rec.Body.String()
 	snapshotIdx := strings.Index(body, "data: initial")
@@ -223,29 +175,19 @@ func TestStreamSSE_SnapshotEmpty(t *testing.T) {
 
 	ch := make(chan string, 1)
 	ch <- NewSSEMessage("event", "hello").String()
+	close(ch)
 
+	var snapshotCalls int
 	rec := newFlushRecorder()
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
+	err := StreamSSE(t.Context(), rec, ch, func(s string) string { return s },
+		WithStreamSnapshot(func() string {
+			snapshotCalls++
+			return ""
+		}),
+	)
+	require.NoError(t, err)
 
-	var snapshotCalls int32
-	done := make(chan error, 1)
-	go func() {
-		done <- StreamSSE(ctx, rec, ch, func(s string) string { return s },
-			WithStreamSnapshot(func() string {
-				atomic.AddInt32(&snapshotCalls, 1)
-				return ""
-			}),
-		)
-	}()
-
-	waitFor(t, time.Second, func() bool {
-		return strings.Contains(rec.Body.String(), "data: hello")
-	})
-	cancel()
-	require.NoError(t, <-done)
-
-	assert.Equal(t, int32(1), atomic.LoadInt32(&snapshotCalls))
+	assert.Equal(t, 1, snapshotCalls)
 	// Body should contain exactly one event — the live one.
 	assert.Equal(t, 1, strings.Count(rec.Body.String(), "event: event"))
 }
@@ -256,7 +198,6 @@ func TestStreamSSE_Heartbeat(t *testing.T) {
 	ch := make(chan string)
 	rec := newFlushRecorder()
 	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 
 	done := make(chan error, 1)
 	go func() {
@@ -265,12 +206,16 @@ func TestStreamSSE_Heartbeat(t *testing.T) {
 		)
 	}()
 
-	waitFor(t, time.Second, func() bool {
-		return strings.Count(rec.Body.String(), ": keepalive\n\n") >= 2
-	})
+	// Let the heartbeat fire a few times before cancelling. We do NOT read
+	// rec from the main goroutine while the streaming goroutine is running —
+	// that would race on rec.Body. The sleep is bounded and deterministic:
+	// 60ms / 10ms = 6 expected ticks, well above the asserted minimum of 2.
+	time.Sleep(60 * time.Millisecond)
 	cancel()
 	require.NoError(t, <-done)
 
+	// Safe to read rec.Body after <-done; the goroutine has exited and the
+	// receive on done establishes happens-before with the writes inside it.
 	assert.GreaterOrEqual(t, strings.Count(rec.Body.String(), ": keepalive\n\n"), 2)
 }
 
@@ -282,10 +227,7 @@ func TestStreamSSE_EncoderEmptySkips(t *testing.T) {
 	ch <- 2 // skipped
 	ch <- 3
 	ch <- 4 // skipped
-
-	rec := newFlushRecorder()
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
+	close(ch)
 
 	encode := func(n int) string {
 		if n%2 == 0 {
@@ -294,16 +236,9 @@ func TestStreamSSE_EncoderEmptySkips(t *testing.T) {
 		return NewSSEMessage("odd", string(rune('0'+n))).String()
 	}
 
-	done := make(chan error, 1)
-	go func() {
-		done <- StreamSSE(ctx, rec, ch, encode)
-	}()
-
-	waitFor(t, time.Second, func() bool {
-		return strings.Contains(rec.Body.String(), "data: 3")
-	})
-	cancel()
-	require.NoError(t, <-done)
+	rec := newFlushRecorder()
+	err := StreamSSE(t.Context(), rec, ch, encode)
+	require.NoError(t, err)
 
 	body := rec.Body.String()
 	assert.Contains(t, body, "data: 1")
@@ -320,16 +255,12 @@ func TestStreamSSE_CustomWriter(t *testing.T) {
 	ch := make(chan string, 2)
 	ch <- "frame-a"
 	ch <- "frame-b"
+	close(ch)
 
-	rec := newFlushRecorder()
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	var calls int32
+	var calls int
 	custom := func(w http.ResponseWriter, msg string) error {
-		atomic.AddInt32(&calls, 1)
-		_, err := w.Write([]byte("custom:" + msg + "|"))
-		if err != nil {
+		calls++
+		if _, err := w.Write([]byte("custom:" + msg + "|")); err != nil {
 			return err
 		}
 		if f, ok := w.(http.Flusher); ok {
@@ -338,20 +269,13 @@ func TestStreamSSE_CustomWriter(t *testing.T) {
 		return nil
 	}
 
-	done := make(chan error, 1)
-	go func() {
-		done <- StreamSSE(ctx, rec, ch, func(s string) string { return s },
-			WithStreamWriter(custom),
-		)
-	}()
+	rec := newFlushRecorder()
+	err := StreamSSE(t.Context(), rec, ch, func(s string) string { return s },
+		WithStreamWriter(custom),
+	)
+	require.NoError(t, err)
 
-	waitFor(t, time.Second, func() bool {
-		return atomic.LoadInt32(&calls) >= 2
-	})
-	cancel()
-	require.NoError(t, <-done)
-
-	assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(2))
+	assert.Equal(t, 2, calls)
 	body := rec.Body.String()
 	assert.Contains(t, body, "custom:frame-a|")
 	assert.Contains(t, body, "custom:frame-b|")


### PR DESCRIPTION
Fixes the main-branch CI failure introduced by #199 and closes the current reopening of #16.

## Problem

The new StreamSSE tests polled \`rec.Header()\` and \`rec.Body.String()\` from the main goroutine while \`StreamSSE\` ran in a spawned goroutine writing to those same fields. CI runs \`go test -race\`, which rightly caught the concurrent map access (\`http.Header\`) and the concurrent \`bytes.Buffer\` writes inside \`httptest.ResponseRecorder.Body\`.

Local \`go test ./...\` without \`-race\` passed, which is how this slipped through.

Example race site (from the CI log):

\`\`\`
WARNING: DATA RACE
Write at ... by goroutine 2372:
  net/http.Header.Set()
  github.com/catgoose/tavern.StreamSSE[go.shape.string]()
      stream.go:109
  github.com/catgoose/tavern.TestStreamSSE_HeadersSet.func1()
      stream_test.go:174
Previous read ...
  net/http.Header.Get()
  github.com/catgoose/tavern.TestStreamSSE_HeadersSet.func2()
      stream_test.go:178
\`\`\`

## Fix

Restructure the tests so \`rec\` is only accessed from one goroutine at a time:

- **Synchronous tests.** Tests that just verify output pre-fill and close the channel, then call \`StreamSSE\` synchronously. The select loop drains the buffered values and returns on channel close — no goroutine at all, no possible race. This applies to \`StreamsString\`, \`StreamsTopicMessage\`, \`ChannelClose\`, \`HeadersSet\`, \`Snapshot\`, \`SnapshotEmpty\`, \`EncoderEmptySkips\`, and \`CustomWriter\`.
- **Timing-sensitive tests.** \`Heartbeat\` and \`ContextCancellation\` genuinely need mid-stream timing, so they still spawn a goroutine — but they only read \`rec\` **after** receiving from the \`done\` channel, which establishes happens-before ordering with the goroutine's writes.
- **Helper cleanup.** Remove the \`waitFor\` polling helper, which is no longer needed. Drop \`sync/atomic\` in favour of plain ints since the affected counters are no longer touched concurrently.

## Verification

\`\`\`
$ go test -race ./...
ok      github.com/catgoose/tavern              20.958s
ok      github.com/catgoose/tavern/backend      (cached)
ok      github.com/catgoose/tavern/backend/memory       (cached)
ok      github.com/catgoose/tavern/presence     (cached)
ok      github.com/catgoose/tavern/taverntest   (cached)
\`\`\`

Also clean under \`go vet ./...\` and \`gofmt -l stream.go stream_test.go\`.

No changes to \`stream.go\` — the primitive itself was correct; only the test harness was racy.

## Test plan

- [x] \`go test -race ./...\` passes locally
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l\` clean