### PR TITLE
feat: composable resume-aware SubscribeFromIDWith (#201)

### DIFF
--- a/resume.go
+++ b/resume.go
@@ -87,6 +87,22 @@ func (b *SSEBroker) PublishWithID(topic, id, msg string) {
 // protocol. The HTTP handler should read the Last-Event-ID header from
 // the request and pass it here.
 func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan string, unsubscribe func()) {
+	return b.subscribeFromIDInternal(topic, lastEventID, subscribeConfig{})
+}
+
+// subscribeFromIDInternal is the shared implementation behind
+// [SSEBroker.SubscribeFromID] and [SSEBroker.SubscribeFromIDWith]. It handles
+// registration, replay, reconnect control events, gap fallback, and delivery
+// of replay messages. Rate limiting is applied by callers (never to replay
+// messages).
+func (b *SSEBroker) subscribeFromIDInternal(topic, lastEventID string, cfg subscribeConfig) (msgs <-chan string, unsubscribe func()) {
+	// Pre-compute the fresh-subscribe snapshot outside the lock to mirror
+	// SubscribeWith's atomic ordering.
+	var preSnap string
+	if cfg.snapshotFn != nil && lastEventID == "" {
+		preSnap = cfg.snapshotFn()
+	}
+
 	b.mu.Lock()
 	if b.closed {
 		b.mu.Unlock()
@@ -100,11 +116,45 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 	}
 	ch := make(chan string, b.bufferSize)
 	b.chanGuards.Store(ch, &chanGuard{})
-	if b.topics[topic] == nil {
-		b.topics[topic] = make(map[chan string]struct{})
+
+	// Inject snapshot BEFORE registering so no live publish can race ahead.
+	// Only applies to fresh subscribes; resumes rely on replay instead.
+	if preSnap != "" {
+		select {
+		case ch <- preSnap:
+		default:
+		}
 	}
-	b.topics[topic][ch] = struct{}{}
-	b.subscriberMeta[ch] = &SubscriberInfo{Topic: topic, ConnectedAt: time.Now()}
+
+	scoped := cfg.scope != ""
+	if scoped {
+		if b.scopedTopics[topic] == nil {
+			b.scopedTopics[topic] = make(map[chan string]scopedSub)
+		}
+		b.scopedTopics[topic][ch] = scopedSub{scope: cfg.scope}
+		b.subscriberMeta[ch] = &SubscriberInfo{Topic: topic, Scope: cfg.scope, ConnectedAt: time.Now()}
+	} else {
+		if b.topics[topic] == nil {
+			b.topics[topic] = make(map[chan string]struct{})
+		}
+		b.topics[topic][ch] = struct{}{}
+		b.subscriberMeta[ch] = &SubscriberInfo{Topic: topic, ConnectedAt: time.Now()}
+	}
+
+	if cfg.meta != nil {
+		if info := b.subscriberMeta[ch]; info != nil {
+			info.ID = cfg.meta.ID
+			info.Meta = cfg.meta.Meta
+		}
+	}
+
+	if cfg.filter != nil {
+		if b.filterPredicates == nil {
+			b.filterPredicates = make(map[chan string]FilterPredicate)
+		}
+		b.filterPredicates[ch] = cfg.filter
+	}
+
 	total := len(b.topics[topic]) + len(b.scopedTopics[topic])
 	var firstHooks []func(string)
 	if total == 1 {
@@ -220,6 +270,19 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 		}
 	}
 
+	// Apply replay filter: filter predicate applies uniformly to replay and
+	// live messages. Control events are generated inline and bypass the
+	// filter (they are never stored in filterPredicates).
+	if cfg.filter != nil && len(replayMsgs) > 0 {
+		filtered := replayMsgs[:0]
+		for _, msg := range replayMsgs {
+			if cfg.filter(msg) {
+				filtered = append(filtered, msg)
+			}
+		}
+		replayMsgs = filtered
+	}
+
 	// Send reconnected control event when Last-Event-ID is present.
 	if isReconnect {
 		controlMsg := reconnectedControlEvent()
@@ -292,12 +355,33 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 			}
 		}
 	}
-	return ch, func() {
+
+	unsub := b.makeSubscribeFromIDUnsubscribe(topic, ch, scoped)
+	return ch, unsub
+}
+
+// makeSubscribeFromIDUnsubscribe builds an unsubscribe closure for
+// subscriptions created via [SSEBroker.subscribeFromIDInternal]. It cleans up
+// topic/scoped maps, subscriber metadata, filter predicates, and drop counts.
+func (b *SSEBroker) makeSubscribeFromIDUnsubscribe(topic string, ch chan string, scoped bool) func() {
+	return func() {
 		b.mu.Lock()
 		var lastHooks []func(string)
-		if _, ok := b.topics[topic][ch]; ok {
-			delete(b.topics[topic], ch)
+		var removed bool
+		if scoped {
+			if _, ok := b.scopedTopics[topic][ch]; ok {
+				delete(b.scopedTopics[topic], ch)
+				removed = true
+			}
+		} else {
+			if _, ok := b.topics[topic][ch]; ok {
+				delete(b.topics[topic], ch)
+				removed = true
+			}
+		}
+		if removed {
 			delete(b.subscriberMeta, ch)
+			delete(b.filterPredicates, ch)
 			b.closeChan(ch)
 			total := len(b.topics[topic]) + len(b.scopedTopics[topic])
 			if total == 0 {
@@ -316,4 +400,56 @@ func (b *SSEBroker) SubscribeFromID(topic, lastEventID string) (msgs <-chan stri
 		}
 		b.publishConnectionEvent("unsubscribe", topic, -1)
 	}
+}
+
+// SubscribeFromIDWith creates a composable resume-aware subscription. When
+// lastEventID is empty it behaves like [SSEBroker.SubscribeWith] with
+// replay-cache replay. When lastEventID is non-empty it replays messages from
+// the ID-backed replay log after that ID, emits a tavern-reconnected control
+// event, and handles gap fallback consistently with
+// [SSEBroker.SubscribeFromID].
+//
+// Option semantics:
+//
+//   - [SubWithFilter]:   applies uniformly to replay AND live messages.
+//     Control events (tavern-reconnected, tavern-replay-gap,
+//     tavern-replay-truncated) always bypass the filter.
+//   - [SubWithMeta]:     applied the same as live subscriptions.
+//   - [SubWithSnapshot]: applied ONLY on fresh subscribe (lastEventID is
+//     empty); never delivered on successful resume. Gap-fallback snapshot
+//     is a separate mechanism configured via
+//     [SSEBroker.SetReplayGapPolicy].
+//   - [SubWithRate]:     applied to LIVE delivery only. Replay messages are
+//     delivered directly and are NOT rate-limited.
+//   - [SubWithScope]:    sets the subscriber scope for live scope filtering.
+//     The replay log is scope-less, so any replayed messages are delivered
+//     regardless of scope. Note that [SSEBroker.PublishWithID] publishes only
+//     to unscoped subscribers, so a scoped resume subscriber will only receive
+//     live messages via scope-aware publish paths such as
+//     [SSEBroker.PublishTo].
+func (b *SSEBroker) SubscribeFromIDWith(topic, lastEventID string, opts ...SubscribeOption) (msgs <-chan string, unsubscribe func()) {
+	cfg := buildSubscribeConfig(opts)
+	ch, unsub := b.subscribeFromIDInternal(topic, lastEventID, cfg)
+	if ch == nil {
+		return nil, nil
+	}
+
+	// Apply rate limiting to LIVE delivery only. Replay has already been
+	// written directly to the channel above and is not affected.
+	if cfg.rate != nil {
+		interval := cfg.rate.interval()
+		if interval > 0 {
+			biCh := b.findBiChanAny(topic, ch)
+			if biCh != nil {
+				b.rateLimit.add(biCh, topic, interval)
+				origUnsub := unsub
+				unsub = func() {
+					b.rateLimit.remove(biCh)
+					origUnsub()
+				}
+			}
+		}
+	}
+
+	return ch, unsub
 }

--- a/resume_options_test.go
+++ b/resume_options_test.go
@@ -1,0 +1,388 @@
+package tavern
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubscribeFromIDWith_FilterAppliesToReplayAndLive(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(32))
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	for i := 1; i <= 5; i++ {
+		var body string
+		if i%2 == 0 {
+			body = fmt.Sprintf("keep-%d", i)
+		} else {
+			body = fmt.Sprintf("drop-%d", i)
+		}
+		b.PublishWithID("events", fmt.Sprintf("%d", i), body)
+	}
+
+	ch, unsub := b.SubscribeFromIDWith("events", "1",
+		SubWithFilter(func(msg string) bool {
+			return strings.Contains(msg, "keep")
+		}),
+	)
+	require.NotNil(t, ch)
+	defer unsub()
+
+	// First message must be the reconnect control event (always bypasses filter).
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reconnected control event")
+	}
+
+	// Replay messages 2..5, but only "keep-2" and "keep-4" should pass.
+	var replay []string
+	timeout := time.After(200 * time.Millisecond)
+	for len(replay) < 2 {
+		select {
+		case msg := <-ch:
+			replay = append(replay, msg)
+		case <-timeout:
+			t.Fatalf("timed out waiting for filtered replay messages, got %v", replay)
+		}
+	}
+	require.Len(t, replay, 2)
+	assert.Contains(t, replay[0], "keep-2")
+	assert.Contains(t, replay[1], "keep-4")
+
+	// Verify the filtered-out messages are not buffered.
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected extra replay message: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Now publish more live messages and verify filter still applies.
+	b.PublishWithID("events", "6", "drop-6")
+	b.PublishWithID("events", "7", "keep-7")
+	b.PublishWithID("events", "8", "drop-8")
+	b.PublishWithID("events", "9", "keep-9")
+
+	var live []string
+	timeout = time.After(time.Second)
+	for len(live) < 2 {
+		select {
+		case msg := <-ch:
+			live = append(live, msg)
+		case <-timeout:
+			t.Fatalf("timed out waiting for live messages, got %v", live)
+		}
+	}
+	require.Len(t, live, 2)
+	assert.Contains(t, live[0], "keep-7")
+	assert.Contains(t, live[1], "keep-9")
+}
+
+func TestSubscribeFromIDWith_MetaAppliesOnResume(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(16))
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	b.PublishWithID("events", "1", "msg-1")
+	b.PublishWithID("events", "2", "msg-2")
+
+	_, unsub := b.SubscribeFromIDWith("events", "1",
+		SubWithMeta(SubscribeMeta{
+			ID:   "user-1",
+			Meta: map[string]string{"role": "admin"},
+		}),
+	)
+	defer unsub()
+
+	subs := b.Subscribers("events")
+	require.Len(t, subs, 1)
+	assert.Equal(t, "user-1", subs[0].ID)
+	assert.Equal(t, "events", subs[0].Topic)
+	require.NotNil(t, subs[0].Meta)
+	assert.Equal(t, "admin", subs[0].Meta["role"])
+}
+
+func TestSubscribeFromIDWith_RateLimitsLiveNotReplay(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(64))
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	for i := 1; i <= 5; i++ {
+		b.PublishWithID("events", fmt.Sprintf("%d", i), fmt.Sprintf("replay-%d", i))
+	}
+
+	ch, unsub := b.SubscribeFromIDWith("events", "",
+		SubWithRate(Rate{MinInterval: 200 * time.Millisecond}),
+	)
+	require.NotNil(t, ch)
+	defer unsub()
+
+	// All 5 replay messages should arrive in a burst (well under the rate).
+	start := time.Now()
+	var replay []string
+	for len(replay) < 5 {
+		select {
+		case msg := <-ch:
+			replay = append(replay, msg)
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for replay burst, got %d", len(replay))
+		}
+	}
+	burstElapsed := time.Since(start)
+	assert.Less(t, burstElapsed, 100*time.Millisecond, "replay should not be rate-limited")
+	require.Len(t, replay, 5)
+
+	// Now publish two live messages back-to-back. The first should arrive
+	// quickly (no held state) and the second should be held by the rate
+	// limiter and delivered after the interval as the latest-wins value.
+	b.PublishWithID("events", "10", "live-a")
+	// Drain the first live message.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "live-a")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first live message")
+	}
+
+	// Publish two more in quick succession; only the latest should arrive
+	// after the rate-limit interval, not immediately.
+	b.PublishWithID("events", "11", "live-b")
+	b.PublishWithID("events", "12", "live-c")
+
+	// Within ~50ms (well under 200ms interval) we should NOT see live-c yet.
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected immediate delivery while rate-limited: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// After the interval elapses, live-c should be delivered (latest-wins).
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "live-c")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for held live message")
+	}
+}
+
+func TestSubscribeFromIDWith_SnapshotOnFreshSubscribe(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(16))
+	defer b.Close()
+
+	ch, unsub := b.SubscribeFromIDWith("events", "",
+		SubWithSnapshot(func() string { return "snapshot-payload" }),
+	)
+	require.NotNil(t, ch)
+	defer unsub()
+
+	// Snapshot must be the first message delivered.
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "snapshot-payload", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for snapshot on fresh subscribe")
+	}
+
+	// Live messages still flow.
+	b.Publish("events", "live")
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "live", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for live message")
+	}
+}
+
+func TestSubscribeFromIDWith_SnapshotSkippedOnResume(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(16))
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	for i := 1; i <= 3; i++ {
+		b.PublishWithID("events", fmt.Sprintf("%d", i), fmt.Sprintf("msg-%d", i))
+	}
+
+	snapCalled := false
+	ch, unsub := b.SubscribeFromIDWith("events", "1",
+		SubWithSnapshot(func() string {
+			snapCalled = true
+			return "should-not-be-delivered"
+		}),
+	)
+	require.NotNil(t, ch)
+	defer unsub()
+
+	assert.False(t, snapCalled, "snapshot fn must not be invoked on resume")
+
+	// First message must be the reconnect control event, not the snapshot.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+		assert.NotContains(t, msg, "should-not-be-delivered")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reconnected control event")
+	}
+
+	// Replay messages 2 and 3 should follow.
+	var replay []string
+	for len(replay) < 2 {
+		select {
+		case msg := <-ch:
+			replay = append(replay, msg)
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for replay, got %d", len(replay))
+		}
+	}
+	require.Len(t, replay, 2)
+	assert.Contains(t, replay[0], "msg-2")
+	assert.Contains(t, replay[1], "msg-3")
+
+	// And nothing else.
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected extra message after replay: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestSubscribeFromIDWith_ReconnectControlEventBypassesFilter(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(16))
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	b.PublishWithID("events", "1", "drop-1")
+	b.PublishWithID("events", "2", "drop-2")
+
+	// Filter rejects everything to prove the control event bypasses it.
+	ch, unsub := b.SubscribeFromIDWith("events", "1",
+		SubWithFilter(func(msg string) bool { return false }),
+	)
+	require.NotNil(t, ch)
+	defer unsub()
+
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected",
+			"reconnect control event must be delivered even when the filter rejects everything")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reconnected control event")
+	}
+
+	// No filtered replay should arrive.
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected message past the reject-all filter: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Live publishes should also be filtered out.
+	b.PublishWithID("events", "3", "drop-3")
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected live message past the reject-all filter: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestSubscribeFromIDWith_GapFallbackStillWorks(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(16))
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	b.SetReplayGapPolicy("events", GapFallbackToSnapshot, func() string {
+		return "gap-fallback-snapshot"
+	})
+
+	b.PublishWithID("events", "1", "msg-1")
+	b.PublishWithID("events", "2", "msg-2")
+
+	// Subscribe with an unknown ID AND a user snapshot. The user snapshot
+	// should NOT fire (resume path), but the gap-fallback snapshot SHOULD.
+	userSnapCalled := false
+	ch, unsub := b.SubscribeFromIDWith("events", "unknown-id",
+		SubWithSnapshot(func() string {
+			userSnapCalled = true
+			return "user-snapshot-should-not-fire"
+		}),
+	)
+	require.NotNil(t, ch)
+	defer unsub()
+
+	assert.False(t, userSnapCalled, "user snapshot must not fire on resume")
+
+	// First: reconnect control event.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reconnected control event")
+	}
+
+	// Second: gap control event.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-replay-gap")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for gap control event")
+	}
+
+	// Third: gap-fallback snapshot.
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "gap-fallback-snapshot", msg)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for gap-fallback snapshot")
+	}
+}
+
+func TestSubscribeFromIDWith_FreshSubscribeNoReconnectEvent(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(16))
+	defer b.Close()
+
+	ch, unsub := b.SubscribeFromIDWith("events", "")
+	require.NotNil(t, ch)
+	defer unsub()
+
+	// No control event should arrive: this is a fresh subscribe.
+	b.Publish("events", "first-live")
+	select {
+	case msg := <-ch:
+		assert.Equal(t, "first-live", msg, "fresh subscribe must not emit a reconnect control event")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for live message")
+	}
+}
+
+func TestSubscribeFromIDWith_UnsubscribeCleansFilterAndMeta(t *testing.T) {
+	b := NewSSEBroker(WithBufferSize(16))
+	defer b.Close()
+
+	b.SetReplayPolicy("events", 10)
+	b.PublishWithID("events", "1", "msg-1")
+
+	ch, unsub := b.SubscribeFromIDWith("events", "1",
+		SubWithFilter(func(msg string) bool { return true }),
+		SubWithMeta(SubscribeMeta{ID: "user-9"}),
+	)
+	require.NotNil(t, ch)
+
+	require.Len(t, b.Subscribers("events"), 1)
+	unsub()
+
+	// After unsubscribe the broker should report no subscribers and the
+	// filterPredicates / subscriberMeta entries should be gone.
+	assert.Empty(t, b.Subscribers("events"))
+
+	b.mu.RLock()
+	filterCount := len(b.filterPredicates)
+	metaCount := len(b.subscriberMeta)
+	b.mu.RUnlock()
+	assert.Zero(t, filterCount, "filterPredicates should be cleaned up on unsubscribe")
+	assert.Zero(t, metaCount, "subscriberMeta should be cleaned up on unsubscribe")
+}


### PR DESCRIPTION
## Summary

Adds `SubscribeFromIDWith`, the composable resume-aware sibling of `SubscribeWith`. Closes #201.

```go
func (b *SSEBroker) SubscribeFromIDWith(topic, lastEventID string, opts ...SubscribeOption) (<-chan string, func())
```

The existing `SubscribeFromID` is refactored into a thin wrapper around a new internal helper (`subscribeFromIDInternal`) so behavior for unoptioned callers is identical to before. All existing reconnect/resume/gap tests still pass unchanged.

## Option semantics

- **`SubWithFilter`** — applies uniformly to replay AND live messages. Control events (`tavern-reconnected`, `tavern-replay-gap`, `tavern-replay-truncated`) always bypass the filter so clients can still react to reconnect/gap signals even with a reject-all predicate.
- **`SubWithSnapshot`** — only fires on fresh subscribe (empty `lastEventID`). On a resume, the snapshot fn is not invoked. Gap-fallback snapshot is a separate mechanism configured via `SetReplayGapPolicy(topic, GapFallbackToSnapshot, fn)`.
- **`SubWithRate`** — applied to LIVE delivery only. Replay messages are written directly to the channel before the rate limiter is wired up, so a burst of replay arrives immediately and live messages then follow the configured interval.
- **`SubWithMeta`** — behaves the same as on live subscriptions; ID/Meta are written into the subscriber's `SubscriberInfo` and queryable via `Subscribers(topic)`.
- **`SubWithScope`** — set on the subscriber for live scope filtering. The replay log is scope-less, so any replayed messages are delivered regardless of scope. Note that `PublishWithID` only publishes to unscoped subscribers, so a scoped resume subscription will only receive live messages via scope-aware paths such as `PublishTo`.

## Implementation notes

- `SubscribeFromID` is now `return b.subscribeFromIDInternal(topic, lastEventID, subscribeConfig{})`.
- `subscribeFromIDInternal` handles channel creation, fresh-subscribe snapshot injection (atomic, before topic registration), scoped-vs-unscoped registration, optional filter installation, meta enrichment, replay (in-memory + ReplayStore), gap detection and fallback, reconnect control event, replay delivery (with bundling), reconnect callbacks, and truncation control event.
- A new `makeSubscribeFromIDUnsubscribe` cleans up `topics`/`scopedTopics`, `subscriberMeta`, `filterPredicates`, and `dropCounts`. The existing `makeUnsubscribe` couldn't be reused as-is because it doesn't know about scoped vs unscoped at call time.
- Replay filtering is done inline before delivering replays; live filtering is handled by the existing `filterPredicates` path in `publishToChannels`.
- Rate limiting is applied in `SubscribeFromIDWith` after `subscribeFromIDInternal` returns, mirroring `SubscribeWith`'s pattern.

## Tests

New `resume_options_test.go` covers:

1. `TestSubscribeFromIDWith_FilterAppliesToReplayAndLive`
2. `TestSubscribeFromIDWith_MetaAppliesOnResume`
3. `TestSubscribeFromIDWith_RateLimitsLiveNotReplay` — verifies the replay burst comes through unrate-limited then live messages are held by the latest-wins limiter.
4. `TestSubscribeFromIDWith_SnapshotOnFreshSubscribe`
5. `TestSubscribeFromIDWith_SnapshotSkippedOnResume`
6. `TestSubscribeFromIDWith_ReconnectControlEventBypassesFilter` — proves the control event still arrives even with a reject-all predicate.
7. `TestSubscribeFromIDWith_GapFallbackStillWorks` — `SetReplayGapPolicy(topic, GapFallbackToSnapshot, fn)` + unknown ID + user `SubWithSnapshot` confirms the gap-fallback snapshot is delivered while the user snapshot is suppressed.
8. `TestSubscribeFromIDWith_FreshSubscribeNoReconnectEvent`
9. `TestSubscribeFromIDWith_UnsubscribeCleansFilterAndMeta`

## Test plan

- [x] `go test ./... -run 'Subscribe|Reconnect|Resume|Multi|FromID' -race -count=1`
- [x] `go test ./... -count=1`
- [x] `go test -race ./... -count=1`
- [x] `go vet ./...`

All existing reconnect/resume tests pass unchanged. All 9 new tests pass under `-race`.