### PR TITLE
feat: public multi-topic SubscribeMultiFromID (#202)

### DIFF
--- a/multi.go
+++ b/multi.go
@@ -78,3 +78,83 @@ func (b *SSEBroker) SubscribeMulti(topics ...string) (msgs <-chan TopicMessage, 
 		closeOut()
 	}
 }
+
+// SubscribeMultiFromID subscribes to multiple topics with shared Last-Event-ID
+// replay/resume semantics and returns a single channel of TopicMessage values
+// tagged with their source topic. Each topic independently replays from its
+// ID-backed replay log after lastEventID (or from the current cache if
+// lastEventID is empty), then continues with live messages. The returned
+// unsubscribe function closes all inner subscriptions at once.
+//
+// Semantics:
+//   - The same lastEventID is applied uniformly to every topic. If a topic's
+//     replay log does not contain the ID, that topic's gap handling (reconnect
+//     callbacks, gap strategy) runs as configured via SetReplayGapPolicy.
+//   - Ordering is not guaranteed across topics. Within a single topic,
+//     messages preserve their published order.
+//   - Calling the returned unsubscribe closes all inner channels; the output
+//     channel is closed once all fan-in goroutines exit.
+//
+// This is the multi-topic counterpart to [SSEBroker.SubscribeFromID] and
+// mirrors [SSEBroker.SubscribeMulti]'s fan-in structure.
+func (b *SSEBroker) SubscribeMultiFromID(topics []string, lastEventID string) (msgs <-chan TopicMessage, unsubscribe func()) {
+	out := make(chan TopicMessage, b.bufferSize)
+	unsubs := make([]func(), 0, len(topics))
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for _, topic := range topics {
+		ch, unsub := b.SubscribeFromID(topic, lastEventID)
+		if ch == nil {
+			continue
+		}
+		unsubs = append(unsubs, unsub)
+		t := topic
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case msg, ok := <-ch:
+					if !ok {
+						return
+					}
+					select {
+					case out <- TopicMessage{Topic: t, Data: msg}:
+					case <-done:
+						return
+					}
+				case <-done:
+					return
+				}
+			}
+		}()
+	}
+
+	var closeOnce sync.Once
+	closeOut := func() {
+		closeOnce.Do(func() { close(out) })
+	}
+
+	var unsubOnce sync.Once
+	doUnsub := func() {
+		unsubOnce.Do(func() {
+			close(done)
+			for _, unsub := range unsubs {
+				unsub()
+			}
+		})
+	}
+
+	// Close out when all fan-in goroutines exit (e.g. broker closed).
+	go func() {
+		wg.Wait()
+		closeOut()
+	}()
+
+	return out, func() {
+		doUnsub()
+		wg.Wait()
+		closeOut()
+	}
+}

--- a/multi_test.go
+++ b/multi_test.go
@@ -1,11 +1,14 @@
 package tavern
 
 import (
+	"fmt"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSubscribeMulti_ReceivesFromAllTopics(t *testing.T) {
@@ -122,4 +125,264 @@ func TestSubscribeMulti_SingleTopic(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out")
 	}
+}
+
+func TestSubscribeMultiFromID_ReplaysAcrossTopics(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("t1", 10)
+	b.SetReplayPolicy("t2", 10)
+
+	b.PublishWithID("t1", "a1", "msg-a1")
+	b.PublishWithID("t1", "a2", "msg-a2")
+	b.PublishWithID("t1", "a3", "msg-a3")
+	b.PublishWithID("t2", "b1", "msg-b1")
+	b.PublishWithID("t2", "b2", "msg-b2")
+	b.PublishWithID("t2", "b3", "msg-b3")
+
+	ch, unsub := b.SubscribeMultiFromID([]string{"t1", "t2"}, "a1")
+	defer unsub()
+
+	// Expected messages:
+	//   t1: tavern-reconnected, msg-a2, msg-a3 (resumes after a1)
+	//   t2: tavern-reconnected (a1 not found -> gap; default silent strategy,
+	//       so no gap control event and no replay).
+	// Total: 4 messages across both topics.
+	t1Payloads := make([]string, 0, 2)
+	t1Reconnects := 0
+	t2Reconnects := 0
+	deadline := time.After(time.Second)
+	for range 4 {
+		select {
+		case tm := <-ch:
+			switch tm.Topic {
+			case "t1":
+				if containsReconnected(tm.Data) {
+					t1Reconnects++
+				} else {
+					t1Payloads = append(t1Payloads, tm.Data)
+				}
+			case "t2":
+				if containsReconnected(tm.Data) {
+					t2Reconnects++
+				} else {
+					t.Fatalf("unexpected t2 payload (a1 should be unknown to t2): %s", tm.Data)
+				}
+			default:
+				t.Fatalf("unexpected topic: %s", tm.Topic)
+			}
+		case <-deadline:
+			t.Fatalf("timed out; got t1 payloads=%d t1 reconnects=%d t2 reconnects=%d",
+				len(t1Payloads), t1Reconnects, t2Reconnects)
+		}
+	}
+
+	assert.Equal(t, 1, t1Reconnects, "t1 should emit one reconnected control event")
+	assert.Equal(t, 1, t2Reconnects, "t2 should emit one reconnected control event")
+	require.Len(t, t1Payloads, 2, "t1 should replay msg-a2 and msg-a3")
+	assert.Contains(t, t1Payloads[0], "msg-a2")
+	assert.Contains(t, t1Payloads[0], "id: a2")
+	assert.Contains(t, t1Payloads[1], "msg-a3")
+	assert.Contains(t, t1Payloads[1], "id: a3")
+
+	// No further messages should arrive.
+	select {
+	case tm := <-ch:
+		t.Fatalf("unexpected extra message: topic=%s data=%s", tm.Topic, tm.Data)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestSubscribeMultiFromID_EmptyIDReplaysAllCached(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("t1", 10)
+	b.SetReplayPolicy("t2", 10)
+	for i := 1; i <= 3; i++ {
+		b.PublishWithID("t1", fmt.Sprintf("a%d", i), fmt.Sprintf("msg-a%d", i))
+		b.PublishWithID("t2", fmt.Sprintf("b%d", i), fmt.Sprintf("msg-b%d", i))
+	}
+
+	ch, unsub := b.SubscribeMultiFromID([]string{"t1", "t2"}, "")
+	defer unsub()
+
+	t1Got := make([]string, 0, 3)
+	t2Got := make([]string, 0, 3)
+	deadline := time.After(time.Second)
+	for range 6 {
+		select {
+		case tm := <-ch:
+			switch tm.Topic {
+			case "t1":
+				t1Got = append(t1Got, tm.Data)
+			case "t2":
+				t2Got = append(t2Got, tm.Data)
+			default:
+				t.Fatalf("unexpected topic: %s", tm.Topic)
+			}
+		case <-deadline:
+			t.Fatalf("timed out; got t1=%d t2=%d", len(t1Got), len(t2Got))
+		}
+	}
+
+	require.Len(t, t1Got, 3)
+	require.Len(t, t2Got, 3)
+	for i, msg := range t1Got {
+		assert.Contains(t, msg, fmt.Sprintf("msg-a%d", i+1))
+		assert.Contains(t, msg, fmt.Sprintf("id: a%d", i+1))
+	}
+	for i, msg := range t2Got {
+		assert.Contains(t, msg, fmt.Sprintf("msg-b%d", i+1))
+		assert.Contains(t, msg, fmt.Sprintf("id: b%d", i+1))
+	}
+}
+
+func TestSubscribeMultiFromID_LiveContinuation(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMultiFromID([]string{"t1", "t2"}, "")
+	defer unsub()
+
+	b.PublishWithID("t1", "a1", "live-a1")
+	b.PublishWithID("t2", "b1", "live-b1")
+	b.PublishWithID("t1", "a2", "live-a2")
+
+	got := make(map[string][]string)
+	deadline := time.After(time.Second)
+	for range 3 {
+		select {
+		case tm := <-ch:
+			got[tm.Topic] = append(got[tm.Topic], tm.Data)
+		case <-deadline:
+			t.Fatalf("timed out; got t1=%d t2=%d", len(got["t1"]), len(got["t2"]))
+		}
+	}
+
+	require.Len(t, got["t1"], 2)
+	require.Len(t, got["t2"], 1)
+	assert.Contains(t, got["t1"][0], "live-a1")
+	assert.Contains(t, got["t1"][0], "id: a1")
+	assert.Contains(t, got["t1"][1], "live-a2")
+	assert.Contains(t, got["t1"][1], "id: a2")
+	assert.Contains(t, got["t2"][0], "live-b1")
+	assert.Contains(t, got["t2"][0], "id: b1")
+}
+
+func TestSubscribeMultiFromID_UnsubscribeClosesAll(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMultiFromID([]string{"t1", "t2"}, "")
+
+	b.PublishWithID("t1", "a1", "msg-a1")
+	b.PublishWithID("t2", "b1", "msg-b1")
+
+	// Drain any delivered messages briefly before unsubscribing.
+drain:
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				break drain
+			}
+		case <-time.After(50 * time.Millisecond):
+			break drain
+		}
+	}
+
+	unsub()
+
+	// After unsubscribe, channel must be drained and closed within a bounded
+	// timeout.
+	closed := make(chan struct{})
+	go func() {
+		for range ch {
+		}
+		close(closed)
+	}()
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("channel did not close after unsubscribe")
+	}
+
+	// Both topics should have no subscribers now.
+	assert.False(t, b.HasSubscribers("t1"), "t1 should have no subscribers")
+	assert.False(t, b.HasSubscribers("t2"), "t2 should have no subscribers")
+
+	// Double unsubscribe is safe.
+	assert.NotPanics(t, func() { unsub() })
+}
+
+func TestSubscribeMultiFromID_ReconnectControlEventsPerTopic(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("t1", 10)
+	b.SetReplayPolicy("t2", 10)
+	b.PublishWithID("t1", "a1", "msg-a1")
+	b.PublishWithID("t2", "b1", "msg-b1")
+
+	ch, unsub := b.SubscribeMultiFromID([]string{"t1", "t2"}, "some-id")
+	defer unsub()
+
+	reconnects := make(map[string]int)
+	deadline := time.After(time.Second)
+	for range 2 {
+		select {
+		case tm := <-ch:
+			if containsReconnected(tm.Data) {
+				reconnects[tm.Topic]++
+			} else {
+				t.Fatalf("unexpected payload on topic %s: %s", tm.Topic, tm.Data)
+			}
+		case <-deadline:
+			t.Fatalf("timed out; got reconnects=%v", reconnects)
+		}
+	}
+	assert.Equal(t, 1, reconnects["t1"])
+	assert.Equal(t, 1, reconnects["t2"])
+}
+
+func TestSubscribeMultiFromID_EmptyTopicList(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	for _, topics := range [][]string{nil, {}} {
+		ch, unsub := b.SubscribeMultiFromID(topics, "")
+		require.NotNil(t, ch)
+		require.NotNil(t, unsub)
+
+		// No messages should ever arrive.
+		select {
+		case tm, ok := <-ch:
+			if ok {
+				t.Fatalf("unexpected message on empty-topic subscription: %+v", tm)
+			}
+		case <-time.After(25 * time.Millisecond):
+		}
+
+		// Unsubscribe must close the channel and must not panic.
+		assert.NotPanics(t, unsub)
+		closed := make(chan struct{})
+		go func() {
+			for range ch {
+			}
+			close(closed)
+		}()
+		select {
+		case <-closed:
+		case <-time.After(time.Second):
+			t.Fatal("channel did not close after unsubscribe on empty topic list")
+		}
+	}
+}
+
+// containsReconnected reports whether msg is a tavern-reconnected control
+// event emitted by SubscribeFromID-style subscriptions.
+func containsReconnected(msg string) bool {
+	return strings.Contains(msg, "event: tavern-reconnected")
 }


### PR DESCRIPTION
## Summary

Adds `SSEBroker.SubscribeMultiFromID(topics []string, lastEventID string) (<-chan TopicMessage, func())` — the multi-topic counterpart to `SubscribeFromID`. Each topic independently replays/resumes from the shared `lastEventID` and the resulting streams are fanned in onto a single `TopicMessage` channel with one unsubscribe.

Semantics:

- The same `lastEventID` is applied uniformly to every topic. If a topic's replay log does not contain the ID, that topic's configured gap handling runs (reconnect callbacks, gap strategy via `SetReplayGapPolicy`).
- Empty `lastEventID` replays each topic's cache, matching `SubscribeFromID(topic, "")`.
- Ordering across topics is not guaranteed; within a single topic, messages preserve their published order.
- Unsubscribe closes all inner subscriptions; the output channel closes once all fan-in goroutines exit.

Implementation notes:

- Mirrors `SubscribeMulti`'s fan-in structure (per-topic goroutine, `done` channel, `WaitGroup`, `closeOnce`, `unsubOnce`).
- Uses `SubscribeFromID` per topic (not `SubscribeFromIDWith`) to keep the helper narrow, per `plan.md` guidance ("Do not add option composition to #202 unless it remains obviously small").
- Topics whose admission is rejected (`ch == nil`) are skipped, matching `SubscribeMultiWith`.

Closes #202.

## Test plan

- [x] `go test ./... -run 'Subscribe|Reconnect|Resume|Multi|FromID' -race -count=1`
- [x] `go test ./... -count=1`
- [x] `go test ./... -race -count=1`
- [x] `go vet ./...`

New tests in `multi_test.go`:

- `TestSubscribeMultiFromID_ReplaysAcrossTopics` — cross-topic replay with an ID only present in one topic; verifies replay on one topic and gap/reconnect-only behavior on the other.
- `TestSubscribeMultiFromID_EmptyIDReplaysAllCached` — empty `lastEventID` replays full cache for both topics.
- `TestSubscribeMultiFromID_LiveContinuation` — new publishes flow through the merged channel tagged by topic.
- `TestSubscribeMultiFromID_UnsubscribeClosesAll` — unsubscribe drains and closes the output and deregisters both topics.
- `TestSubscribeMultiFromID_ReconnectControlEventsPerTopic` — each topic independently emits its own `tavern-reconnected` control event.
- `TestSubscribeMultiFromID_EmptyTopicList` — `nil` / `[]string{}` returns a valid channel that never delivers and closes cleanly on unsubscribe.