### PR TITLE
docs: update tavern-js attribute references to tavern-*

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ gap recovery, and topic change notifications — with zero custom JavaScript:
 <script src="https://cdn.jsdelivr.net/gh/catgoose/tavern-js@latest/dist/tavern.min.js"></script>
 <div sse-connect="/sse/notifications"
      sse-swap="message"
-     data-tavern-reconnecting-class="opacity-50"
-     data-tavern-gap-action="banner">
+     tavern-reconnecting-class="opacity-50"
+     tavern-gap-action="banner">
 
-  <div data-tavern-status class="hidden">Reconnecting...</div>
+  <div tavern-status class="hidden">Reconnecting...</div>
 </div>
 ```
 

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -1600,11 +1600,11 @@ mux.Handle("/sse/dashboard", broker.SSEHandler("dashboard",
 <div id="dashboard"
      sse-connect="/sse/dashboard"
      sse-swap="update"
-     data-tavern-reconnecting-class="opacity-50 pointer-events-none"
-     data-tavern-gap-action="banner"
-     data-tavern-gap-banner-text="Dashboard was disconnected. Click to refresh.">
+     tavern-reconnecting-class="opacity-50 pointer-events-none"
+     tavern-gap-action="banner"
+     tavern-gap-banner-text="Dashboard was disconnected. Click to refresh.">
 
-  <div data-tavern-status class="hidden">
+  <div tavern-status class="hidden">
     <div class="animate-pulse text-gray-500">Reconnecting...</div>
   </div>
 
@@ -1631,7 +1631,7 @@ For cases where you want programmatic control instead of a banner:
 <div id="prices"
      sse-connect="/sse/prices"
      sse-swap="ticker"
-     data-tavern-gap-action="prices-stale">
+     tavern-gap-action="prices-stale">
 </div>
 
 <script>
@@ -1641,7 +1641,7 @@ For cases where you want programmatic control instead of a banner:
 </script>
 ```
 
-Setting `data-tavern-gap-action` to a custom name dispatches that as a DOM
+Setting `tavern-gap-action` to a custom name dispatches that as a DOM
 event, giving you full control over recovery.
 
 ---


### PR DESCRIPTION
## Summary

- Updated all `data-tavern-*` HTML attribute references to `tavern-*` in README.md and RECIPES.md
- Aligns tavern docs with the tavern-js v0.0.14 breaking change that renamed `data-tavern-*` attributes to shorter `tavern-*` custom attributes
- Affected files: README.md (Client-Side Helpers section), RECIPES.md (Recipe 26 examples and prose)

## Test plan

- [ ] Verify README.md code examples use `tavern-*` attributes
- [ ] Verify RECIPES.md Recipe 26 code examples and prose use `tavern-*` attributes
- [ ] Grep repo for any remaining `data-tavern-` references in public docs