### PR TITLE
docs: codify lifeline/scoped stream contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -909,18 +909,26 @@ falls back to non-blocking behavior.
 
 ### App-shell lifeline architecture
 
+> **Full contract:** See [docs/stream-contract.md](docs/stream-contract.md) for
+> the complete lifeline/scoped stream contract, including guarantees, failure
+> isolation, reconnection behavior, and decision guidance.
+
 For apps that go beyond page-local SSE, Tavern supports a **lifeline + scoped
 streams** pattern: one warm connection stays open for the life of the app shell,
 while optional high-bandwidth streams spin up and down as the user navigates.
 
-**Lifeline (control plane)** -- always connected, low volume:
+**Lifeline (control plane)** -- always connected, low volume. Use this for
+topics that are relevant across the entire session:
 - notifications, presence, nav-state changes
 - invalidation signals ("data changed, refetch when ready")
 - small counters, theme broadcasts
+- any topic producing less than ~1 msg/s under load
 
-**Scoped streams (data plane)** -- active only for hot views:
+**Scoped streams (data plane)** -- active only for hot views. Use a separate
+connection when bandwidth or lifecycle demands it:
 - charts, feeds, detail panels via `SubscribeScoped` / `PublishTo`
 - high-frequency section-specific updates with per-user isolation
+- topics that need independent buffer sizing, eviction, or backpressure
 
 #### Handoff with AddTopic / RemoveTopic
 
@@ -971,9 +979,13 @@ drops and the browser reconnects.
 
 | Pattern | Problem |
 |---------|---------|
-| **Firehose** -- one connection subscribed to every topic | Buffer overflows, drops, backpressure issues |
-| **Reconnect-as-navigation** -- tear down SSE on every route change | Unnecessary latency, missed events during reconnect window |
+| **Firehose** -- one connection subscribed to every topic | High-bandwidth topics cause backpressure that stalls control events. Buffer overflows drop notifications. |
+| **Reconnect-as-navigation** -- tear down SSE on every route change | Unnecessary latency, missed events during reconnect window, no replay continuity |
 | **Duplicate DOM ownership** -- two streams updating the same element | Race conditions, flicker, unpredictable state |
+| **Lifeline as data pipe** -- routing high-bandwidth data through the lifeline | Backpressure from data topics delays control events |
+
+> See [docs/stream-contract.md](docs/stream-contract.md) for the full
+> anti-patterns list and decision guidance table.
 
 > **Rendering on hot pages:** Transport backpressure and browser render cadence
 > are separate concerns. If delivery metrics look healthy but the page stutters,

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -1648,6 +1648,11 @@ event, giving you full control over recovery.
 
 ## Recipe 27: App-shell lifeline with scoped panel streams
 
+> **Contract reference:** See [docs/stream-contract.md](docs/stream-contract.md)
+> for the full lifeline/scoped stream contract -- guarantees, failure isolation,
+> reconnection semantics, and a decision guidance table for when to use each
+> approach.
+
 One persistent SSE connection for app-level events, with scoped panel streams
 that spin up only for high-bandwidth views. Two alternative architectures are
 shown below -- choose one, not both.
@@ -1666,6 +1671,10 @@ broker.SetReplayPolicy("analytics-data", 50)
 ```
 
 ### Approach A: Single connection with AddTopic / RemoveTopic
+
+Best for low-bandwidth panel topics that share the lifeline's lifecycle. See
+the [stream contract decision guidance](docs/stream-contract.md#decision-guidance)
+for when this is the right choice.
 
 One SSE connection carries everything. The server mutates topic membership
 when the user navigates. Requires `SubscribeMultiWithMeta` for a subscriber
@@ -1744,10 +1753,14 @@ func navigateHandler(broker *tavern.SSEBroker) http.HandlerFunc {
 
 ### Approach B: Separate scoped connections
 
+Best for high-bandwidth panel topics that need independent backpressure, buffer
+sizing, or eviction policies. See the
+[stream contract decision guidance](docs/stream-contract.md#decision-guidance)
+for when this is the right choice.
+
 The lifeline uses a standard handler for control-plane topics. Each panel opens
-its own SSE connection. Use this when panels need independent backpressure,
-buffer sizing, or eviction policies. Works well under HTTP/2 and HTTP/3 where
-additional streams are cheap.
+its own SSE connection. Works well under HTTP/2 and HTTP/3 where additional
+streams are cheap.
 
 #### Handlers
 

--- a/docs/page-multiplexing.md
+++ b/docs/page-multiplexing.md
@@ -8,7 +8,10 @@ and how.
 
 These patterns build on the topic vocabulary defined in
 [Topic Semantics](topic-semantics.md) and the replay/snapshot strategies
-defined in [Snapshot and Replay Patterns](snapshot-replay.md).
+defined in [Snapshot and Replay Patterns](snapshot-replay.md). For the
+app-shell lifeline/scoped stream contract (when to multiplex on one
+connection vs open separate streams), see
+[Stream Contract](stream-contract.md).
 
 ---
 
@@ -183,6 +186,10 @@ Both fragments arrive in one SSE message and swap atomically.
 ---
 
 ## Dynamic topic changes
+
+> For the full `tavern-topics-changed` payload guarantees and guidance on
+> when to use `AddTopic`/`RemoveTopic` vs separate scoped connections, see
+> the [Stream Contract](stream-contract.md).
 
 `AddTopic` and `RemoveTopic` modify a subscriber's topic set without
 tearing down the connection. This requires `SubscribeMultiWithMeta` so

--- a/docs/stream-contract.md
+++ b/docs/stream-contract.md
@@ -1,0 +1,179 @@
+# Lifeline + Scoped Stream Contract
+
+This document codifies the contract between lifeline and scoped streams in
+a Tavern app-shell architecture. It defines what each stream is responsible
+for, when to use each pattern, and what guarantees the system provides.
+
+For implementation examples, see
+[Recipe 27: App-shell lifeline with scoped panel streams](../RECIPES.md#recipe-27-app-shell-lifeline-with-scoped-panel-streams)
+and the [App-shell lifeline architecture](../README.md#app-shell-lifeline-architecture)
+section of the README.
+
+These patterns build on the topic vocabulary defined in
+[Topic Semantics](topic-semantics.md) and the multiplexing guidance in
+[Page-Level Multiplexing](page-multiplexing.md).
+
+---
+
+## Stream roles
+
+### Lifeline stream
+
+A **lifeline stream** is a long-lived, app-wide SSE connection that stays
+open for the entire user session. It carries control-plane and
+low-bandwidth topics.
+
+- Created with `SubscribeMultiWithMeta` so the subscriber has an ID that
+  `AddTopic` / `RemoveTopic` can target.
+- Topics are mutated dynamically as the user navigates. The connection
+  itself is never torn down for navigation.
+- Carries: notifications, presence, nav-state, invalidation signals,
+  small counters, theme broadcasts.
+
+### Scoped stream
+
+A **scoped stream** is a short-lived, high-bandwidth SSE connection tied
+to a specific view, panel, or widget. It has its own buffer, backpressure,
+and eviction policy.
+
+- Created with `SubscribeMulti`, `SubscribeScoped`, or a dedicated
+  `SSEHandler` endpoint.
+- Torn down when the view is dismissed (e.g., user navigates away, panel
+  closes, widget is removed from the DOM).
+- Carries: charts, feeds, detail-panel data, high-frequency
+  section-specific updates.
+
+---
+
+## Contract points
+
+### 1. What belongs on each stream
+
+| Stream | Content | Rate | Examples |
+|--------|---------|------|----------|
+| **Lifeline** | Control-plane, low-bandwidth | < 1 msg/s typical | notifications, presence, nav-state, invalidation signals |
+| **Scoped** | Data-plane, high-bandwidth | Unbounded (with backpressure) | chart updates, activity feeds, log tails, real-time metrics |
+
+**Rule of thumb:** if a topic produces more than a few messages per second
+under load, it belongs on a scoped stream. If it is relevant across the
+entire session regardless of what view is active, it belongs on the
+lifeline.
+
+### 2. When to use AddTopic/RemoveTopic vs a separate scoped connection
+
+Use `AddTopic` / `RemoveTopic` on the lifeline when:
+
+- The new topic is low-bandwidth and shares the lifeline's lifecycle
+  characteristics.
+- You want a single reconnection path for all active topics.
+- The topic set changes with navigation but the data rate stays low.
+
+Open a separate scoped connection when:
+
+- The topic is high-bandwidth and could cause backpressure on the
+  lifeline's low-frequency topics.
+- The view needs independent buffer sizing, eviction, or
+  `MaxConnectionDuration`.
+- The view needs per-user scoping via `SubscribeScoped` / `PublishTo`.
+- You want the stream's lifecycle to match the DOM element's lifecycle
+  exactly (element removed = connection closed).
+
+### 3. tavern-topics-changed guarantees
+
+When `AddTopic` or `RemoveTopic` is called with `sendControl: true`, the
+subscriber receives a `tavern-topics-changed` SSE event with a JSON
+payload:
+
+```json
+{
+  "action": "added",
+  "topic": "dashboard-data",
+  "topics": ["notifications", "nav-state", "dashboard-data"]
+}
+```
+
+**Guarantees:**
+
+- `action` is `"added"` or `"removed"` -- the delta that just occurred.
+- `topic` is the single topic that was added or removed.
+- `topics` is the **full current topic list** after the change. The client
+  can use this to reconstruct state from scratch (useful after reconnect
+  or if delta processing fails).
+- The event is delivered on the same SSE connection, in-order with other
+  events. No events for the new topic will arrive before the
+  `tavern-topics-changed` event for its addition.
+
+### 4. Failure isolation
+
+Lifeline and scoped streams are fully independent connections. A failure
+in one does not affect the other:
+
+- **Scoped stream errors** do not propagate to the lifeline. The lifeline
+  continues delivering control events uninterrupted.
+- **Lifeline errors** do not tear down scoped streams. Each stream
+  reconnects independently.
+- The client (tavern-js) can dispatch `tavern:stream-fallback` when a
+  scoped stream enters an error state, allowing the app shell to show
+  fallback UI for that panel while the lifeline remains healthy.
+
+### 5. Reconnection behavior
+
+Each stream reconnects independently using the browser's native
+`EventSource` reconnection with `Last-Event-ID`:
+
+- **Lifeline replay** covers only the lifeline's topics. It uses
+  `SubscribeFromID` to resume from where it left off.
+- **Scoped stream replay** covers only that stream's topics. Its buffer
+  and gap strategy are configured independently.
+- **No cross-contamination.** A lifeline reconnect never replays scoped
+  stream events and vice versa. Each stream has its own replay buffer and
+  its own `Last-Event-ID` sequence.
+- Gap strategies (`GapSilent`, `GapFallbackToSnapshot`) apply per-topic
+  within each stream. A gap in one topic does not affect other topics on
+  the same connection.
+
+### 6. Anti-patterns
+
+| Anti-pattern | Problem | Fix |
+|---|---|---|
+| **Firehose** -- everything on one stream | High-bandwidth topics cause backpressure that stalls low-frequency control events. Buffer overflows drop notifications. | Split into lifeline (control) + scoped (data) streams. |
+| **Reconnect-as-navigation** -- tear down and re-establish the SSE connection on every route change | Unnecessary latency, missed events during the reconnect window, no replay continuity. | Use `AddTopic` / `RemoveTopic` on the lifeline, or open/close scoped streams per view. |
+| **Duplicate DOM ownership** -- two streams updating the same element | Race conditions, flicker, unpredictable state. One stream's update overwrites the other's. | Each DOM region is owned by exactly one stream. Use distinct `sse-swap` targets. |
+| **Scoped stream for everything** -- opening a new connection for every low-frequency topic | Connection overhead, unnecessary reconnection complexity, wasted server resources. | Low-frequency topics belong on the lifeline with `AddTopic`. |
+| **Lifeline as data pipe** -- routing high-bandwidth data through the lifeline | Backpressure from data topics delays control events. | High-bandwidth data belongs on scoped streams. |
+
+---
+
+## Decision guidance
+
+| Scenario | Use lifeline AddTopic | Use scoped stream |
+|---|---|---|
+| Low-frequency status updates | Yes | No |
+| High-bandwidth data feed | No | Yes |
+| Ephemeral panel data (low rate) | Yes | Either |
+| Ephemeral panel data (high rate) | No | Yes |
+| App-wide notifications | Yes | No |
+| User navigates to a new view (control data) | AddTopic on lifeline | -- |
+| User navigates to a new view (heavy data) | -- | New scoped connection |
+| Per-user isolated panel data | No | Yes (`SubscribeScoped` / `PublishTo`) |
+| Independent buffer/eviction needed | No | Yes |
+
+**When in doubt:** start with `AddTopic` on the lifeline. If you observe
+backpressure affecting control topics, or you need per-view buffer tuning,
+move that topic to a scoped stream.
+
+---
+
+## Relationship to other patterns
+
+- **Page-level multiplexing** ([docs/page-multiplexing.md](page-multiplexing.md)):
+  covers multiplexing multiple topics on a single connection for a
+  server-rendered page. The lifeline is a special case of multiplexing
+  that spans the entire session rather than a single page.
+- **Snapshot and replay** ([docs/snapshot-replay.md](snapshot-replay.md)):
+  covers per-topic replay strategies. Both lifeline and scoped streams
+  use these independently.
+- **Topic semantics** ([docs/topic-semantics.md](topic-semantics.md)):
+  defines topic naming conventions. Lifeline topics tend to be
+  `notify/*`, `presence/*`, `nav/*` categories. Scoped stream topics
+  tend to be `resource/*`, `collection/*`, or domain-specific.


### PR DESCRIPTION
## Summary

- Creates `docs/stream-contract.md` codifying the lifeline + scoped stream contract: stream roles, what belongs on each, `tavern-topics-changed` payload guarantees, failure isolation, reconnection behavior, anti-patterns, and a decision guidance table
- Updates README app-shell architecture section with link to the contract, more prescriptive guidance on the lifeline/scoped split, and expanded anti-patterns table
- Updates RECIPES.md Recipe 27 with contract cross-references and guidance notes on both approaches
- Updates `docs/page-multiplexing.md` with cross-references to the contract in the intro and dynamic topic changes sections

Closes #211

## Test plan

- [x] `go test ./...` passes (docs-only change, no code modifications)
- [ ] Review that all four docs tell one consistent story with no contradictions
- [ ] Verify cross-reference links resolve correctly