### PR TITLE
feat: add SubscriberTopics query and fix AddTopic/unsubscribe race

### DIFF
--- a/lifeline_test.go
+++ b/lifeline_test.go
@@ -364,3 +364,112 @@ func TestLifeline_ConcurrentHandoff(t *testing.T) {
 	// Test completing without panic is the assertion.
 	<-done
 }
+
+func TestLifeline_ScopedReconnectCycleDoesNotLeakToLifeline(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "app"}, "control", "notifications")
+	defer unsub()
+
+	// Simulate multiple scoped stream connect/disconnect cycles.
+	for i := 0; i < 10; i++ {
+		scopedCh, scopedUnsub := b.SubscribeScoped("dashboard", "user:1")
+		b.PublishTo("dashboard", "user:1", fmt.Sprintf("data-%d", i))
+		msg := awaitStringMsg(t, scopedCh, time.Second)
+		assert.Equal(t, fmt.Sprintf("data-%d", i), msg)
+		scopedUnsub()
+	}
+
+	// Lifeline is untouched by scoped churn.
+	b.Publish("control", "after-churn")
+	msg := awaitTopicMsg(t, ch, time.Second)
+	assert.Equal(t, "control", msg.Topic)
+	assert.Equal(t, "after-churn", msg.Data)
+
+	// Verify no stale messages leaked onto the lifeline.
+	assertNoTopicMsg(t, ch, 100*time.Millisecond)
+}
+
+func TestLifeline_TopicSetQueryDuringHandoff(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "control")
+	defer unsub()
+
+	topics := b.SubscriberTopics("sub1")
+	require.Len(t, topics, 1)
+	assert.Contains(t, topics, "control")
+
+	b.AddTopic("sub1", "panel-a", false)
+	b.AddTopic("sub1", "panel-b", false)
+
+	topics = b.SubscriberTopics("sub1")
+	assert.Len(t, topics, 3)
+	assert.ElementsMatch(t, []string{"control", "panel-a", "panel-b"}, topics)
+
+	b.RemoveTopic("sub1", "panel-a", false)
+	topics = b.SubscriberTopics("sub1")
+	assert.Len(t, topics, 2)
+	assert.ElementsMatch(t, []string{"control", "panel-b"}, topics)
+}
+
+func TestLifeline_AddRemoveWithControlEvents_TopicListAccuracy(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "control")
+	defer unsub()
+
+	// Add three topics with control events.
+	for _, topic := range []string{"panel-a", "panel-b", "panel-c"} {
+		b.AddTopic("sub1", topic, true)
+		ctrl := awaitTopicMsg(t, ch, time.Second)
+		assert.Equal(t, topicsChangedEvent, ctrl.Topic)
+		assert.Contains(t, ctrl.Data, `"action":"added"`)
+	}
+
+	// Remove middle topic.
+	b.RemoveTopic("sub1", "panel-b", true)
+	ctrl := awaitTopicMsg(t, ch, time.Second)
+	assert.Equal(t, topicsChangedEvent, ctrl.Topic)
+	assert.Contains(t, ctrl.Data, `"action":"removed"`)
+	assert.Contains(t, ctrl.Data, `"topic":"panel-b"`)
+
+	// Verify SubscriberTopics matches what the control events reported.
+	topics := b.SubscriberTopics("sub1")
+	assert.ElementsMatch(t, []string{"control", "panel-a", "panel-c"}, topics)
+}
+
+func TestLifeline_MultipleLifelinesIndependent(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch1, unsub1 := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "app1"}, "control")
+	defer unsub1()
+
+	ch2, unsub2 := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "app2"}, "control")
+	defer unsub2()
+
+	// Add different topics to each lifeline.
+	b.AddTopic("app1", "panel-a", false)
+	b.AddTopic("app2", "panel-b", false)
+
+	b.Publish("panel-a", "for-app1")
+	b.Publish("panel-b", "for-app2")
+
+	// app1 gets panel-a but not panel-b.
+	msg1 := awaitTopicMsg(t, ch1, time.Second)
+	assert.Equal(t, "panel-a", msg1.Topic)
+	assert.Equal(t, "for-app1", msg1.Data)
+
+	// app2 gets panel-b but not panel-a.
+	msg2 := awaitTopicMsg(t, ch2, time.Second)
+	assert.Equal(t, "panel-b", msg2.Topic)
+	assert.Equal(t, "for-app2", msg2.Data)
+
+	// No cross-contamination.
+	assertNoTopicMsg(t, ch1, 50*time.Millisecond)
+	assertNoTopicMsg(t, ch2, 50*time.Millisecond)
+}

--- a/subscription_changes.go
+++ b/subscription_changes.go
@@ -21,6 +21,7 @@ type multiSub struct {
 	mu     sync.Mutex
 	topics map[string]chan string // topic → internal channel
 	unsubs map[string]func()     // topic → unsubscribe function
+	closed bool                  // set when unsubscribe starts; prevents new wg.Add after wg.Wait
 }
 
 // AddTopic adds a topic to an existing subscriber identified by subscriberID.
@@ -66,12 +67,20 @@ func (b *SSEBroker) AddTopic(subscriberID, topic string, sendControl bool) bool 
 		unsub()
 		return false
 	}
+	// If the subscriber is closing, bail out to avoid wg.Add after wg.Wait.
+	if ms.closed {
+		ms.mu.Unlock()
+		unsub()
+		return false
+	}
 	ms.topics[topic] = b.readToBidir(topic, ch)
 	ms.unsubs[topic] = unsub
+
+	// Start fan-in goroutine for the new topic. wg.Add must happen under
+	// ms.mu so it cannot race with the unsubscribe path's wg.Wait.
+	ms.wg.Add(1)
 	ms.mu.Unlock()
 
-	// Start fan-in goroutine for the new topic.
-	ms.wg.Add(1)
 	go func() {
 		defer ms.wg.Done()
 		for {
@@ -229,6 +238,12 @@ func (b *SSEBroker) SubscribeMultiWithMeta(meta SubscribeMeta, topics ...string)
 	var unsubOnce sync.Once
 	doUnsub := func() {
 		unsubOnce.Do(func() {
+			// Mark closed under ms.mu so concurrent AddTopic sees it before
+			// wg.Wait, preventing wg.Add after wg.Wait.
+			ms.mu.Lock()
+			ms.closed = true
+			ms.mu.Unlock()
+
 			close(done)
 			ms.mu.Lock()
 			for _, unsub := range ms.unsubs {
@@ -254,6 +269,28 @@ func (b *SSEBroker) SubscribeMultiWithMeta(meta SubscribeMeta, topics ...string)
 		ms.wg.Wait()
 		closeOut()
 	}
+}
+
+// SubscriberTopics returns the current set of topics for a managed
+// multi-subscriber identified by subscriberID. Returns nil if the
+// subscriber is not found. The returned slice is a snapshot safe to
+// read without synchronization.
+func (b *SSEBroker) SubscriberTopics(subscriberID string) []string {
+	b.mu.RLock()
+	ms := b.findMultiSub(subscriberID)
+	b.mu.RUnlock()
+
+	if ms == nil {
+		return nil
+	}
+
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	topics := make([]string, 0, len(ms.topics))
+	for t := range ms.topics {
+		topics = append(topics, t)
+	}
+	return topics
 }
 
 // findMultiSub returns the multiSub for the given subscriber ID.

--- a/subscription_changes_test.go
+++ b/subscription_changes_test.go
@@ -528,3 +528,228 @@ func TestSubscribeMultiWithMeta_BrokerClose(t *testing.T) {
 	for range ch {
 	}
 }
+
+// ---------------------------------------------------------------------------
+// SubscriberTopics — query current topic set
+// ---------------------------------------------------------------------------
+
+func TestSubscriberTopics_ReflectsCurrentState(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a", "b")
+	defer unsub()
+
+	topics := b.SubscriberTopics("sub1")
+	assert.Len(t, topics, 2)
+	assert.ElementsMatch(t, []string{"a", "b"}, topics)
+
+	b.AddTopic("sub1", "c", false)
+	topics = b.SubscriberTopics("sub1")
+	assert.Len(t, topics, 3)
+	assert.ElementsMatch(t, []string{"a", "b", "c"}, topics)
+
+	b.RemoveTopic("sub1", "a", false)
+	topics = b.SubscriberTopics("sub1")
+	assert.Len(t, topics, 2)
+	assert.ElementsMatch(t, []string{"b", "c"}, topics)
+}
+
+func TestSubscriberTopics_UnknownSubscriber(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	topics := b.SubscriberTopics("nonexistent")
+	assert.Nil(t, topics)
+}
+
+func TestSubscriberTopics_AfterUnsubscribe(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a")
+	unsub()
+
+	topics := b.SubscriberTopics("sub1")
+	assert.Nil(t, topics, "should return nil after unsubscribe deregisters the multi-sub")
+}
+
+// ---------------------------------------------------------------------------
+// AddTopic does NOT replay historical messages
+// ---------------------------------------------------------------------------
+
+func TestAddTopic_NoHistoricalReplay(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	b.SetReplayPolicy("hot-topic", 10)
+
+	// Publish messages BEFORE subscribing via AddTopic.
+	for i := 0; i < 5; i++ {
+		b.Publish("hot-topic", "pre-existing-"+strings.Repeat("x", i))
+	}
+
+	ch, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "control")
+	defer unsub()
+
+	b.AddTopic("sub1", "hot-topic", false)
+
+	// Publish a new message after AddTopic.
+	b.Publish("hot-topic", "after-add")
+
+	msg := <-ch
+	assert.Equal(t, "hot-topic", msg.Topic)
+	assert.Equal(t, "after-add", msg.Data, "should only receive messages published after AddTopic, not historical replay")
+
+	// No more messages should arrive.
+	select {
+	case extra := <-ch:
+		t.Fatalf("unexpected extra message: %+v", extra)
+	case <-time.After(100 * time.Millisecond):
+		// Expected
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RemoveTopic while messages are in-flight
+// ---------------------------------------------------------------------------
+
+func TestRemoveTopic_InFlightMessages(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	ch, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "keep", "remove-me")
+	defer unsub()
+
+	// Rapidly publish to the topic we're about to remove.
+	for i := 0; i < 10; i++ {
+		b.Publish("remove-me", "inflight-msg")
+	}
+
+	// Remove topic while messages may still be in the fan-in pipeline.
+	ok := b.RemoveTopic("sub1", "remove-me", false)
+	assert.True(t, ok)
+
+	// Publish to the kept topic to verify the subscriber is still alive.
+	b.Publish("keep", "still-alive")
+
+	// Drain all messages and verify we eventually get our "keep" message.
+	deadline := time.After(2 * time.Second)
+	gotKeep := false
+	for !gotKeep {
+		select {
+		case msg := <-ch:
+			if msg.Topic == "keep" && msg.Data == "still-alive" {
+				gotKeep = true
+			}
+			// Ignore any in-flight "remove-me" messages that arrived before cleanup.
+		case <-deadline:
+			t.Fatal("timed out waiting for 'keep' topic message after RemoveTopic")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unsubscribe while AddTopic goroutines may still be running
+// ---------------------------------------------------------------------------
+
+func TestUnsubscribe_WhileAddTopicInProgress(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "base")
+
+	var wg sync.WaitGroup
+
+	// Spin up concurrent AddTopic calls.
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			b.AddTopic("sub1", "dyn-"+strings.Repeat("x", idx), false)
+		}(i)
+	}
+
+	// Immediately unsubscribe while AddTopic goroutines are likely in-flight.
+	unsub()
+
+	wg.Wait()
+	// Test passes if no panic, deadlock, or goroutine leak.
+}
+
+// ---------------------------------------------------------------------------
+// AddTopic/RemoveTopic after the subscriber has been unsubscribed
+// ---------------------------------------------------------------------------
+
+func TestAddTopic_AfterUnsubscribe(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a")
+	unsub()
+
+	ok := b.AddTopic("sub1", "b", false)
+	assert.False(t, ok, "AddTopic on unsubscribed subscriber should return false")
+}
+
+func TestRemoveTopic_AfterUnsubscribe(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	_, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub1"}, "a")
+	unsub()
+
+	ok := b.RemoveTopic("sub1", "a", false)
+	assert.False(t, ok, "RemoveTopic on unsubscribed subscriber should return false")
+}
+
+// ---------------------------------------------------------------------------
+// AddTopicForScope / RemoveTopicForScope during concurrent reconnects
+// ---------------------------------------------------------------------------
+
+func TestScopeOps_DuringConcurrentActivity(t *testing.T) {
+	b := NewSSEBroker()
+	defer b.Close()
+
+	// Create multiple subscribers with the same scope.
+	var unsubs []func()
+	for i := 0; i < 5; i++ {
+		_, unsub := b.SubscribeMultiWithMeta(SubscribeMeta{ID: "sub-" + strings.Repeat("x", i)}, "base")
+		b.mu.Lock()
+		for _, info := range b.subscriberMeta {
+			if info.ID == "sub-"+strings.Repeat("x", i) {
+				info.Scope = "team:42"
+			}
+		}
+		b.mu.Unlock()
+		unsubs = append(unsubs, unsub)
+	}
+	defer func() {
+		for _, u := range unsubs {
+			u()
+		}
+	}()
+
+	var wg sync.WaitGroup
+
+	// Concurrently add and remove topics for the scope while publishing.
+	for i := 0; i < 10; i++ {
+		wg.Add(3)
+		topic := "scope-topic-" + strings.Repeat("x", i%3)
+		go func() {
+			defer wg.Done()
+			b.AddTopicForScope("team:42", topic, false)
+		}()
+		go func() {
+			defer wg.Done()
+			b.RemoveTopicForScope("team:42", topic, false)
+		}()
+		go func() {
+			defer wg.Done()
+			b.Publish("base", "ping")
+		}()
+	}
+
+	wg.Wait()
+	// Test passes if no panics or deadlocks.
+}


### PR DESCRIPTION
## Summary

- Add `SubscriberTopics(subscriberID string) []string` method for querying the current topic set of a managed multi-subscriber (useful for debugging and contract verification)
- Fix a data race where `AddTopic` could call `wg.Add(1)` after `wg.Wait()` had started in the unsubscribe path, by introducing a `closed` flag checked under `ms.mu`
- Add 12 new tests covering coordination edge cases: replay semantics, in-flight message handling, concurrent unsubscribe/AddTopic, scope operations under load, and lifeline/scoped stream isolation

## Test plan

- [x] `go test -race -count=3 ./...` passes (all packages, 3 iterations with race detector)
- [ ] Verify `SubscriberTopics` returns accurate topic list after add/remove operations
- [ ] Verify `AddTopic` returns false when called on an unsubscribed subscriber
- [ ] Verify no goroutine leaks under concurrent AddTopic + unsubscribe

Closes #208