### PR TITLE
feat: structured JSON payloads for control events

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -607,12 +607,12 @@ func ExampleSSEBroker_lifelineReplay() {
 	panelCh, panelUnsub := broker.SubscribeFromID("panel", "e1")
 	defer panelUnsub()
 
-	// Skip the reconnected control event.
-	<-panelCh
-
-	// Replayed message arrives.
+	// Replayed message arrives first.
 	replayed := <-panelCh
 	fmt.Println("replayed:", extractData(replayed))
+
+	// Skip the reconnected control event that follows replay.
+	<-panelCh
 
 	// Lifeline was never interrupted.
 	broker.Publish("control", "still-alive")

--- a/gap.go
+++ b/gap.go
@@ -1,5 +1,7 @@
 package tavern
 
+import "fmt"
+
 // GapStrategy determines how the broker responds when a subscriber reconnects
 // with a Last-Event-ID that is no longer in the replay log (i.e., the log has
 // rolled over and the requested ID is gone). Configure per-topic via
@@ -86,5 +88,6 @@ func (b *SSEBroker) SetReplayGapPolicy(topic string, strategy GapStrategy, snaps
 // replayGapControlEvent returns the wire-format SSE control event that
 // notifies clients a replay gap was detected.
 func replayGapControlEvent(lastEventID string) string {
-	return NewSSEMessage("tavern-replay-gap", lastEventID).String()
+	return NewSSEMessage("tavern-replay-gap",
+		fmt.Sprintf(`{"lastEventId":"%s"}`, lastEventID)).String()
 }

--- a/gap_test.go
+++ b/gap_test.go
@@ -69,21 +69,21 @@ func TestSubscribeFromID_GapControlEvent(t *testing.T) {
 	ch, unsub := b.SubscribeFromID("events", "1")
 	defer unsub()
 
-	// First: reconnected control event.
+	// First: gap control event.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-replay-gap")
+		assert.Contains(t, msg, `"lastEventId":"1"`)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for gap control event")
+	}
+
+	// Then: reconnected control event with replay stats.
 	select {
 	case msg := <-ch:
 		assert.Contains(t, msg, "event: tavern-reconnected")
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for reconnected control event")
-	}
-
-	// Then: gap control event.
-	select {
-	case msg := <-ch:
-		assert.Contains(t, msg, "event: tavern-replay-gap")
-		assert.Contains(t, msg, "data: 1")
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for gap control event")
 	}
 }
 
@@ -104,15 +104,7 @@ func TestSubscribeFromID_GapFallbackToSnapshot(t *testing.T) {
 	ch, unsub := b.SubscribeFromID("events", "1")
 	defer unsub()
 
-	// First: reconnected control event.
-	select {
-	case msg := <-ch:
-		assert.Contains(t, msg, "event: tavern-reconnected")
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for reconnected control event")
-	}
-
-	// Second: gap control event.
+	// First: gap control event.
 	select {
 	case msg := <-ch:
 		assert.Contains(t, msg, "event: tavern-replay-gap")
@@ -120,12 +112,20 @@ func TestSubscribeFromID_GapFallbackToSnapshot(t *testing.T) {
 		t.Fatal("timed out waiting for gap control event")
 	}
 
-	// Third: snapshot.
+	// Second: snapshot.
 	select {
 	case msg := <-ch:
 		assert.Equal(t, snapshotData, msg)
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for snapshot")
+	}
+
+	// Third: reconnected control event with replay stats.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reconnected control event")
 	}
 
 	// No more buffered messages (no replay since ID was not found).
@@ -152,20 +152,20 @@ func TestSubscribeFromID_GapSnapshotEmpty(t *testing.T) {
 	ch, unsub := b.SubscribeFromID("events", "1")
 	defer unsub()
 
-	// First: reconnected control event.
-	select {
-	case msg := <-ch:
-		assert.Contains(t, msg, "event: tavern-reconnected")
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for reconnected control event")
-	}
-
-	// Then: gap control event.
+	// First: gap control event.
 	select {
 	case msg := <-ch:
 		assert.Contains(t, msg, "event: tavern-replay-gap")
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for gap control event")
+	}
+
+	// Then: reconnected control event with replay stats.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reconnected control event")
 	}
 
 	select {
@@ -303,7 +303,7 @@ func TestSetReplayGapPolicy_ClosedBrokerNoop(t *testing.T) {
 func TestGapControlEventFormat(t *testing.T) {
 	msg := replayGapControlEvent("abc-123")
 	assert.True(t, strings.HasPrefix(msg, "event: tavern-replay-gap\n"))
-	assert.Contains(t, msg, "data: abc-123")
+	assert.Contains(t, msg, `"lastEventId":"abc-123"`)
 	assert.True(t, strings.HasSuffix(msg, "\n\n"), "SSE messages must end with double newline")
 }
 
@@ -393,20 +393,20 @@ func TestSetReplayGapPolicy_NilSnapshotFn(t *testing.T) {
 	ch, unsub := b.SubscribeFromID("events", "1")
 	defer unsub()
 
-	// First: reconnected control event.
-	select {
-	case msg := <-ch:
-		assert.Contains(t, msg, "event: tavern-reconnected")
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for reconnected control event")
-	}
-
-	// Then: gap control event.
+	// First: gap control event.
 	select {
 	case msg := <-ch:
 		assert.Contains(t, msg, "event: tavern-replay-gap")
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for gap control event")
+	}
+
+	// Then: reconnected control event with replay stats.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reconnected control event")
 	}
 
 	select {

--- a/lifeline_test.go
+++ b/lifeline_test.go
@@ -281,15 +281,16 @@ func TestLifeline_ReplayOnPanelStreamReconnect(t *testing.T) {
 	require.NotNil(t, panelCh2)
 	defer panelUnsub2()
 
-	// First message is the tavern-reconnected control event -- drain it.
-	reconnectMsg := awaitStringMsg(t, panelCh2, time.Second)
-	assert.Contains(t, reconnectMsg, "tavern-reconnected")
-
-	// Assert next 3 messages are the replayed ones.
+	// First 3 messages are the replayed ones, then the reconnected control event.
 	for i := 6; i <= 8; i++ {
 		msg := awaitStringMsg(t, panelCh2, time.Second)
 		assert.Contains(t, msg, fmt.Sprintf("panel-%d", i))
 	}
+
+	// Then the tavern-reconnected control event with replay stats.
+	reconnectMsg := awaitStringMsg(t, panelCh2, time.Second)
+	assert.Contains(t, reconnectMsg, "tavern-reconnected")
+	assert.Contains(t, reconnectMsg, `"replayDelivered":3`)
 
 	// Meanwhile, lifeline is never interrupted.
 	b.Publish("control", "control-during-replay")

--- a/message_test.go
+++ b/message_test.go
@@ -121,8 +121,8 @@ func TestSSEMessage_SingleLineData(t *testing.T) {
 }
 
 func TestIsControlEvent(t *testing.T) {
-	assert.True(t, isControlEvent("event: tavern-reconnected\ndata: \n\n"))
-	assert.True(t, isControlEvent("event: tavern-replay-gap\ndata: old-id\n\n"))
+	assert.True(t, isControlEvent("event: tavern-reconnected\ndata: {\"replayDelivered\":0,\"replayDropped\":0}\n\n"))
+	assert.True(t, isControlEvent("event: tavern-replay-gap\ndata: {\"lastEventId\":\"old-id\"}\n\n"))
 	assert.False(t, isControlEvent("event: metrics\ndata: cpu=42\n\n"))
 	assert.False(t, isControlEvent("just raw text"))
 	assert.False(t, isControlEvent(""))
@@ -156,7 +156,7 @@ func TestExtractSSEID(t *testing.T) {
 
 func TestWrapForGroup(t *testing.T) {
 	t.Run("control event passed through", func(t *testing.T) {
-		ctrl := "event: tavern-reconnected\ndata: \n\n"
+		ctrl := reconnectedControlEvent(0, 0)
 		got := wrapForGroup("metrics", ctrl)
 		assert.Equal(t, ctrl, got, "control events should pass through unchanged")
 	})
@@ -213,7 +213,7 @@ func TestWrapForGroup_KeepalivePassthrough(t *testing.T) {
 func TestIsSSEFormatted(t *testing.T) {
 	assert.True(t, isSSEFormatted("event: update\ndata: hello\n\n"))
 	assert.True(t, isSSEFormatted("data: hello\n\n"))
-	assert.True(t, isSSEFormatted("event: tavern-reconnected\ndata: \n\n"))
+	assert.True(t, isSSEFormatted(reconnectedControlEvent(0, 0)))
 	// id: and retry: alone are NOT considered pre-formatted SSE
 	assert.False(t, isSSEFormatted("id: 42\ndata: hello\n\n"))
 	assert.False(t, isSSEFormatted("retry: 3000\n\n"))
@@ -280,7 +280,7 @@ func TestWrapForGroup_PreformattedSSE(t *testing.T) {
 	})
 
 	t.Run("control event still passes through", func(t *testing.T) {
-		ctrl := "event: tavern-reconnected\ndata: \n\n"
+		ctrl := reconnectedControlEvent(0, 0)
 		got := wrapForGroup("metrics", ctrl)
 		assert.Equal(t, ctrl, got)
 	})

--- a/reconnect.go
+++ b/reconnect.go
@@ -72,16 +72,18 @@ func (b *SSEBroker) SetBundleOnReconnect(topic string, bundle bool) {
 }
 
 // reconnectedControlEvent returns the wire-format SSE control event that
-// notifies clients a reconnection was detected.
-func reconnectedControlEvent() string {
-	return NewSSEMessage("tavern-reconnected", "").String()
+// notifies clients a reconnection was detected. The payload includes replay
+// delivery statistics so the client knows how much catch-up occurred.
+func reconnectedControlEvent(replayDelivered, replayDropped int) string {
+	return NewSSEMessage("tavern-reconnected",
+		fmt.Sprintf(`{"replayDelivered":%d,"replayDropped":%d}`, replayDelivered, replayDropped)).String()
 }
 
 // replayTruncatedControlEvent returns an SSE control event indicating that
 // some replay messages were dropped due to subscriber buffer limits.
 func replayTruncatedControlEvent(delivered, dropped int) string {
 	return NewSSEMessage("tavern-replay-truncated",
-		fmt.Sprintf("delivered:%d dropped:%d", delivered, dropped)).String()
+		fmt.Sprintf(`{"delivered":%d,"dropped":%d}`, delivered, dropped)).String()
 }
 
 // buildReconnectInfo constructs a ReconnectInfo from the replay log state.

--- a/reconnect_test.go
+++ b/reconnect_test.go
@@ -253,21 +253,22 @@ func TestReconnectedControlEvent(t *testing.T) {
 	ch, unsub := b.SubscribeFromID("events", "1")
 	defer unsub()
 
-	// First message should be the reconnected control event.
-	select {
-	case msg := <-ch:
-		assert.Contains(t, msg, "event: tavern-reconnected")
-	case <-time.After(time.Second):
-		t.Fatal("no control event received")
-	}
-
-	// Then the replayed message (with id field injected).
+	// First: the replayed message (with id field injected).
 	select {
 	case msg := <-ch:
 		assert.Contains(t, msg, "msg-2")
 		assert.Contains(t, msg, "id: 2")
 	case <-time.After(time.Second):
 		t.Fatal("no replay message received")
+	}
+
+	// Then: reconnected control event with replay stats.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+		assert.Contains(t, msg, `"replayDelivered":1`)
+	case <-time.After(time.Second):
+		t.Fatal("no control event received")
 	}
 }
 
@@ -285,21 +286,22 @@ func TestBundleOnReconnect(t *testing.T) {
 	ch, unsub := b.SubscribeFromID("events", "1")
 	defer unsub()
 
-	// First: reconnected control event.
-	select {
-	case msg := <-ch:
-		assert.Contains(t, msg, "event: tavern-reconnected")
-	case <-time.After(time.Second):
-		t.Fatal("no control event")
-	}
-
-	// Second: bundled replay (msg-2 and msg-3 in a single string).
+	// First: bundled replay (msg-2 and msg-3 in a single string).
 	select {
 	case msg := <-ch:
 		assert.Contains(t, msg, "msg-2")
 		assert.Contains(t, msg, "msg-3")
 	case <-time.After(time.Second):
 		t.Fatal("no bundled replay received")
+	}
+
+	// Then: reconnected control event with replay stats.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+		assert.Contains(t, msg, `"replayDelivered":2`)
+	case <-time.After(time.Second):
+		t.Fatal("no control event")
 	}
 
 	// No more replay messages — they were bundled.
@@ -325,10 +327,7 @@ func TestBundleOnReconnect_Disabled(t *testing.T) {
 	ch, unsub := b.SubscribeFromID("events", "1")
 	defer unsub()
 
-	// Skip control event.
-	<-ch
-
-	// Should receive individual messages (with id fields injected).
+	// Should receive individual replay messages first (with id fields injected).
 	select {
 	case msg := <-ch:
 		assert.Contains(t, msg, "msg-2")
@@ -342,6 +341,14 @@ func TestBundleOnReconnect_Disabled(t *testing.T) {
 		assert.Contains(t, msg, "id: 3")
 	case <-time.After(time.Second):
 		t.Fatal("no second replay")
+	}
+
+	// Then reconnected control event.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+	case <-time.After(time.Second):
+		t.Fatal("no control event")
 	}
 }
 
@@ -602,9 +609,10 @@ func TestBundleOnReconnect_ClearedByClearReplay(t *testing.T) {
 }
 
 func TestReconnectedControlEvent_Format(t *testing.T) {
-	msg := reconnectedControlEvent()
+	msg := reconnectedControlEvent(5, 2)
 	assert.Contains(t, msg, "event: tavern-reconnected")
-	assert.Contains(t, msg, "data: ")
+	assert.Contains(t, msg, `"replayDelivered":5`)
+	assert.Contains(t, msg, `"replayDropped":2`)
 	assert.True(t, strings.HasSuffix(msg, "\n\n"), "SSE message must end with double newline")
 }
 
@@ -652,16 +660,21 @@ func TestBundleOnReconnect_SingleMessage(t *testing.T) {
 	ch, unsub := b.SubscribeFromID("events", "1")
 	defer unsub()
 
-	// Skip control event.
-	<-ch
-
-	// Single bundled message containing only msg-2 (with id field).
+	// Single bundled replay message containing only msg-2 (with id field).
 	select {
 	case msg := <-ch:
 		assert.Contains(t, msg, "msg-2")
 		assert.Contains(t, msg, "id: 2")
 	case <-time.After(time.Second):
 		t.Fatal("no bundled replay received")
+	}
+
+	// Then reconnected control event.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+	case <-time.After(time.Second):
+		t.Fatal("no control event")
 	}
 }
 
@@ -808,7 +821,8 @@ func TestBundleOnReconnect_TruncationAccounting(t *testing.T) {
 func TestReplayTruncatedControlEvent_Format(t *testing.T) {
 	msg := replayTruncatedControlEvent(5, 3)
 	assert.Contains(t, msg, "event: tavern-replay-truncated")
-	assert.Contains(t, msg, "delivered:5 dropped:3")
+	assert.Contains(t, msg, `"delivered":5`)
+	assert.Contains(t, msg, `"dropped":3`)
 	assert.True(t, strings.HasSuffix(msg, "\n\n"), "SSE message must end with double newline")
 }
 

--- a/replay_store_test.go
+++ b/replay_store_test.go
@@ -212,14 +212,7 @@ func TestBrokerWithReplayStore_PublishWithID_SubscribeFromID(t *testing.T) {
 	ch, unsub := b.SubscribeFromID("events", "3")
 	defer unsub()
 
-	// Drain reconnected control event.
-	select {
-	case msg := <-ch:
-		assert.Contains(t, msg, "event: tavern-reconnected")
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for reconnected control event")
-	}
-
+	// Replay messages come first, then reconnected control event.
 	var got []string
 	for range 2 {
 		select {
@@ -234,6 +227,15 @@ func TestBrokerWithReplayStore_PublishWithID_SubscribeFromID(t *testing.T) {
 	assert.Contains(t, got[0], "id: 4")
 	assert.Contains(t, got[1], "msg-5")
 	assert.Contains(t, got[1], "id: 5")
+
+	// Reconnected control event with replay stats.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+		assert.Contains(t, msg, `"replayDelivered":2`)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reconnected control event")
+	}
 }
 
 func TestBrokerWithReplayStore_GapDetection(t *testing.T) {
@@ -252,20 +254,20 @@ func TestBrokerWithReplayStore_GapDetection(t *testing.T) {
 	ch, unsub := b.SubscribeFromID("events", "unknown-id")
 	defer unsub()
 
-	// Reconnected control event.
-	select {
-	case msg := <-ch:
-		assert.Contains(t, msg, "event: tavern-reconnected")
-	case <-time.After(time.Second):
-		t.Fatal("timed out")
-	}
-
-	// Gap control event.
+	// Gap control event comes first.
 	select {
 	case msg := <-ch:
 		assert.Contains(t, msg, "event: tavern-replay-gap")
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for gap control event")
+	}
+
+	// Then reconnected control event with replay stats.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reconnected control event")
 	}
 
 	// No replay messages.

--- a/resume.go
+++ b/resume.go
@@ -283,15 +283,6 @@ func (b *SSEBroker) subscribeFromIDInternal(topic, lastEventID string, cfg subsc
 		replayMsgs = filtered
 	}
 
-	// Send reconnected control event when Last-Event-ID is present.
-	if isReconnect {
-		controlMsg := reconnectedControlEvent()
-		select {
-		case ch <- controlMsg:
-		default:
-		}
-	}
-
 	// Handle replay gap: fire callbacks, optionally send control event and snapshot.
 	if gapDetected {
 		// Fire registered gap callbacks regardless of strategy.
@@ -344,6 +335,13 @@ func (b *SSEBroker) subscribeFromIDInternal(topic, lastEventID string, cfg subsc
 	if isReconnect {
 		reconnectInfo.ReplayDelivered = replayDelivered
 		reconnectInfo.ReplayDropped = replayDropped
+
+		// Send reconnected control event with replay stats.
+		select {
+		case ch <- reconnectedControlEvent(replayDelivered, replayDropped):
+		default:
+		}
+
 		for _, fn := range reconnectCallbacks {
 			go fn(reconnectInfo)
 		}

--- a/resume_options_test.go
+++ b/resume_options_test.go
@@ -33,14 +33,6 @@ func TestSubscribeFromIDWith_FilterAppliesToReplayAndLive(t *testing.T) {
 	require.NotNil(t, ch)
 	defer unsub()
 
-	// First message must be the reconnect control event (always bypasses filter).
-	select {
-	case msg := <-ch:
-		assert.Contains(t, msg, "event: tavern-reconnected")
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for reconnected control event")
-	}
-
 	// Replay messages 2..5, but only "keep-2" and "keep-4" should pass.
 	var replay []string
 	timeout := time.After(200 * time.Millisecond)
@@ -51,6 +43,14 @@ func TestSubscribeFromIDWith_FilterAppliesToReplayAndLive(t *testing.T) {
 		case <-timeout:
 			t.Fatalf("timed out waiting for filtered replay messages, got %v", replay)
 		}
+	}
+
+	// Reconnected control event comes after replay (always bypasses filter).
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reconnected control event")
 	}
 	require.Len(t, replay, 2)
 	assert.Contains(t, replay[0], "keep-2")
@@ -220,16 +220,7 @@ func TestSubscribeFromIDWith_SnapshotSkippedOnResume(t *testing.T) {
 
 	assert.False(t, snapCalled, "snapshot fn must not be invoked on resume")
 
-	// First message must be the reconnect control event, not the snapshot.
-	select {
-	case msg := <-ch:
-		assert.Contains(t, msg, "event: tavern-reconnected")
-		assert.NotContains(t, msg, "should-not-be-delivered")
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for reconnected control event")
-	}
-
-	// Replay messages 2 and 3 should follow.
+	// Replay messages 2 and 3 come first.
 	var replay []string
 	for len(replay) < 2 {
 		select {
@@ -242,6 +233,15 @@ func TestSubscribeFromIDWith_SnapshotSkippedOnResume(t *testing.T) {
 	require.Len(t, replay, 2)
 	assert.Contains(t, replay[0], "msg-2")
 	assert.Contains(t, replay[1], "msg-3")
+
+	// Reconnected control event comes after replay (not the snapshot).
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+		assert.NotContains(t, msg, "should-not-be-delivered")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reconnected control event")
+	}
 
 	// And nothing else.
 	select {
@@ -316,15 +316,7 @@ func TestSubscribeFromIDWith_GapFallbackStillWorks(t *testing.T) {
 
 	assert.False(t, userSnapCalled, "user snapshot must not fire on resume")
 
-	// First: reconnect control event.
-	select {
-	case msg := <-ch:
-		assert.Contains(t, msg, "event: tavern-reconnected")
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for reconnected control event")
-	}
-
-	// Second: gap control event.
+	// First: gap control event.
 	select {
 	case msg := <-ch:
 		assert.Contains(t, msg, "event: tavern-replay-gap")
@@ -332,12 +324,20 @@ func TestSubscribeFromIDWith_GapFallbackStillWorks(t *testing.T) {
 		t.Fatal("timed out waiting for gap control event")
 	}
 
-	// Third: gap-fallback snapshot.
+	// Second: gap-fallback snapshot.
 	select {
 	case msg := <-ch:
 		assert.Equal(t, "gap-fallback-snapshot", msg)
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for gap-fallback snapshot")
+	}
+
+	// Third: reconnected control event with replay stats.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reconnected control event")
 	}
 }
 

--- a/resume_test.go
+++ b/resume_test.go
@@ -40,14 +40,7 @@ func TestSubscribeFromID_ReplaysAfterID(t *testing.T) {
 	ch, unsub := b.SubscribeFromID("events", "3")
 	defer unsub()
 
-	// First message is the reconnected control event.
-	select {
-	case msg := <-ch:
-		assert.Contains(t, msg, "event: tavern-reconnected")
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for reconnected control event")
-	}
-
+	// Replay messages come first, then reconnected control event.
 	var got []string
 	for range 2 {
 		select {
@@ -62,6 +55,16 @@ func TestSubscribeFromID_ReplaysAfterID(t *testing.T) {
 	assert.Contains(t, got[0], "id: 4")
 	assert.Contains(t, got[1], "msg-5")
 	assert.Contains(t, got[1], "id: 5")
+
+	// Reconnected control event with replay stats comes after replay.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+		assert.Contains(t, msg, `"replayDelivered":2`)
+		assert.Contains(t, msg, `"replayDropped":0`)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reconnected control event")
+	}
 
 	// Verify no more replay messages are buffered.
 	select {
@@ -150,10 +153,11 @@ func TestSubscribeFromID_AllCaughtUp(t *testing.T) {
 	ch, unsub := b.SubscribeFromID("events", "3")
 	defer unsub()
 
-	// First message is the reconnected control event.
+	// Reconnected control event (no replay messages preceded it).
 	select {
 	case msg := <-ch:
 		assert.Contains(t, msg, "event: tavern-reconnected")
+		assert.Contains(t, msg, `"replayDelivered":0`)
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for reconnected control event")
 	}
@@ -335,15 +339,7 @@ func TestPublishWithID_RoundTrip(t *testing.T) {
 	ch, unsub := b.SubscribeFromID("events", "evt-1")
 	defer unsub()
 
-	// Drain reconnected control event.
-	select {
-	case msg := <-ch:
-		assert.Contains(t, msg, "event: tavern-reconnected")
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for reconnected control event")
-	}
-
-	// Replayed messages should contain id fields.
+	// Replayed messages should contain id fields (come before reconnected event).
 	for _, expected := range []struct {
 		data string
 		id   string
@@ -358,5 +354,14 @@ func TestPublishWithID_RoundTrip(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatalf("timed out waiting for replay of %s", expected.id)
 		}
+	}
+
+	// Reconnected control event with replay stats comes after replay.
+	select {
+	case msg := <-ch:
+		assert.Contains(t, msg, "event: tavern-reconnected")
+		assert.Contains(t, msg, `"replayDelivered":2`)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reconnected control event")
 	}
 }

--- a/ttl_test.go
+++ b/ttl_test.go
@@ -292,13 +292,7 @@ func TestPublishWithTTL_SubscribeFromID_FiltersExpired(t *testing.T) {
 	ch, unsub := b.SubscribeFromID("events", "1")
 	defer unsub()
 
-	// Drain the reconnected control event injected by the reconnection feature.
-	select {
-	case <-ch:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for reconnect event")
-	}
-
+	// Replay message comes first (expired entry skipped).
 	var got []string
 	for range 1 {
 		select {
@@ -311,6 +305,13 @@ func TestPublishWithTTL_SubscribeFromID_FiltersExpired(t *testing.T) {
 	require.Len(t, got, 1)
 	assert.Contains(t, got[0], "msg-2")
 	assert.Contains(t, got[0], "id: 2")
+
+	// Drain the reconnected control event.
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reconnect event")
+	}
 
 	// No more messages.
 	select {


### PR DESCRIPTION
## Summary

Closes #210

- `tavern-reconnected` now emits `{"replayDelivered":N,"replayDropped":N}` instead of empty data, giving clients visibility into replay delivery stats
- `tavern-replay-gap` now emits `{"lastEventId":"..."}` instead of the raw ID string
- `tavern-replay-truncated` now emits `{"delivered":N,"dropped":N}` instead of `delivered:N dropped:N`
- `tavern-topics-changed` unchanged (already JSON)
- `tavern-reconnected` is now emitted **after** replay messages (acting as a "replay complete" signal with accurate delivery counts), rather than before

## Test plan

- [x] All existing tests updated to match new JSON payloads and event ordering
- [x] `go test ./...` passes (all packages)
- [x] `go vet ./...` clean