### PR TITLE
docs: client-visible delivery observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ on top of Tavern:
 - [Page-Level Multiplexing](docs/page-multiplexing.md) -- single-connection
   multi-topic pages. StaticGroup vs DynamicGroup vs SubscribeMulti. OOB
   fragment composition for multi-region updates.
+- [Delivery Observability](docs/delivery-observability.md) -- control events
+  clients receive during reconnection and subscription changes. Structured
+  JSON payloads, delivery scenarios, and how tavern-js consumes them.
 
 ---
 
@@ -101,7 +104,9 @@ go get github.com/catgoose/tavern/tavernotel   # OpenTelemetry export
 ## Client-Side Helpers
 
 Tavern emits control events (`tavern-reconnected`, `tavern-replay-gap`,
-`tavern-topics-changed`) over the SSE stream. The companion library
+`tavern-replay-truncated`, `tavern-topics-changed`) over the SSE stream with
+structured JSON payloads carrying delivery statistics, gap details, and
+subscription state. The companion library
 [tavern-js](https://github.com/catgoose/tavern-js) listens for these events
 and translates them into declarative UI behaviors — reconnection overlays,
 gap recovery, and topic change notifications — with zero custom JavaScript:
@@ -118,7 +123,9 @@ gap recovery, and topic change notifications — with zero custom JavaScript:
 ```
 
 See the [tavern-js README](https://github.com/catgoose/tavern-js) for full
-API documentation, data attributes, and examples.
+API documentation, data attributes, and examples. For the complete control
+event contract and delivery scenarios, see
+[Delivery Observability](docs/delivery-observability.md).
 
 ### Commands from Hot DOM Regions
 

--- a/docs/delivery-observability.md
+++ b/docs/delivery-observability.md
@@ -1,0 +1,144 @@
+# Client-Visible Delivery Observability
+
+Tavern emits control events over the SSE stream to tell clients exactly what
+happened during reconnection and subscription changes. These events carry
+structured JSON payloads so clients can make informed decisions about data
+freshness without guessing.
+
+This document defines the observability contract: which control events fire,
+when they fire, what they carry, and what they mean for the client.
+
+---
+
+## Control event reference
+
+| Event | When | Payload | Client meaning |
+|---|---|---|---|
+| `tavern-reconnected` | Server confirms reconnection complete | `{"replayDelivered": N, "replayDropped": N}` | Recovery is done. Check `replayDropped` for data loss. |
+| `tavern-replay-gap` | `Last-Event-ID` not found in replay log | `{"lastEventId": "..."}` | Messages were missed. Region is stale until fresh data arrives. |
+| `tavern-replay-truncated` | Replay buffer too small for full recovery | `{"delivered": N, "dropped": N}` | Partial recovery. Some messages lost to buffer limits. |
+| `tavern-topics-changed` | Topic added or removed dynamically | `{"action": "added"/"removed", "topic": "...", "topics": [...]}` | Subscription set changed. Full topic list in `topics`. |
+
+All control events use structured JSON in the SSE `data` field. The event
+type (SSE `event` field) is the control event name shown above.
+
+---
+
+## Delivery scenarios
+
+### Clean reconnect (full recovery)
+
+The client reconnects with `Last-Event-ID`. The server finds the ID in the
+replay log and replays all missed messages. The client receives:
+
+1. Replayed messages (in order)
+2. `tavern-reconnected` with `{"replayDelivered": N, "replayDropped": 0}`
+
+`replayDropped: 0` means every missed message was delivered. The client is
+fully caught up.
+
+### Reconnect with truncation (partial recovery)
+
+The client reconnects and the server finds the ID, but the subscriber's
+channel buffer is too small to hold all replayed messages. The client
+receives:
+
+1. As many replayed messages as fit in the buffer
+2. `tavern-replay-truncated` with `{"delivered": N, "dropped": M}`
+3. `tavern-reconnected` with `{"replayDelivered": N, "replayDropped": M}`
+
+`replayDropped > 0` means some messages were lost to buffer limits. The
+client should treat the region as partially stale and may want to request a
+fresh snapshot or reload.
+
+### Reconnect with gap (stale, needs refresh)
+
+The client reconnects but the `Last-Event-ID` is not in the replay log. The
+ID rolled out of the ring buffer, the server restarted, or no replay store
+was configured. The client receives:
+
+1. `tavern-replay-gap` with `{"lastEventId": "..."}`
+2. If a gap fallback policy is configured (`GapFallbackToSnapshot`), the
+   snapshot is delivered as the next message
+3. `tavern-reconnected` with `{"replayDelivered": 0, "replayDropped": 0}`
+
+The gap event means the client missed an unknown number of messages. If no
+snapshot fallback is configured, the client should treat the region as stale
+until fresh data arrives from normal publishes.
+
+### Normal operation (no control events)
+
+During normal connected operation, no control events fire. The client
+receives application messages as they are published. The absence of control
+events means delivery is healthy.
+
+### Dynamic topic changes
+
+When the server calls `AddTopic` or `RemoveTopic` with `sendControl: true`,
+the client receives:
+
+- `tavern-topics-changed` with `{"action": "added", "topic": "new-topic", "topics": ["t1", "t2", "new-topic"]}`
+
+The `topics` array is the complete current subscription set. Clients can use
+this to set up or tear down SSE-swap targets dynamically.
+
+---
+
+## How tavern-js consumes these events
+
+The companion library [tavern-js](https://github.com/catgoose/tavern-js)
+listens for these control events and translates them into declarative UX
+behaviors:
+
+- **`tavern-reconnected`**: Removes reconnecting state classes, restores
+  normal appearance. If `replayDropped > 0`, can trigger stale indicators.
+- **`tavern-replay-gap`**: Applies stale classes to affected regions, shows
+  gap banners prompting the user to refresh.
+- **`tavern-replay-truncated`**: Signals partial recovery so the UI can warn
+  about incomplete data.
+- **`tavern-topics-changed`**: Updates internal subscription tracking.
+
+All of this happens through data attributes on HTML elements -- no custom
+JavaScript required for the default behaviors. See the
+[tavern-js README](https://github.com/catgoose/tavern-js) for the full
+attribute reference.
+
+---
+
+## Extracting payloads client-side
+
+Control events arrive as standard SSE events. In raw `EventSource` usage:
+
+```js
+const es = new EventSource("/sse/events");
+
+es.addEventListener("tavern-reconnected", (e) => {
+  const { replayDelivered, replayDropped } = JSON.parse(e.data);
+  if (replayDropped > 0) {
+    console.warn(`Reconnected with ${replayDropped} dropped messages`);
+  }
+});
+
+es.addEventListener("tavern-replay-gap", (e) => {
+  const { lastEventId } = JSON.parse(e.data);
+  console.warn(`Gap detected, last known ID: ${lastEventId}`);
+});
+
+es.addEventListener("tavern-replay-truncated", (e) => {
+  const { delivered, dropped } = JSON.parse(e.data);
+  console.warn(`Replay truncated: ${delivered} delivered, ${dropped} dropped`);
+});
+```
+
+With tavern-js, these listeners are set up automatically and drive the
+declarative attribute system.
+
+---
+
+## Relationship to server-side observability
+
+The control events described here are the **client-visible** half of Tavern's
+observability story. On the server side, `OnReconnect` callbacks,
+`OnReplayGap` hooks, and the Prometheus/OpenTelemetry export adapters provide
+equivalent visibility for operators. The two halves are complementary: server
+metrics for dashboards and alerts, client events for UX adaptation.

--- a/docs/snapshot-replay.md
+++ b/docs/snapshot-replay.md
@@ -155,7 +155,8 @@ and `SetReplayGapPolicy` to define fallback behavior:
 - `GapSilent` -- no replay, subscriber receives only live messages.
   Backwards compatible but not honest.
 - `GapFallbackToSnapshot` -- call the snapshot function and deliver it
-  as the first message, preceded by a `tavern-replay-gap` control event.
+  as the first message, preceded by a `tavern-replay-gap` control event
+  carrying `{"lastEventId": "..."}` so the client knows which ID was lost.
   Honest.
 
 **Recommended fallbacks by topic category:**
@@ -196,6 +197,12 @@ broker.OnReconnect("collection/tasks", func(info tavern.ReconnectInfo) {
         "missed", info.MissedCount)
 })
 ```
+
+All reconnection control events (`tavern-reconnected`, `tavern-replay-gap`,
+`tavern-replay-truncated`) carry structured JSON payloads so the client can
+distinguish clean recovery from partial or failed recovery. See
+[Delivery Observability](delivery-observability.md) for the full control
+event reference and delivery scenarios.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `docs/delivery-observability.md` documenting the control event contract: which events fire during reconnection and subscription changes, their structured JSON payloads, and what each delivery scenario means for clients
- Update README to reference the new doc page, mention structured JSON payloads, and include `tavern-replay-truncated` in the control event list
- Update `docs/snapshot-replay.md` gap handling section to reference JSON payloads and cross-link to the new doc

Closes #209