### PR TITLE
fix: satisfy gap control event lint

### DIFF
--- a/gap.go
+++ b/gap.go
@@ -89,5 +89,5 @@ func (b *SSEBroker) SetReplayGapPolicy(topic string, strategy GapStrategy, snaps
 // notifies clients a replay gap was detected.
 func replayGapControlEvent(lastEventID string) string {
 	return NewSSEMessage("tavern-replay-gap",
-		fmt.Sprintf(`{"lastEventId":"%s"}`, lastEventID)).String()
+		fmt.Sprintf(`{"lastEventId":%q}`, lastEventID)).String()
 }


### PR DESCRIPTION
## Summary
- use `%q` when formatting the replay-gap control event JSON string
- fixes the gocritic lint failure currently reported on main

## Validation
- `golangci-lint run --timeout=5m`
- `go vet ./...`
- `go test ./...`